### PR TITLE
Rustdoc to GitHub Pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,5 +30,5 @@ jobs:
           sudo apt install -y libwebkit2gtk-4.0-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
       - name: Make Tauri build destination
         run: mkdir -p app/build
-      - name: Build
+      - name: Build App
         run: cargo build --verbose --package app

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,44 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - main
+
+env: 
+  CARGO_TERM_COLOR: always    
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Rustup
+        run: rustup toolchain install stable --profile minimal
+      - name: install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt install -y libwebkit2gtk-4.0-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+      - name: Build Doc
+        run: cargo doc --no-deps
+      - name: Upload Doc
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: target/doc
+      
+  pages:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v3

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 [![Test Tauri App](https://github.com/MIERUNE/nusamai/actions/workflows/test_app.yml/badge.svg)](https://github.com/MIERUNE/nusamai/actions/workflows/test_app.yml)
 [![Test Libraries](https://github.com/MIERUNE/nusamai/actions/workflows/test_libs.yml/badge.svg)](https://github.com/MIERUNE/nusamai/actions/workflows/test_libs.yml)
 [![codecov](https://codecov.io/gh/MIERUNE/nusamai/graph/badge.svg?token=oa62wDWoqu)](https://codecov.io/gh/MIERUNE/nusamai)
+[![Docs](https://github.com/MIERUNE/nusamai/actions/workflows/doc.yml/badge.svg)](https://mierune.github.io/nusamai/app/)
 
-Notion: [BRIDGE 都市デジタルツイン・GISコンバータの開発](https://www.notion.so/mierune/BRIDGE-GIS-461ba0355b3041619ed3f303a8b0166f)
+- Notion: [BRIDGE 都市デジタルツイン・GISコンバータの開発](https://www.notion.so/mierune/BRIDGE-GIS-461ba0355b3041619ed3f303a8b0166f)
+- Rustdoc: https://mierune.github.io/nusamai/app/ 
 
 ## リポジトリ構成
 

--- a/nusamai-plateau/citygml/src/namespace.rs
+++ b/nusamai-plateau/citygml/src/namespace.rs
@@ -2,7 +2,7 @@ use quick_xml::name::{Namespace, ResolveResult};
 
 /// Normalize a XML namaespace URI to a well-known prefix.
 ///
-/// e.g. "http://www.opengis.net/citygml/2.0" -> "core:"
+/// e.g. `"http://www.opengis.net/citygml/2.0"` -> `"core:"`
 pub fn normalize_ns_prefix<'a>(ns: &ResolveResult<'a>) -> &'a [u8] {
     match ns {
         ResolveResult::Bound(Namespace(name)) => {


### PR DESCRIPTION
Rustdoc (`cargo doc --no-deps`) で生成されるドキュメントを、GitHub Pagesにアップロードします。

main ブランチに push されたきにトリガされます。

:warning: GitHub Pages にアップロードされたものはパブリックに閲覧可能です。

Closes #66 