### PR TITLE
geom: 座標変換のためのメソッドを追加

### DIFF
--- a/nusamai-geometry/src/compact/multi_linestring.rs
+++ b/nusamai-geometry/src/compact/multi_linestring.rs
@@ -87,7 +87,7 @@ impl<'a, const D: usize, T: CoordNum> MultiLineString<'a, D, T> {
         self.all_coords.to_mut().extend(iter.into_iter().flatten());
     }
 
-    /// Create a new multipolygon by applying the given transformation to all coordinates in the MultiLineString.
+    /// Create a new MultiLineString by applying the given transformation to all coordinates.
     pub fn transform(&self, f: impl Fn(&[T; D]) -> [T; D]) -> Self {
         Self {
             all_coords: self

--- a/nusamai-geometry/src/compact/multi_point.rs
+++ b/nusamai-geometry/src/compact/multi_point.rs
@@ -58,7 +58,7 @@ impl<'a, const D: usize, T: CoordNum> MultiPoint<'a, D, T> {
         self.coords.to_mut().clear();
     }
 
-    /// Create a new multipolygon by applying the given transformation to all coordinates in the MultiPoint.
+    /// Create a new MultiPoint by applying the given transformation to all coordinates.
     pub fn transform(&self, f: impl Fn(&[T; D]) -> [T; D]) -> Self {
         Self {
             coords: self
@@ -156,7 +156,7 @@ mod tests {
     #[test]
     fn test_transform() {
         {
-            let mut mpoints = MultiPoint2::from_raw([0., 0., 5., 0., 5., 5., 0., 5.][..].into());
+            let mpoints = MultiPoint2::from_raw([0., 0., 5., 0., 5., 5., 0., 5.][..].into());
             let new_mpoints = mpoints.transform(|[x, y]| [x + 2., y + 1.]);
             assert_eq!(new_mpoints.coords(), [2., 1., 7., 1., 7., 6., 2., 6.]);
         }

--- a/nusamai-geometry/src/compact/multi_polygon.rs
+++ b/nusamai-geometry/src/compact/multi_polygon.rs
@@ -204,7 +204,7 @@ impl<'a, const D: usize, T: CoordNum> MultiPolygon<'a, D, T> {
         }
     }
 
-    /// Create a new multipolygon by applying the given transformation to all coordinates in the MultiPolygon.
+    /// Create a new MultiPolygon by applying the given transformation to all coordinates.
     pub fn transform(&self, f: impl Fn(&[T; D]) -> [T; D]) -> Self {
         Self {
             all_coords: self


### PR DESCRIPTION
MultiPoint, MultiLineString, MultiPolygonに対して座標変換を行うメソッドを追加します。具体的には、与えたクロージャを全座標に対して適用します。CRSの変換などに使うことを意図しています。

- `transform` -- 座標変換を適用した新たなジオメトリを得る。元のジオメトリは変更されない。
- `transform_inplace` -- 現在のジオメトリの内部データを直接変更 (in-place演算) する。