### PR TITLE
タイリングの実験用Sink

### DIFF
--- a/nusamai/Cargo.toml
+++ b/nusamai/Cargo.toml
@@ -16,6 +16,7 @@ ctrlc = "3.4.1"
 bincode = "1.3.3"
 lz4_flex = "0.11.1"
 nusamai-geojson = { path = "../nusamai-geojson" }
+nusamai-geometry = { path = "../nusamai-geometry" }
 geojson = "0.24.1"
 serde_json = "1.0.108"
 url = "2.5.0"

--- a/nusamai/src/main.rs
+++ b/nusamai/src/main.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use nusamai::pipeline::Canceller;
 use nusamai::sink::{
     geojson::GeoJsonSinkProvider, gpkg::GpkgSinkProvider, noop::NoopSinkProvider,
-    serde::SerdeSinkProvider,
+    serde::SerdeSinkProvider, tiling2d::Tiling2DSinkProvider,
 };
 use nusamai::sink::{DataSink, DataSinkProvider};
 use nusamai::source::citygml::CityGMLSourceProvider;
@@ -28,6 +28,7 @@ enum SinkChoice {
     Serde,
     Geojson,
     Gpkg,
+    Tiling2d,
 }
 
 impl SinkChoice {
@@ -37,6 +38,7 @@ impl SinkChoice {
             SinkChoice::Serde => Box::new(SerdeSinkProvider {}),
             SinkChoice::Geojson => Box::new(GeoJsonSinkProvider {}),
             SinkChoice::Gpkg => Box::new(GpkgSinkProvider {}),
+            SinkChoice::Tiling2d => Box::new(Tiling2DSinkProvider {}),
         }
     }
 }

--- a/nusamai/src/sink/mod.rs
+++ b/nusamai/src/sink/mod.rs
@@ -2,6 +2,7 @@ pub mod geojson;
 pub mod gpkg;
 pub mod noop;
 pub mod serde;
+pub mod tiling2d;
 
 use crate::configuration::Config;
 use crate::pipeline::{Feedback, Receiver};


### PR DESCRIPTION
nusamai/examples にある タイリング実験のコードを、そのまま Sink として機能するようにコードを移しました。

`nusamai/examples/gml2sliced_geojson.rs` → `nusamai/src/sink/tiling2d`

### 実行方法

```
cargo run --release -- ~/Desktop/PLATEAU/15100_niigata-shi_2022_citygml_1_op/udx/urf/563857_urf_6668_op.gml --sink tiling2d
```