### PR TITLE
Fix #178 stretto のキャッシュがエラーログを出す問題に対処

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1,38 +1,15 @@
-# create-svelte
+# app
 
-Everything you need to build a Svelte project, powered by [`create-svelte`](https://github.com/sveltejs/kit/tree/master/packages/create-svelte).
+## Development
 
-## Creating a project
+Tauri dev:
 
-If you're seeing this, you've probably already done this step. Congrats!
-
-```bash
-# create a new project in the current directory
-npm create svelte@latest
-
-# create a new project in my-app
-npm create svelte@latest my-app
+```console
+RUST_BACKTRACE=1 npx tauri dev
 ```
 
-## Developing
+Tauri build:
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
-
-```bash
-npm run dev
-
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
 ```
-
-## Building
-
-To create a production version of your app:
-
-```bash
-npm run build
+npx tauri build
 ```
-
-You can preview the production build with `npm run preview`.
-
-> To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.

--- a/nusamai-plateau/src/codelist/resolver.rs
+++ b/nusamai-plateau/src/codelist/resolver.rs
@@ -28,10 +28,7 @@ impl Default for Resolver {
 
 impl Drop for Resolver {
     fn drop(&mut self) {
-        // FIXME
-        self.cache.wait().unwrap();
         self.cache.close().unwrap();
-        self.cache.wait().unwrap();
     }
 }
 


### PR DESCRIPTION
See #178 

stretto のキャッシュ（コードリストのキャッシュとして使っている）がエラーログを吐く問題に対処する。

`cache.close` を明示的に呼び出すことでエラーログは出なくなるように思う（他のPR #181 で既に対処していたが改めて整理する）。

Fix #178 