### PR TITLE
LineStringが空のときの `iter_closed()` の挙動を修正

### DIFF
--- a/nusamai-geometry/src/compact/linestring.rs
+++ b/nusamai-geometry/src/compact/linestring.rs
@@ -90,14 +90,10 @@ impl<'a, const D: usize, T: CoordNum> Iterator for Iter<'a, D, T> {
     type Item = &'a [T];
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.slice.is_empty() {
-            return None;
-        }
-
         self.pos += D;
         if self.pos <= self.slice.len() {
             Some(&self.slice[self.pos - D..self.pos])
-        } else if self.pos == self.slice.len() + D && self.close {
+        } else if self.close && self.slice.len() >= D && self.pos == self.slice.len() + D {
             Some(&self.slice[..D])
         } else {
             None


### PR DESCRIPTION
LineStringが空のとき、 `iter_closed()` を実行すると、↓みたいにpanicする（終点として一つ目の要素を取りに行くため）:

```
range end index 2 out of range for slice of length 0
```

impl Iteretaorで、座標配列が空のときの条件分岐を追加した。