### PR TITLE
log crate を使う

### DIFF
--- a/nusamai/Cargo.toml
+++ b/nusamai/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = { version = "1.0.108", features = ["indexmap"] }
 url = "2.5.0"
 nusamai-gpkg = { path = "../nusamai-gpkg" }
 tokio = { version = "1.35.1", features = ["full"] }
+log = "0.4.20"
+pretty_env_logger = "0.5.0"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/nusamai/src/pipeline/runner.rs
+++ b/nusamai/src/pipeline/runner.rs
@@ -19,12 +19,12 @@ fn run_source_thread(
 ) -> (std::thread::JoinHandle<()>, Receiver) {
     let (sender, receiver) = sync_channel(SOURCE_OUTPUT_CHANNEL_BOUND);
     let handle = std::thread::spawn(move || {
-        println!("Source thread started.");
+        log::info!("Source thread started.");
         let pool = ThreadPoolBuilder::new().build().unwrap();
         pool.install(|| {
             source.run(sender, &feedback);
         });
-        println!("Source thread finished.");
+        log::info!("Source thread finished.");
     });
     (handle, receiver)
 }
@@ -38,10 +38,10 @@ fn run_transformer_thread(
     let handle = std::thread::spawn(move || {
         let pool = ThreadPoolBuilder::new().build().unwrap();
         pool.install(|| {
-            println!("Transformer threads started.");
+            log::info!("Transformer threads started.");
             let _ = upstream.into_iter().par_bridge().try_for_each(|parcel| {
                 if feedback.is_cancelled() {
-                    println!("transformer cancelled");
+                    log::info!("transformer cancelled");
                     return Err(());
                 }
                 if transformer.transform(parcel, &sender, &feedback).is_err() {
@@ -50,7 +50,7 @@ fn run_transformer_thread(
                     Ok(())
                 }
             });
-            println!("Transformer threads finished.");
+            log::info!("Transformer threads finished.");
         });
     });
     (handle, receiver)
@@ -62,12 +62,12 @@ fn run_sink_thread(
     mut feedback: Feedback,
 ) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
-        println!("Sink thread started.");
+        log::info!("Sink thread started.");
         let pool = ThreadPoolBuilder::new().build().unwrap();
         pool.install(|| {
             sink.run(upstream, &mut feedback);
         });
-        println!("Sink thread finished.");
+        log::info!("Sink thread finished.");
     })
 }
 
@@ -80,7 +80,7 @@ impl PipelineHandle {
     pub fn join(self) {
         self.thread_handles.into_iter().for_each(|handle| {
             if let Err(err) = handle.join() {
-                eprintln!("Error: {:#?}", err);
+                log::error!("Error: {:#?}", err);
             }
         });
     }

--- a/nusamai/src/sink/geojson/mod.rs
+++ b/nusamai/src/sink/geojson/mod.rs
@@ -77,7 +77,7 @@ impl DataSink for GeoJsonSink {
                                 return Err(());
                             };
                             if sender.send(bytes).is_err() {
-                                println!("sink cancelled");
+                                log::info!("sink cancelled");
                                 return Err(());
                             };
                         }

--- a/nusamai/src/sink/noop/mod.rs
+++ b/nusamai/src/sink/noop/mod.rs
@@ -36,20 +36,20 @@ impl DataSink for NoopSink {
     fn run(&mut self, upstream: Receiver, feedback: &mut Feedback) {
         for parcel in upstream {
             if feedback.is_cancelled() {
-                println!("sink cancelled");
+                log::info!("sink cancelled");
                 return;
             }
 
             self.num_features += 1;
             self.num_vertices += parcel.cityobj.geometries.vertices.len();
 
-            println!("feature: {:?}", parcel.cityobj.root);
+            log::info!("feature: {:?}", parcel.cityobj.root);
         }
 
         if feedback.is_cancelled() {
             return;
         }
-        println!("total number of features: {:#?}", self.num_features);
-        println!("total vertices: {}", self.num_vertices);
+        log::info!("total number of features: {:#?}", self.num_features);
+        log::info!("total vertices: {}", self.num_vertices);
     }
 }

--- a/nusamai/src/sink/serde/mod.rs
+++ b/nusamai/src/sink/serde/mod.rs
@@ -73,7 +73,7 @@ impl DataSink for SerdeSink {
                         buf.clear();
                         bincode::serialize_into(buf as &mut Vec<u8>, &parcel.cityobj).unwrap();
                         if sender.send(lz4_flex::compress_prepend_size(buf)).is_err() {
-                            println!("sink cancelled");
+                            log::info!("sink cancelled");
                             return Err(());
                         };
                         Ok(())
@@ -95,9 +95,10 @@ impl DataSink for SerdeSink {
                     self.bytes_written += 4 + compressed.len();
                 }
 
-                println!(
+                log::info!(
                     "Wrote {} features ({} bytes)",
-                    self.features_written, self.bytes_written
+                    self.features_written,
+                    self.bytes_written
                 );
             },
         );

--- a/nusamai/src/sink/tiling2d/mod.rs
+++ b/nusamai/src/sink/tiling2d/mod.rs
@@ -75,7 +75,7 @@ impl DataSink for Tiling2DSink {
                                 return Err(());
                             };
                             if sender.send(bytes).is_err() {
-                                println!("sink cancelled");
+                                log::info!("sink cancelled");
                                 return Err(());
                             };
                         }

--- a/nusamai/src/source/citygml.rs
+++ b/nusamai/src/source/citygml.rs
@@ -45,7 +45,7 @@ impl DataSource for CityGMLSource {
         let code_resolver = nusamai_plateau::codelist::Resolver::new();
 
         let _ = self.filenames.par_iter().try_for_each(|filename| {
-            println!("loading city objects from: {} ...", filename);
+            log::info!("loading city objects from: {} ...", filename);
             let Ok(file) = std::fs::File::open(filename) else {
                 panic!("failed to open file {}", filename);
             };
@@ -110,7 +110,7 @@ fn toplevel_dispatcher<R: BufRead>(
     match result {
         Ok(_) => Ok(()),
         Err(e) => {
-            println!("Err: {:?}", e);
+            log::error!("{:?}", e);
             Err(e)
         }
     }


### PR DESCRIPTION
ログ出力のための println をなるべく減らして、準公式でデファクトスタンダードの [rust-lang/log](https://github.com/rust-lang/log) crate  を使うようにしていく。

試しに `nusamai` crate の一部の println! を log::* に置き換えている。