### PR TITLE
`Geometry` enum での不整合を修正 & 記載の順番を並び替え

### DIFF
--- a/nusamai-geometry/src/compact/mod.rs
+++ b/nusamai-geometry/src/compact/mod.rs
@@ -19,10 +19,10 @@ impl<T: Num + Copy + NumCast + PartialOrd + Default + Debug> CoordNum for T {}
 /// Computer-friendly Geometry
 #[derive(Debug, Clone)]
 pub enum Geometry<'a, const D: usize, T: CoordNum> {
-    LineString(MultiPolygon<'a, D, T>),
-    Polygon(LineString<'a, D, T>),
     MultiPoint(MultiPoint<'a, D, T>),
+    LineString(LineString<'a, D, T>),
     MultiLineString(MultiLineString<'a, D, T>),
+    Polygon(Polygon<'a, D, T>),
     MultiPolygon(MultiPolygon<'a, D, T>),
 }
 


### PR DESCRIPTION
2行変更しただけの軽微なPRです！ #15 にも関わるので、サラッとレビューしていただけると助かります。


***

Geometry enum の一部で、↓のように、内容との不一致がありました。

```
    LineString(MultiPolygon<'a, D, T>),
    Polygon(LineString<'a, D, T>),
```

ついでに、より複雑なジオメトリへという感じで並び替えました。