### PR TITLE
parser: モデル生成支援ツールのための小さな調整

### DIFF
--- a/nusamai-citygml/macros/src/derive.rs
+++ b/nusamai-citygml/macros/src/derive.rs
@@ -75,7 +75,16 @@ fn generate_citygml_impl_for_struct(
                 continue;
             }
             attr.parse_nested_meta(|meta| {
-                if meta.path.is_ident("path") {
+                if meta.path.is_ident("required") {
+                    // TODO: required
+                    Ok(())
+                }
+                else if meta.path.is_ident("codelist") {
+                    // TODO: codelist
+                    let _codelist: LitStr = meta.value()?.parse()?;
+                    Ok(())
+                }
+                else if meta.path.is_ident("path") {
                     let path: LitByteStr = meta.value()?.parse()?;
 
                     if path.value().starts_with(b"@") {

--- a/nusamai-citygml/macros/src/type_attrs.rs
+++ b/nusamai-citygml/macros/src/type_attrs.rs
@@ -118,15 +118,15 @@ fn modify(ty: &ElementType, args: &FeatureArgs, input: &mut DeriveInput) -> Resu
                     add_named_field(
                         fields,
                         quote! {
-                            #[citygml(path = b"gml:name")]
-                            pub name: Vec<String>
+                            #[citygml(path = b"gml:description")]
+                            pub description: Option<String>
                         },
                     );
                     add_named_field(
                         fields,
                         quote! {
-                            #[citygml(path = b"gml:description")]
-                            pub description: Option<String>
+                            #[citygml(path = b"gml:name")]
+                            pub name: Vec<String>
                         },
                     );
                     add_named_field(

--- a/nusamai-citygml/src/values.rs
+++ b/nusamai-citygml/src/values.rs
@@ -6,6 +6,11 @@ use serde::{Deserialize, Serialize};
 use std::io::BufRead;
 
 pub type Date = chrono::NaiveDate;
+pub type GYear = String; // TODO?
+pub type GYearMonth = String; // TODO?
+pub type MeasureOrNullList = String; // TODO?
+pub type BuildingLODType = String; // TODO?
+pub type DoubleList = String; // TODO?
 
 impl CityGMLElement for String {
     const ELEMENT_TYPE: ElementType = ElementType::BasicType;
@@ -201,11 +206,13 @@ impl CityGMLElement for bool {
     }
 }
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Measure {
     pub value: f64,
     // pub uom: Option<String>,
 }
+
+pub type Length = Measure;
 
 impl CityGMLElement for Measure {
     const ELEMENT_TYPE: ElementType = ElementType::BasicType;


### PR DESCRIPTION
モデルの生成支援ツールを改善したため、それに追従するための変更を加える。

そのツールを実際に適用していくつかのモデルを定める例はPR #140 を参照。