### PR TITLE
Run tests on CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,43 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+  pull_request:
+
+env: 
+  CARGO_TERM_COLOR: always    
+
+permissions:
+  contents: read
+
+jobs:
+  bulid_and_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Rustup
+        run: rustup update stable
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: install dependencies
+        # if: matrix.platform == 'ubuntu-20.04'
+        run: |
+          sudo apt-get update
+          sudo apt install -y libwebkit2gtk-4.0-dev build-essential curl wget file libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+      - name: Build
+        run: cargo build --verbose --workspace
+      - name: Test
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: lcov.info
+          fail_ci_if_error: false


### PR DESCRIPTION
- テストを GitHub Actions で実行する
- テストカバレッジを Codecov にアップロードする

## 検討事項

Cargo workspace の全体をテストするため、アプリケーション部分 (Tauri) の初回ビルドやテストにかなりの時間 (例: 8分) がかかる（とはいえCIのキャッシュが効いていれば2分以内で終わるようにはしてある）。今後、ライブラリ部分の開発体験に影響を及ぼすようであれば何らかの対処が必要。