### PR TITLE
.gml が GitHub の言語統計に認識されないようにする

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.gml linguist-detectable=false


### PR DESCRIPTION
参考: https://github.com/github-linguist/linguist/blob/master/docs/overrides.md

Close #184