### PR TITLE
nusamai-geometry: Polygonの単体テストを追加

### DIFF
--- a/nusamai-geometry/src/compact/polygon.rs
+++ b/nusamai-geometry/src/compact/polygon.rs
@@ -145,7 +145,8 @@ mod tests {
         assert_eq!(polygon.interiors().count(), 0);
     }
 
-    /// Currently, it does not check whether the interior is valid (have at least three vertices) or not
+    /// Currently, it does not check whether the exterior is valid (have at least three vertices) or not
+    /// (It could be a "Steiner point", as we see in earcut)
     #[test]
     fn test_polygon_invalid_interior() {
         let all_coords: Vec<f64> = (0..=10).flat_map(|i| vec![i as f64, i as f64]).collect();


### PR DESCRIPTION
Polygonに単体テストがなかったので、勉強がてら追加してみました。

invalidなデータが入れられた時の挙動も、説明のため記述してみました。