### PR TITLE
codecov: Tweak patch target

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,12 +2,12 @@ coverage:
   status:
     project:
       default:
-        # allows a 7% drop from the previous base commit coverage
-        threshold: 7%
+        # allows a 5% drop from the previous base commit coverage
+        threshold: 5%
     patch:
       default:
-        # allows a 7% drop from the previous base commit coverage
-        threshold: 7%
+        target: 60%
+        threshold: 5%
 
 comment:
   layout: "condensed_header, condensed_files, components, condensed_footer"

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths:
       - "app/**"
+      - ".github/**"
 
 env: 
   CARGO_TERM_COLOR: always

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - "nusamai/**"
       - "nusamai-*/**"
+      - ".github/**"
 
 env: 
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Codecov の patch がよくひっかかっていて狼少年っぽいので、ゆるめる。

追加されたコードのうち 60% ± 5% がカバーされていたら ✅  にする。

Closes #97 