### PR TITLE
パイプラインのテストを修正

### DIFF
--- a/nusamai/tests/pipeline.rs
+++ b/nusamai/tests/pipeline.rs
@@ -39,7 +39,9 @@ impl Source for DummySource {
             feedback.send(FeedbackMessage {
                 message: format!("generating: {:?}", obj),
             });
-            sink.send(obj).unwrap();
+            if sink.send(obj).is_err() {
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
テストコード中で、必要なチェック（受信者が終了していたら送信側も終了する）が抜けていました。
他ブランチのCIテストがランダムにコケてしまうので修正します。