### PR TITLE
Transform: 属性名から名前空間接頭辞を除去する操作

### DIFF
--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -10,7 +10,7 @@ use nusamai::sink::{
     geojson::GeoJsonSinkProvider, gpkg::GpkgSinkProvider, mvt::MVTSinkProvider,
     serde::SerdeSinkProvider,
 };
-use nusamai::source::citygml::CityGMLSourceProvider;
+use nusamai::source::citygml::CityGmlSourceProvider;
 use nusamai::source::DataSourceProvider;
 use nusamai::transformer::builder::{NusamaiTransformBuilder, TransformBuilder};
 use nusamai::transformer::runner::MultiThreadTransformer;
@@ -38,7 +38,7 @@ fn run(input_paths: Vec<String>, output_path: String, filetype: String) {
     let canceller = Arc::new(Mutex::new(Canceller::default()));
 
     let source = {
-        let source_provider: Box<dyn DataSourceProvider> = Box::new(CityGMLSourceProvider {
+        let source_provider: Box<dyn DataSourceProvider> = Box::new(CityGmlSourceProvider {
             filenames: input_paths,
         });
         let mut source_params = source_provider.parameters();
@@ -75,7 +75,7 @@ fn run(input_paths: Vec<String>, output_path: String, filetype: String) {
     };
 
     let (transformer, schema) = {
-        use nusamai_citygml::CityGMLElement;
+        use nusamai_citygml::CityGmlElement;
         let transform_builder = NusamaiTransformBuilder::default();
         let mut schema = nusamai_citygml::schema::Schema::default();
         TopLevelCityObject::collect_schema(&mut schema);

--- a/nusamai-citygml/macros/README.md
+++ b/nusamai-citygml/macros/README.md
@@ -20,7 +20,7 @@ pub struct FooBarFeature {
 It expands to:
 
 ```rust
-#[derive(Default, Debug, CityGMLElement)]
+#[derive(Default, Debug, CityGmlElement)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(tag = "type"))]
 #[citygml(name = "abc:FooBarFeature")]
 pub struct FooBarFeature {
@@ -66,7 +66,7 @@ pub struct FooBarData {
 It expands to:
 
 ```rust
-#[derive(Default, Debug, CityGMLElement)]
+#[derive(Default, Debug, CityGmlElement)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(tag = "type"))]
 #[citygml(name = "abc:FooBarData")]
 pub struct FooBarFeature {
@@ -90,7 +90,7 @@ pub enum FooBarProperty {
 It expands to:
 
 ```rust
-#[derive(Default, Debug, CityGMLElement)]
+#[derive(Default, Debug, CityGmlElement)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(tag = "type"))]
 #[citygml(name = "abc:FooBarProperty")]
 pub enum FooBarProperty {
@@ -105,9 +105,9 @@ pub enum FooBarProperty {
 
 ## Derive macros
 
-### `#[derive(CityGMLElement)]`
+### `#[derive(CityGmlElement)]`
 
-It automatically implements the `CityGMLElement` trait for the target struct/enum, enabling it to parse corresponding CityGML fragments.
+It automatically implements the `CityGmlElement` trait for the target struct/enum, enabling it to parse corresponding CityGML fragments.
 
 In most cases, you should use the attribute macros above instead of directly applying this derive macro.
 

--- a/nusamai-citygml/macros/src/derive.rs
+++ b/nusamai-citygml/macros/src/derive.rs
@@ -1,4 +1,4 @@
-//! CityGMLElement derive macro
+//! CityGmlElement derive macro
 
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
@@ -195,7 +195,7 @@ fn generate_citygml_impl_for_struct(
                         let pat = LitByteStr::new(path, attr.span());
                         let hash = hash(path);
                         child_arms.push(quote! {
-                            (#hash, #pat) => <#field_ty as CityGMLElement>::parse(&mut self.#field_ident, st),
+                            (#hash, #pat) => <#field_ty as CityGmlElement>::parse(&mut self.#field_ident, st),
                         });
                     };
 
@@ -216,7 +216,7 @@ fn generate_citygml_impl_for_struct(
                     );
                     prop_stmts.push(
                         quote! {
-                            attributes.insert("gen:genericAttribute".into(), <#field_ty as CityGMLElement>::collect_schema(schema));
+                            attributes.insert("gen:genericAttribute".into(), <#field_ty as CityGmlElement>::collect_schema(schema));
                         }
                     );
                     Ok(())
@@ -232,7 +232,7 @@ fn generate_citygml_impl_for_struct(
                     // XML attributes (e.g. @gml:id)
                     attribute_arms.push(quote! {
                         #path => {
-                            self.#field_ident = <#field_ty as nusamai_citygml::CityGMLAttribute>::parse_attr_value(
+                            self.#field_ident = <#field_ty as nusamai_citygml::CityGmlAttribute>::parse_attr_value(
                                 std::str::from_utf8(value).unwrap(),
                             )?;
                             Ok(())
@@ -251,7 +251,7 @@ fn generate_citygml_impl_for_struct(
                         });
                         prop_stmts.push(
                             quote! {
-                                attributes.insert(#name.into(), <#field_ty as CityGMLElement>::collect_schema(schema));
+                                attributes.insert(#name.into(), <#field_ty as CityGmlElement>::collect_schema(schema));
                             }
                         );
                     }
@@ -269,7 +269,7 @@ fn generate_citygml_impl_for_struct(
 
                     let hash = hash(&path.value());
                     child_arms.push(quote! {
-                        (#hash, #path) => <#field_ty as CityGMLElement>::parse(&mut self.#field_ident, st),
+                        (#hash, #path) => <#field_ty as CityGmlElement>::parse(&mut self.#field_ident, st),
                     });
 
                     if !into_obj_generated {
@@ -289,12 +289,12 @@ fn generate_citygml_impl_for_struct(
                         prop_stmts.push(
                             match required {
                                 true => quote! {
-                                    let mut ty_ref = <#field_ty as CityGMLElement>::collect_schema(schema);
+                                    let mut ty_ref = <#field_ty as CityGmlElement>::collect_schema(schema);
                                     if ty_ref.min_occurs == 0 { ty_ref.min_occurs = 1; }
                                     attributes.insert(#name.into(), ty_ref);
                                 },
                                 false => quote! {
-                                    attributes.insert(#name.into(), <#field_ty as CityGMLElement>::collect_schema(schema));
+                                    attributes.insert(#name.into(), <#field_ty as CityGmlElement>::collect_schema(schema));
                                 }
                             }
                         );
@@ -374,7 +374,7 @@ fn generate_citygml_impl_for_struct(
     };
 
     Ok(quote! {
-        impl #impl_generics ::nusamai_citygml::CityGMLElement for #struct_ident #ty_generics #where_clause {
+        impl #impl_generics ::nusamai_citygml::CityGmlElement for #struct_ident #ty_generics #where_clause {
             fn parse<R: std::io::BufRead>(&mut self, st: &mut ::nusamai_citygml::SubTreeReader<R>) -> Result<(), ::nusamai_citygml::ParseError> {
                 #attr_parsing
 
@@ -459,7 +459,7 @@ fn generate_citygml_impl_for_enum(
         let field_ty = &field.ty;
         let variant_ident = &variant.ident;
         choice_types.push(quote! {
-            <#field_ty as CityGMLElement>::collect_schema(schema),
+            <#field_ty as CityGmlElement>::collect_schema(schema),
         });
 
         for attr in &variant.attrs {
@@ -476,7 +476,7 @@ fn generate_citygml_impl_for_enum(
                         quote! {
                             (_, #path) => {
                                 let mut v: #field_ty = Default::default();
-                                <#field_ty as CityGMLElement>::parse(&mut v, st)?;
+                                <#field_ty as CityGmlElement>::parse(&mut v, st)?;
                                 *self = Self::#variant_ident(v);
                                 Ok(())
                             }
@@ -485,7 +485,7 @@ fn generate_citygml_impl_for_enum(
                         quote! {
                             (#hash, #path) => {
                                 let mut v: #field_ty = Default::default();
-                                <#field_ty as CityGMLElement>::parse(&mut v, st)?;
+                                <#field_ty as CityGmlElement>::parse(&mut v, st)?;
                                 *self = Self::#variant_ident(v);
                                 Ok(())
                             }
@@ -505,7 +505,7 @@ fn generate_citygml_impl_for_enum(
     let struct_name = &derive_input.ident;
 
     Ok(quote! {
-        impl #impl_generics ::nusamai_citygml::CityGMLElement for #struct_name #ty_generics #where_clause {
+        impl #impl_generics ::nusamai_citygml::CityGmlElement for #struct_name #ty_generics #where_clause {
             fn parse<R: ::std::io::BufRead>(&mut self, st: &mut ::nusamai_citygml::SubTreeReader<R>) -> Result<(), ::nusamai_citygml::ParseError> {
                 st.parse_children(|st| {
                     let path = st.current_path();

--- a/nusamai-citygml/macros/src/lib.rs
+++ b/nusamai-citygml/macros/src/lib.rs
@@ -7,7 +7,7 @@ mod type_attrs;
 
 use proc_macro::TokenStream;
 
-#[proc_macro_derive(CityGMLElement, attributes(citygml))]
+#[proc_macro_derive(CityGmlElement, attributes(citygml))]
 pub fn derive_citygml_element(token: TokenStream) -> TokenStream {
     derive::derive_citygml_element(token)
 }

--- a/nusamai-citygml/macros/src/type_attrs.rs
+++ b/nusamai-citygml/macros/src/type_attrs.rs
@@ -49,7 +49,7 @@ pub(crate) fn citygml_type(
 
     quote! {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(tag = "type"))]
-        #[derive(Default, Debug, ::nusamai_citygml::CityGMLElement)]
+        #[derive(Default, Debug, ::nusamai_citygml::CityGmlElement)]
         #input
     }
     .into()
@@ -190,25 +190,27 @@ fn modify(ty: &StereoType, args: &FeatureArgs, input: &mut DeriveInput) -> Resul
                     );
                     pos += 1;
 
-                    add_named_field(
-                        pos,
-                        fields,
-                        quote! {
-                            #[citygml(path = b"core:validFrom")]
-                            pub valid_from: Option<::nusamai_citygml::Date> // TODO: DateTime (CityGML 3.0)
-                        },
-                    );
-                    pos += 1;
-
-                    add_named_field(
-                        pos,
-                        fields,
-                        quote! {
-                            #[citygml(path = b"core:validTo")]
-                            pub valid_to: Option<::nusamai_citygml::Date> // TODO: DateTime (CityGML 3.0)
-                        },
-                    );
-                    pos += 1;
+                    // // CityGML 3.0
+                    // add_named_field(
+                    //     pos,
+                    //     fields,
+                    //     quote! {
+                    //         #[citygml(path = b"core:validFrom")]
+                    //         pub valid_from: Option<::nusamai_citygml::Date> // TODO: DateTime (CityGML 3.0)
+                    //     },
+                    // );
+                    // pos += 1;
+                    //
+                    // // CityGML 3.0
+                    // add_named_field(
+                    //     pos,
+                    //     fields,
+                    //     quote! {
+                    //         #[citygml(path = b"core:validTo")]
+                    //         pub valid_to: Option<::nusamai_citygml::Date> // TODO: DateTime (CityGML 3.0)
+                    //     },
+                    // );
+                    // pos += 1;
 
                     // TODO: not implemented yet
                     add_named_field(

--- a/nusamai-citygml/src/attribute.rs
+++ b/nusamai-citygml/src/attribute.rs
@@ -1,19 +1,19 @@
 use crate::parser::ParseError;
 
-pub trait CityGMLAttribute: Sized {
+pub trait CityGmlAttribute: Sized {
     fn parse_attr_value(value: &str) -> Result<Self, ParseError>;
 }
 
-impl CityGMLAttribute for String {
+impl CityGmlAttribute for String {
     #[inline]
     fn parse_attr_value(value: &str) -> Result<Self, ParseError> {
         Ok(value.to_string())
     }
 }
 
-impl<T: CityGMLAttribute> CityGMLAttribute for Option<T> {
+impl<T: CityGmlAttribute> CityGmlAttribute for Option<T> {
     #[inline]
     fn parse_attr_value(value: &str) -> Result<Self, ParseError> {
-        Ok(Some(<T as CityGMLAttribute>::parse_attr_value(value)?))
+        Ok(Some(<T as CityGmlAttribute>::parse_attr_value(value)?))
     }
 }

--- a/nusamai-citygml/src/lib.rs
+++ b/nusamai-citygml/src/lib.rs
@@ -16,7 +16,7 @@ pub use values::*;
 
 pub use object::Value;
 
-pub trait CityGMLElement: Sized {
+pub trait CityGmlElement: Sized {
     /// Parse a XML fragment into this element.
     fn parse<R: std::io::BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError>;
 

--- a/nusamai-citygml/src/object.rs
+++ b/nusamai-citygml/src/object.rs
@@ -59,6 +59,27 @@ pub enum Value {
     Object(Object),
 }
 
+impl Value {
+    /// Traverses the attribute tree and apply the function to each object.
+    pub fn traverse_object_mut(&mut self, mut f: impl FnMut(&mut Object)) {
+        self.traverse_object_mut_inner(&mut f);
+    }
+
+    fn traverse_object_mut_inner(&mut self, f: &mut impl FnMut(&mut Object)) {
+        match self {
+            Value::Object(obj) => {
+                f(obj);
+            }
+            Value::Array(arr) => {
+                for v in arr.iter_mut() {
+                    v.traverse_object_mut_inner(f);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
 #[cfg(feature = "serde_json")]
 impl Value {
     /// Extracts the thematic attribute tree and converts it to a JSON representation.

--- a/nusamai-citygml/src/parser.rs
+++ b/nusamai-citygml/src/parser.rs
@@ -29,7 +29,7 @@ pub enum ParseError {
     Cancelled,
 }
 
-pub struct CityGMLReader<'a> {
+pub struct CityGmlReader<'a> {
     state: InternalState<'a>,
 }
 
@@ -100,7 +100,7 @@ impl<'a> Default for ParseContext<'a> {
     }
 }
 
-impl<'a> CityGMLReader<'a> {
+impl<'a> CityGmlReader<'a> {
     #[inline]
     pub fn new(context: ParseContext<'a>) -> Self {
         Self {
@@ -816,7 +816,7 @@ mod tests {
 
     fn parse(doc: &str, f: impl Fn(&mut SubTreeReader<std::io::Cursor<&str>>)) {
         let mut reader = quick_xml::NsReader::from_reader(std::io::Cursor::new(doc));
-        let mut citygml_reader = CityGMLReader::new(ParseContext::default());
+        let mut citygml_reader = CityGmlReader::new(ParseContext::default());
         let mut subtree_reader = citygml_reader
             .start_root(&mut reader)
             .expect("Failed to start root");

--- a/nusamai-citygml/src/schema.rs
+++ b/nusamai-citygml/src/schema.rs
@@ -42,7 +42,7 @@ pub struct PropertyTypeDef {
 pub struct Attribute {
     #[serde(rename = "ref")]
     pub type_ref: TypeRef,
-    #[serde(default, skip_serializing_if = "is_one")]
+    #[serde(default, skip_serializing_if = "is_zero")]
     pub min_occurs: u16,
     #[serde(default, skip_serializing_if = "is_some_one")]
     pub max_occurs: Option<u16>,
@@ -61,7 +61,7 @@ impl Default for Attribute {
     fn default() -> Self {
         Self {
             type_ref: TypeRef::Unknown,
-            min_occurs: 1,
+            min_occurs: 0,
             max_occurs: Some(1),
         }
     }
@@ -88,13 +88,13 @@ fn is_false(n: &bool) -> bool {
     !(*n)
 }
 
-fn is_one(n: &u16) -> bool {
-    *n == 1
+fn is_zero(n: &u16) -> bool {
+    *n == 0
 }
 
 fn is_some_one(n: &Option<u16>) -> bool {
     match n {
-        Some(n) => is_one(n),
+        Some(n) => *n == 1,
         None => false,
     }
 }

--- a/nusamai-citygml/src/values.rs
+++ b/nusamai-citygml/src/values.rs
@@ -1,7 +1,7 @@
 use crate::object::{self, Value};
 use crate::parser::{ParseError, SubTreeReader};
 use crate::schema;
-use crate::CityGMLElement;
+use crate::CityGmlElement;
 pub use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 use std::io::BufRead;
@@ -16,7 +16,7 @@ pub type BuildingLODType = String; // TODO?
 pub type DoubleList = String; // TODO?
 pub type LODType = u64; // TODO?
 
-impl CityGMLElement for String {
+impl CityGmlElement for String {
     #[inline]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         self.push_str(st.parse_text()?);
@@ -44,7 +44,7 @@ impl URI {
     }
 }
 
-impl CityGMLElement for URI {
+impl CityGmlElement for URI {
     #[inline]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         self.0.push_str(st.parse_text()?);
@@ -79,7 +79,7 @@ impl Code {
     }
 }
 
-impl CityGMLElement for Code {
+impl CityGmlElement for Code {
     #[inline]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         let code_space = st.find_codespace_attr();
@@ -120,7 +120,7 @@ impl CityGMLElement for Code {
     }
 }
 
-impl CityGMLElement for i64 {
+impl CityGmlElement for i64 {
     #[inline]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         let text = st.parse_text()?;
@@ -145,7 +145,7 @@ impl CityGMLElement for i64 {
     }
 }
 
-impl CityGMLElement for u64 {
+impl CityGmlElement for u64 {
     #[inline]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         let text = st.parse_text()?;
@@ -170,7 +170,7 @@ impl CityGMLElement for u64 {
     }
 }
 
-impl CityGMLElement for f64 {
+impl CityGmlElement for f64 {
     #[inline]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         let text = st.parse_text()?;
@@ -195,7 +195,7 @@ impl CityGMLElement for f64 {
     }
 }
 
-impl CityGMLElement for bool {
+impl CityGmlElement for bool {
     #[inline]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         let text = st.parse_text()?.trim();
@@ -239,7 +239,7 @@ impl Measure {
     }
 }
 
-impl CityGMLElement for Measure {
+impl CityGmlElement for Measure {
     #[inline]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         let text = st.parse_text()?;
@@ -264,7 +264,7 @@ impl CityGMLElement for Measure {
     }
 }
 
-impl CityGMLElement for Date {
+impl CityGmlElement for Date {
     #[inline]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         let text = st.parse_text()?;
@@ -296,7 +296,7 @@ pub struct Point {
 
 pub type Vector = Point;
 
-impl CityGMLElement for Point {
+impl CityGmlElement for Point {
     #[inline]
     fn parse<R: BufRead>(&mut self, _st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         // TODO
@@ -312,7 +312,7 @@ impl CityGMLElement for Point {
     }
 }
 
-impl<T: CityGMLElement + Default> CityGMLElement for Option<T> {
+impl<T: CityGmlElement + Default> CityGmlElement for Option<T> {
     #[inline]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         if self.is_some() {
@@ -341,11 +341,11 @@ impl<T: CityGMLElement + Default> CityGMLElement for Option<T> {
     }
 }
 
-impl<T: CityGMLElement + Default> CityGMLElement for Vec<T> {
+impl<T: CityGmlElement + Default> CityGmlElement for Vec<T> {
     #[inline]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         let mut v: T = Default::default();
-        <T as CityGMLElement>::parse(&mut v, st)?;
+        <T as CityGmlElement>::parse(&mut v, st)?;
         self.push(v);
         Ok(())
     }
@@ -368,10 +368,10 @@ impl<T: CityGMLElement + Default> CityGMLElement for Vec<T> {
     }
 }
 
-impl<T: CityGMLElement + Default> CityGMLElement for Box<T> {
+impl<T: CityGmlElement + Default> CityGmlElement for Box<T> {
     #[inline]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
-        <T as CityGMLElement>::parse(self, st)?;
+        <T as CityGmlElement>::parse(self, st)?;
         Ok(())
     }
 
@@ -396,7 +396,7 @@ pub struct GenericAttribute {
     pub generic_attr_set: Vec<(String, GenericAttribute)>,
 }
 
-impl CityGMLElement for GenericAttribute {
+impl CityGmlElement for GenericAttribute {
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         match st.current_path() {
             b"gen:stringAttribute" | b"gen:StringAttribute" => {
@@ -495,7 +495,7 @@ impl CityGMLElement for GenericAttribute {
 
 fn parse_value<T, R: BufRead>(st: &mut SubTreeReader<R>) -> Result<(String, T), ParseError>
 where
-    T: CityGMLElement + Default,
+    T: CityGmlElement + Default,
 {
     let mut name = None;
     let mut value = None;

--- a/nusamai-citygml/tests/values.rs
+++ b/nusamai-citygml/tests/values.rs
@@ -1,11 +1,11 @@
 use nusamai_citygml::{
-    citygml_feature, values, CityGMLElement, CityGMLReader, Date, Measure, ParseContext,
+    citygml_feature, values, CityGmlElement, CityGmlReader, Date, Measure, ParseContext,
     ParseError, Value, URI,
 };
 
 #[test]
 fn parse_date() {
-    #[derive(CityGMLElement, Default)]
+    #[derive(CityGmlElement, Default)]
     struct Root {
         #[citygml(path = b"date")]
         date: Option<chrono::NaiveDate>,
@@ -15,7 +15,7 @@ fn parse_date() {
         r#"<root><date>2019-03-21</date></root>"#,
     ));
     let context = ParseContext::default();
-    match CityGMLReader::new(context).start_root(&mut xml_reader) {
+    match CityGmlReader::new(context).start_root(&mut xml_reader) {
         Ok(mut st) => {
             let mut root = Root::default();
             root.parse(&mut st).unwrap();
@@ -28,7 +28,7 @@ fn parse_date() {
 
 #[test]
 fn parse_boolean() {
-    #[derive(CityGMLElement, Default)]
+    #[derive(CityGmlElement, Default)]
     struct Root {
         #[citygml(path = b"boolean")]
         bools: Vec<bool>,
@@ -49,7 +49,7 @@ fn parse_boolean() {
         "#,
     ));
     let context = ParseContext::default();
-    match CityGMLReader::new(context).start_root(&mut xml_reader) {
+    match CityGmlReader::new(context).start_root(&mut xml_reader) {
         Ok(mut st) => {
             let mut root = Root::default();
             root.parse(&mut st).unwrap();
@@ -64,7 +64,7 @@ fn parse_boolean() {
 
 #[test]
 fn parse_basic_types() {
-    #[derive(CityGMLElement, Default)]
+    #[derive(CityGmlElement, Default)]
     struct Root {
         #[citygml(path = b"int")]
         int: Option<i64>,
@@ -99,7 +99,7 @@ fn parse_basic_types() {
         "#,
     ));
     let context = ParseContext::default();
-    match CityGMLReader::new(context).start_root(&mut xml_reader) {
+    match CityGmlReader::new(context).start_root(&mut xml_reader) {
         Ok(mut st) => {
             let mut root = Root::default();
             root.parse(&mut st).unwrap();
@@ -119,10 +119,10 @@ fn parse_basic_types() {
     }
 }
 
-fn expect_invalid<T: CityGMLElement + Default>(xml: &str) {
+fn expect_invalid<T: CityGmlElement + Default>(xml: &str) {
     let mut xml_reader = quick_xml::NsReader::from_reader(std::io::Cursor::new(xml));
     let context = ParseContext::default();
-    match CityGMLReader::new(context).start_root(&mut xml_reader) {
+    match CityGmlReader::new(context).start_root(&mut xml_reader) {
         Ok(mut st) => {
             let mut root = T::default();
             match root.parse(&mut st) {
@@ -156,13 +156,13 @@ fn parse_duplicate_content() {
     "#,
     ));
 
-    #[derive(CityGMLElement, Default)]
+    #[derive(CityGmlElement, Default)]
     struct Root {
         #[citygml(path = b"only_once")]
         only_once: Option<i64>,
     }
     let context = ParseContext::default();
-    match CityGMLReader::new(context).start_root(&mut xml_reader) {
+    match CityGmlReader::new(context).start_root(&mut xml_reader) {
         Ok(mut st) => {
             let mut root = Root::default();
             match root.parse(&mut st) {
@@ -221,7 +221,7 @@ fn generics() {
     let mut xml_reader = quick_xml::NsReader::from_reader(reader);
     let context = nusamai_citygml::ParseContext::default();
     let mut demo = Demo::default();
-    match nusamai_citygml::CityGMLReader::new(context).start_root(&mut xml_reader) {
+    match nusamai_citygml::CityGmlReader::new(context).start_root(&mut xml_reader) {
         Ok(mut st) => {
             demo.parse(&mut st).unwrap();
         }

--- a/nusamai-plateau/examples/parse_and_compress.rs
+++ b/nusamai-plateau/examples/parse_and_compress.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use serde::{Deserialize, Serialize};
 use std::{io::BufRead, time::Instant};
 
-use nusamai_citygml::{object::Value, CityGMLElement, CityGMLReader, ParseError, SubTreeReader};
+use nusamai_citygml::{object::Value, CityGmlElement, CityGmlReader, ParseError, SubTreeReader};
 
 #[derive(Debug, Deserialize, Serialize)]
 struct TopLevelCityObject {
@@ -101,7 +101,7 @@ fn main() {
             let inst = Instant::now();
             let mut xml_reader = quick_xml::NsReader::from_reader(reader);
             let context = nusamai_citygml::ParseContext::default();
-            match CityGMLReader::new(context).start_root(&mut xml_reader) {
+            match CityGmlReader::new(context).start_root(&mut xml_reader) {
                 Ok(mut st) => {
                     match example_toplevel_dispatcher(
                         &mut st,

--- a/nusamai-plateau/examples/render_schema.rs
+++ b/nusamai-plateau/examples/render_schema.rs
@@ -1,4 +1,4 @@
-use nusamai_citygml::{schema, schema::Schema, CityGMLElement};
+use nusamai_citygml::{schema, schema::Schema, CityGmlElement};
 use nusamai_plateau::models::TopLevelCityObject;
 
 use std::io;

--- a/nusamai-plateau/src/models/bridge.rs
+++ b/nusamai-plateau/src/models/bridge.rs
@@ -1,6 +1,6 @@
 use super::core::Address;
 use super::iur::uro;
-use nusamai_citygml::{citygml_feature, citygml_property, CityGMLElement, Code, GYear};
+use nusamai_citygml::{citygml_feature, citygml_property, CityGmlElement, Code, GYear};
 
 #[citygml_feature(name = "brid:Bridge")]
 pub struct Bridge {

--- a/nusamai-plateau/src/models/building.rs
+++ b/nusamai-plateau/src/models/building.rs
@@ -1,7 +1,7 @@
 use super::core::Address;
 use super::iur::uro;
 use nusamai_citygml::{
-    citygml_feature, citygml_property, CityGMLElement, Code, GYear, Length, Measure,
+    citygml_feature, citygml_property, CityGmlElement, Code, GYear, Length, Measure,
     MeasureOrNullList,
 };
 

--- a/nusamai-plateau/src/models/cityfurniture.rs
+++ b/nusamai-plateau/src/models/cityfurniture.rs
@@ -1,5 +1,5 @@
 use super::iur::uro;
-use nusamai_citygml::{citygml_feature, CityGMLElement, Code};
+use nusamai_citygml::{citygml_feature, CityGmlElement, Code};
 
 #[citygml_feature(name = "frn:CityFurniture")]
 pub struct CityFurniture {

--- a/nusamai-plateau/src/models/cityobjectgroup.rs
+++ b/nusamai-plateau/src/models/cityobjectgroup.rs
@@ -1,5 +1,5 @@
 use super::iur::uro;
-use nusamai_citygml::{citygml_feature, CityGMLElement, Code, GYear};
+use nusamai_citygml::{citygml_feature, CityGmlElement, Code, GYear};
 
 #[citygml_feature(name = "grp:CityObjectGroup")]
 pub struct CityObjectGroup {

--- a/nusamai-plateau/src/models/generics.rs
+++ b/nusamai-plateau/src/models/generics.rs
@@ -1,4 +1,4 @@
-use nusamai_citygml::{citygml_feature, CityGMLElement, Code};
+use nusamai_citygml::{citygml_feature, CityGmlElement, Code};
 
 #[citygml_feature(name = "gen:GenericCityObject")]
 pub struct GenericCityObject {

--- a/nusamai-plateau/src/models/iur/urf/zone.rs
+++ b/nusamai-plateau/src/models/iur/urf/zone.rs
@@ -1,5 +1,5 @@
 use nusamai_citygml::{
-    citygml_data, citygml_feature, citygml_property, CityGMLElement, Code, Date, GYear, Length,
+    citygml_data, citygml_feature, citygml_property, CityGmlElement, Code, Date, GYear, Length,
     Measure, URI,
 };
 

--- a/nusamai-plateau/src/models/iur/uro/bridge.rs
+++ b/nusamai-plateau/src/models/iur/uro/bridge.rs
@@ -1,5 +1,5 @@
 use nusamai_citygml::{
-    citygml_data, citygml_property, CityGMLElement, Code, Date, GYear, Length, Measure,
+    citygml_data, citygml_property, CityGmlElement, Code, Date, GYear, Length, Measure,
 };
 
 #[citygml_data(name = "uro:BridgeStructureAttribute")]

--- a/nusamai-plateau/src/models/iur/uro/building.rs
+++ b/nusamai-plateau/src/models/iur/uro/building.rs
@@ -1,5 +1,5 @@
 use nusamai_citygml::{
-    citygml_data, citygml_property, CityGMLElement, Code, Date, GYear, Length, Measure,
+    citygml_data, citygml_property, CityGmlElement, Code, Date, GYear, Length, Measure,
 };
 
 #[citygml_data(name = "uro:BuildingIDAttribute")]

--- a/nusamai-plateau/src/models/iur/uro/city_furniture.rs
+++ b/nusamai-plateau/src/models/iur/uro/city_furniture.rs
@@ -1,4 +1,4 @@
-use nusamai_citygml::{citygml_data, CityGMLElement, Code};
+use nusamai_citygml::{citygml_data, CityGmlElement, Code};
 
 #[citygml_data(name = "uro:CityFurnitureDetailAttribute")]
 pub struct CityFurnitureDetailAttribute {

--- a/nusamai-plateau/src/models/iur/uro/common.rs
+++ b/nusamai-plateau/src/models/iur/uro/common.rs
@@ -1,4 +1,4 @@
-use nusamai_citygml::{citygml_data, CityGMLElement, Code, Date, Length, Measure, Point, URI};
+use nusamai_citygml::{citygml_data, CityGmlElement, Code, Date, Length, Measure, Point, URI};
 
 #[citygml_data(name = "uro:UserDefinedValue")]
 pub struct UserDefinedValue {

--- a/nusamai-plateau/src/models/iur/uro/dm.rs
+++ b/nusamai-plateau/src/models/iur/uro/dm.rs
@@ -1,4 +1,4 @@
-use nusamai_citygml::{citygml_data, citygml_property, CityGMLElement, Code, GYearMonth, Length};
+use nusamai_citygml::{citygml_data, citygml_property, CityGmlElement, Code, GYearMonth, Length};
 
 #[citygml_property(name = "uro:DmAttributeProperty")]
 pub enum DmAttributeProperty {

--- a/nusamai-plateau/src/models/iur/uro/facility.rs
+++ b/nusamai-plateau/src/models/iur/uro/facility.rs
@@ -1,5 +1,5 @@
 use nusamai_citygml::{
-    citygml_data, citygml_property, CityGMLElement, Code, Date, GYear, Length, Measure,
+    citygml_data, citygml_property, CityGmlElement, Code, Date, GYear, Length, Measure,
 };
 
 #[citygml_property(name = "uro:FacilityAttributeProperty")]

--- a/nusamai-plateau/src/models/iur/uro/facility_id.rs
+++ b/nusamai-plateau/src/models/iur/uro/facility_id.rs
@@ -1,4 +1,4 @@
-use nusamai_citygml::{citygml_data, citygml_property, CityGMLElement, Code, Measure};
+use nusamai_citygml::{citygml_data, citygml_property, CityGmlElement, Code, Measure};
 
 #[citygml_property(name = "uro:FacilityIdAttributeProperty")]
 pub enum FacilityIdAttributeProperty {

--- a/nusamai-plateau/src/models/iur/uro/facility_type.rs
+++ b/nusamai-plateau/src/models/iur/uro/facility_type.rs
@@ -1,4 +1,4 @@
-use nusamai_citygml::{citygml_data, CityGMLElement, Code};
+use nusamai_citygml::{citygml_data, CityGmlElement, Code};
 
 #[citygml_data(name = "uro:FacilityTypeAttribute")]
 pub struct FacilityTypeAttribute {

--- a/nusamai-plateau/src/models/iur/uro/ifc.rs
+++ b/nusamai-plateau/src/models/iur/uro/ifc.rs
@@ -1,6 +1,6 @@
 use crate::models::core::Address;
 use nusamai_citygml::{
-    citygml_data, citygml_property, CityGMLElement, Code, Date, DoubleList, Measure, Point, URI,
+    citygml_data, citygml_property, CityGmlElement, Code, Date, DoubleList, Measure, Point, URI,
 };
 
 // TODO?

--- a/nusamai-plateau/src/models/iur/uro/indoor.rs
+++ b/nusamai-plateau/src/models/iur/uro/indoor.rs
@@ -1,5 +1,5 @@
 use super::UserDefinedValue;
-use nusamai_citygml::{citygml_data, citygml_property, CityGMLElement, Code};
+use nusamai_citygml::{citygml_data, citygml_property, CityGmlElement, Code};
 
 #[citygml_property(name = "uro:IndoorAttributeProperty")]
 pub enum IndoorAttributeProperty {

--- a/nusamai-plateau/src/models/iur/uro/keyvalue.rs
+++ b/nusamai-plateau/src/models/iur/uro/keyvalue.rs
@@ -1,4 +1,4 @@
-use nusamai_citygml::{citygml_data, CityGMLElement, Code};
+use nusamai_citygml::{citygml_data, CityGmlElement, Code};
 
 #[citygml_data(name = "uro:KeyValuePairAttribute")]
 pub struct KeyValuePairAttribute {

--- a/nusamai-plateau/src/models/iur/uro/landuse.rs
+++ b/nusamai-plateau/src/models/iur/uro/landuse.rs
@@ -1,6 +1,4 @@
-use nusamai_citygml::{
-    citygml_data, CityGMLElement, Code, GYear, Measure,
-};
+use nusamai_citygml::{citygml_data, CityGmlElement, Code, GYear, Measure};
 
 #[citygml_data(name = "uro:LandUseDetailAttribute")]
 pub struct LandUseDetailAttribute {
@@ -63,7 +61,6 @@ pub struct LandUseDetailAttribute {
 
     #[citygml(path = b"uro:surveyYear")]
     pub survey_year: Option<GYear>,
-
 }
 
 #[citygml_data(name = "uro:LandUseDataQualityAttribute")]
@@ -76,5 +73,4 @@ pub struct LandUseDataQualityAttribute {
 
     #[citygml(path = b"uro:thematicSrcDesc")]
     pub thematic_src_desc: Vec<Code>,
-
 }

--- a/nusamai-plateau/src/models/iur/uro/other_construction.rs
+++ b/nusamai-plateau/src/models/iur/uro/other_construction.rs
@@ -1,4 +1,4 @@
-use nusamai_citygml::{citygml_data, citygml_property, CityGMLElement, Code, Length, Measure};
+use nusamai_citygml::{citygml_data, citygml_property, CityGmlElement, Code, Length, Measure};
 
 #[citygml_data(name = "uro:ConstructionDataQualityAttribute")]
 pub struct ConstructionDataQualityAttribute {

--- a/nusamai-plateau/src/models/iur/uro/transportation.rs
+++ b/nusamai-plateau/src/models/iur/uro/transportation.rs
@@ -1,5 +1,5 @@
 use nusamai_citygml::{
-    citygml_data, citygml_property, CityGMLElement, Code, Date, GYear, Length, Measure, Point,
+    citygml_data, citygml_property, CityGmlElement, Code, Date, GYear, Length, Measure, Point,
 };
 
 #[citygml_data(name = "uro:TransportationDataQualityAttribute")]

--- a/nusamai-plateau/src/models/iur/uro/tunnel.rs
+++ b/nusamai-plateau/src/models/iur/uro/tunnel.rs
@@ -1,4 +1,4 @@
-use nusamai_citygml::{citygml_data, CityGMLElement, Code, Measure, Length};
+use nusamai_citygml::{citygml_data, CityGmlElement, Code, Length, Measure};
 
 #[citygml_data(name = "uro:TunnelFunctionalAttribute")]
 pub struct TunnelFunctionalAttribute {
@@ -7,7 +7,6 @@ pub struct TunnelFunctionalAttribute {
 
     #[citygml(path = b"uro:userType")]
     pub user_type: Option<Code>,
-
 }
 
 #[citygml_data(name = "uro:TunnelStructureAttribute")]
@@ -38,6 +37,4 @@ pub struct TunnelStructureAttribute {
 
     #[citygml(path = b"uro:slopeType")]
     pub slope_type: Option<Code>,
-
 }
-

--- a/nusamai-plateau/src/models/iur/uro/underground_building.rs
+++ b/nusamai-plateau/src/models/iur/uro/underground_building.rs
@@ -1,4 +1,4 @@
-use nusamai_citygml::{citygml_feature, CityGMLElement, Code, GYear, Length, MeasureOrNullList};
+use nusamai_citygml::{citygml_feature, CityGmlElement, Code, GYear, Length, MeasureOrNullList};
 
 use crate::models::building as bldg;
 use crate::models::core;

--- a/nusamai-plateau/src/models/iur/uro/utility_network.rs
+++ b/nusamai-plateau/src/models/iur/uro/utility_network.rs
@@ -19,7 +19,7 @@
 
 use super::*;
 use nusamai_citygml::{
-    citygml_data, citygml_feature, CityGMLElement, Code, GYear, Length, Measure, Point,
+    citygml_data, citygml_feature, CityGmlElement, Code, GYear, Length, Measure, Point,
 };
 
 #[citygml_feature(name = "uro:Appurtenance")]

--- a/nusamai-plateau/src/models/iur/uro/vegetation.rs
+++ b/nusamai-plateau/src/models/iur/uro/vegetation.rs
@@ -1,4 +1,4 @@
-use nusamai_citygml::{citygml_data, CityGMLElement, Code};
+use nusamai_citygml::{citygml_data, CityGmlElement, Code};
 
 #[citygml_data(name = "uro:VegetationDataQualityAttribute")]
 pub struct VegetationDataQualityAttribute {

--- a/nusamai-plateau/src/models/iur/uro/waterbody.rs
+++ b/nusamai-plateau/src/models/iur/uro/waterbody.rs
@@ -1,5 +1,5 @@
 use nusamai_citygml::{
-    citygml_data, citygml_property, CityGMLElement, Code, GYearMonth, Length, Measure,
+    citygml_data, citygml_property, CityGmlElement, Code, GYearMonth, Length, Measure,
 };
 
 #[citygml_property(name = "uro:WaterBodyFloodingRiskAttributeProperty")]

--- a/nusamai-plateau/src/models/landuse.rs
+++ b/nusamai-plateau/src/models/landuse.rs
@@ -1,5 +1,5 @@
 use super::iur::uro;
-use nusamai_citygml::{citygml_feature, CityGMLElement, Code};
+use nusamai_citygml::{citygml_feature, CityGmlElement, Code};
 
 #[citygml_feature(name = "luse:LandUse")]
 pub struct LandUse {

--- a/nusamai-plateau/src/models/mod.rs
+++ b/nusamai-plateau/src/models/mod.rs
@@ -21,7 +21,7 @@ pub use generics::GenericCityObject;
 pub use iur::urf;
 pub use iur::uro;
 pub use landuse::LandUse;
-use nusamai_citygml::{citygml_property, CityGMLElement};
+use nusamai_citygml::{citygml_property, CityGmlElement};
 pub use other_construction::OtherConstruction;
 pub use relief::ReliefFeature;
 pub use transportation::{Railway, Road, Square, Track, Waterway};

--- a/nusamai-plateau/src/models/other_construction.rs
+++ b/nusamai-plateau/src/models/other_construction.rs
@@ -2,7 +2,7 @@
 //! con:OtherConstruction (CityGML 3.x)
 
 use super::iur::uro;
-use nusamai_citygml::{citygml_feature, citygml_property, CityGMLElement, Code, Date};
+use nusamai_citygml::{citygml_feature, citygml_property, CityGmlElement, Code, Date};
 
 type ConditionOfConstructionValue = String;
 

--- a/nusamai-plateau/src/models/relief.rs
+++ b/nusamai-plateau/src/models/relief.rs
@@ -1,6 +1,6 @@
 use super::iur::uro;
 use nusamai_citygml::{
-    citygml_data, citygml_feature, citygml_property, CityGMLElement, LODType, Point, Vector,
+    citygml_data, citygml_feature, citygml_property, CityGmlElement, LODType, Point, Vector,
 };
 
 #[citygml_feature(name = "dem:ReliefFeature")]

--- a/nusamai-plateau/src/models/transportation.rs
+++ b/nusamai-plateau/src/models/transportation.rs
@@ -1,5 +1,5 @@
 use super::iur::uro;
-use nusamai_citygml::{citygml_feature, CityGMLElement, Code};
+use nusamai_citygml::{citygml_feature, CityGmlElement, Code};
 
 #[citygml_feature(name = "tran:Road")]
 pub struct Road {

--- a/nusamai-plateau/src/models/tunnel.rs
+++ b/nusamai-plateau/src/models/tunnel.rs
@@ -1,5 +1,5 @@
 use super::iur::uro;
-use nusamai_citygml::{citygml_feature, citygml_property, CityGMLElement, Code, GYear};
+use nusamai_citygml::{citygml_feature, citygml_property, CityGmlElement, Code, GYear};
 
 #[citygml_feature(name = "tun:Tunnel")]
 pub struct Tunnel {

--- a/nusamai-plateau/src/models/vegetation.rs
+++ b/nusamai-plateau/src/models/vegetation.rs
@@ -1,5 +1,5 @@
 use super::uro;
-use nusamai_citygml::{citygml_feature, CityGMLElement, Code, Length};
+use nusamai_citygml::{citygml_feature, CityGmlElement, Code, Length};
 
 #[citygml_feature(name = "veg:SolitaryVegetationObject")]
 pub struct SolitaryVegetationObject {

--- a/nusamai-plateau/src/models/waterbody.rs
+++ b/nusamai-plateau/src/models/waterbody.rs
@@ -1,5 +1,5 @@
 use super::iur::uro;
-use nusamai_citygml::{citygml_feature, citygml_property, CityGMLElement, Code};
+use nusamai_citygml::{citygml_feature, citygml_property, CityGmlElement, Code};
 
 #[citygml_feature(name = "wtr:WaterBody")]
 pub struct WaterBody {

--- a/nusamai-plateau/tests/common/mod.rs
+++ b/nusamai-plateau/tests/common/mod.rs
@@ -2,7 +2,7 @@ use std::io::BufRead;
 use std::path::Path;
 use url::Url;
 
-use nusamai_citygml::{CityGMLElement, CityGMLReader, GeometryStore, ParseError, SubTreeReader};
+use nusamai_citygml::{CityGmlElement, CityGmlReader, GeometryStore, ParseError, SubTreeReader};
 use nusamai_plateau::models::TopLevelCityObject;
 
 pub struct CityObject {
@@ -48,7 +48,7 @@ pub fn load_cityobjs_from_reader(reader: impl BufRead, path: &Path) -> Vec<CityO
     let source_url = Url::from_file_path(std::fs::canonicalize(path).unwrap()).unwrap();
     let context = nusamai_citygml::ParseContext::new(source_url, &code_resolver);
 
-    let cityobjs = match CityGMLReader::new(context).start_root(&mut xml_reader) {
+    let cityobjs = match CityGmlReader::new(context).start_root(&mut xml_reader) {
         Ok(mut st) => match toplevel_dispatcher(&mut st) {
             Ok(cityobjs) => cityobjs,
             Err(e) => panic!("Err: {:?}", e),

--- a/nusamai-plateau/tests/render_schema.rs
+++ b/nusamai-plateau/tests/render_schema.rs
@@ -1,4 +1,4 @@
-use nusamai_citygml::{schema, CityGMLElement};
+use nusamai_citygml::{schema, CityGmlElement};
 use nusamai_plateau::models::TopLevelCityObject;
 
 #[test]

--- a/nusamai-projection/src/vshift.rs
+++ b/nusamai-projection/src/vshift.rs
@@ -2,11 +2,11 @@ use japan_geoid::gsi::MemoryGrid;
 use japan_geoid::Geoid;
 
 /// Convert from JGD 2011 Geograhpic 3D (EPSG:6697) to WGS84 Geograhpic 3D (EPSG:4979)
-pub struct JGD2011ToWGS84 {
+pub struct Jgd2011ToWgs84 {
     geoid: MemoryGrid<'static>,
 }
 
-impl JGD2011ToWGS84 {
+impl Jgd2011ToWgs84 {
     /// Create a new instance with the embed geoid model data.
     pub fn new() -> Self {
         Self {
@@ -21,7 +21,7 @@ impl JGD2011ToWGS84 {
     }
 }
 
-impl Default for JGD2011ToWGS84 {
+impl Default for Jgd2011ToWgs84 {
     fn default() -> Self {
         Self::new()
     }
@@ -34,7 +34,7 @@ mod tests {
     #[test]
     fn fixtures() {
         let (lng_jgd, lat_jgd, elevation) = (138.2839817085188, 37.12378643088312, 0.);
-        let jgd_to_wgs = JGD2011ToWGS84::new();
+        let jgd_to_wgs = Jgd2011ToWgs84::new();
         let (lng_wgs, lat_wgs, ellips_height) = jgd_to_wgs.convert(lng_jgd, lat_jgd, elevation);
         assert!((ellips_height - 39.47387115961899).abs() < 1e-8);
         // (lng, lat) must not change.

--- a/nusamai/schema.json
+++ b/nusamai/schema.json
@@ -1,0 +1,24576 @@
+{
+  "types": {
+    "bldg:Building": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "yearOfConstruction": {
+          "ref": "NonNegativeInteger"
+        },
+        "yearOfDemolition": {
+          "ref": "NonNegativeInteger"
+        },
+        "roofType": {
+          "ref": "Code"
+        },
+        "measuredHeight": {
+          "ref": "Measure"
+        },
+        "storeysAboveGround": {
+          "ref": "NonNegativeInteger"
+        },
+        "storeysBelowGround": {
+          "ref": "NonNegativeInteger"
+        },
+        "storeyHeightsAboveGround": {
+          "ref": "String"
+        },
+        "storeyHeightsBelowGround": {
+          "ref": "String"
+        },
+        "outerBuildingInstallation": {
+          "ref": {
+            "Named": "bldg:BuildingInstallation"
+          },
+          "max_occurs": null
+        },
+        "interiorBuildingInstallation": {
+          "ref": {
+            "Named": "bldg:BuildingInstallation"
+          },
+          "max_occurs": null
+        },
+        "boundedBy": {
+          "ref": {
+            "Named": "bldg:_BoundarySurfaceProperty"
+          },
+          "max_occurs": null
+        },
+        "interiorRoom": {
+          "ref": {
+            "Named": "bldg:Room"
+          },
+          "max_occurs": null
+        },
+        "consistsOfBuildingPart": {
+          "ref": {
+            "Named": "bldg:BuildingPart"
+          },
+          "max_occurs": null
+        },
+        "address": {
+          "ref": {
+            "Named": "core:Address"
+          },
+          "max_occurs": null
+        },
+        "bldgDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "bldgFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "bldgFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "bldgFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "bldgRealEstateIDAttribute": {
+          "ref": {
+            "Named": "uro:RealEstateIDAttribute"
+          }
+        },
+        "buildingDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:BuildingDataQualityAttribute"
+          }
+        },
+        "buildingDetailAttribute": {
+          "ref": {
+            "Named": "uro:BuildingDetailAttribute"
+          },
+          "max_occurs": null
+        },
+        "buildingDisasterRiskAttribute": {
+          "ref": {
+            "Named": "uro:BuildingDisasterRiskAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "buildingIDAttribute": {
+          "ref": {
+            "Named": "uro:BuildingIDAttribute"
+          },
+          "max_occurs": null
+        },
+        "ifcBuildingAttribute": {
+          "ref": {
+            "Named": "uro:IfcAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "indoorBuildingAttribute": {
+          "ref": {
+            "Named": "uro:IndoorAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "keyValuePairAttribute": {
+          "ref": {
+            "Named": "uro:KeyValuePairAttribute"
+          },
+          "max_occurs": null
+        },
+        "largeCustomerFacilityAttribute": {
+          "ref": {
+            "Named": "uro:LargeCustomerFacilityAttribute"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "gen:genericAttribute": {
+      "type": "Data",
+      "attributes": {},
+      "any": true
+    },
+    "bldg:BuildingInstallation": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "boundedBy": {
+          "ref": {
+            "Named": "bldg:_BoundarySurfaceProperty"
+          },
+          "max_occurs": null
+        },
+        "ifcBuildingInstallationAttribute": {
+          "ref": {
+            "Named": "uro:IfcAttributeProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "bldg:CeilingSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "bldg:_OpeningProperty"
+          },
+          "max_occurs": null
+        },
+        "ifcBoundarySurfaceAttribute": {
+          "ref": {
+            "Named": "uro:IfcAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "indoorBoundarySurfaceAttribute": {
+          "ref": {
+            "Named": "uro:IndoorAttributeProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "bldg:Door": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "ifcOpeningAttribute": {
+          "ref": {
+            "Named": "uro:IfcAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "indoorOpeningAttribute": {
+          "ref": {
+            "Named": "uro:IndoorAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "address": {
+          "ref": {
+            "Named": "core:Address"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:IfcBuilding": {
+      "type": "Data",
+      "attributes": {
+        "globalId": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "String"
+        },
+        "description": {
+          "ref": "String"
+        },
+        "objectType": {
+          "ref": "String"
+        },
+        "longName": {
+          "ref": "String"
+        },
+        "compositionType": {
+          "ref": "String"
+        },
+        "elevationOfRefHeight": {
+          "ref": "Measure"
+        },
+        "elevationOfTerrain": {
+          "ref": "Measure"
+        },
+        "buildingAddress": {
+          "ref": {
+            "Named": "core:Address"
+          }
+        }
+      }
+    },
+    "core:Address": {
+      "type": "Data",
+      "attributes": {}
+    },
+    "uro:IfcBuildingElement": {
+      "type": "Data",
+      "attributes": {
+        "globalId": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "String"
+        },
+        "description": {
+          "ref": "String"
+        },
+        "objectType": {
+          "ref": "String"
+        },
+        "tag": {
+          "ref": "String"
+        },
+        "elementType": {
+          "ref": "Code"
+        },
+        "predefinedType": {
+          "ref": "Code"
+        },
+        "shapeType": {
+          "ref": "Code"
+        },
+        "numberOfRiser": {
+          "ref": "Integer"
+        },
+        "numberOfTreads": {
+          "ref": "Integer"
+        },
+        "riserHeight": {
+          "ref": "Measure"
+        },
+        "treadLength": {
+          "ref": "Measure"
+        },
+        "operationType": {
+          "ref": "String"
+        },
+        "capacityByWeight": {
+          "ref": "Measure"
+        },
+        "capacityByNumber": {
+          "ref": "Integer"
+        }
+      }
+    },
+    "uro:IfcBuildingStorey": {
+      "type": "Data",
+      "attributes": {
+        "globalId": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "String"
+        },
+        "description": {
+          "ref": "String"
+        },
+        "objectType": {
+          "ref": "String"
+        },
+        "longName": {
+          "ref": "String"
+        },
+        "compositionType": {
+          "ref": "String"
+        },
+        "elevation": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:IfcClassificationReference": {
+      "type": "Data",
+      "attributes": {
+        "location": {
+          "ref": "URI"
+        },
+        "itemReference": {
+          "ref": "Code"
+        },
+        "name": {
+          "ref": "String"
+        },
+        "referenceSource": {
+          "ref": {
+            "Named": "uro:IfcClassification"
+          }
+        }
+      }
+    },
+    "uro:IfcClassification": {
+      "type": "Data",
+      "attributes": {
+        "source": {
+          "ref": "String"
+        },
+        "edition": {
+          "ref": "String"
+        },
+        "editionDate": {
+          "ref": "Date"
+        },
+        "name": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:IfcCoordinateReferenceSystem": {
+      "type": "Data",
+      "attributes": {
+        "name": {
+          "ref": "String"
+        },
+        "description": {
+          "ref": "String"
+        },
+        "geodeticDatum": {
+          "ref": "String"
+        },
+        "verticalDatum": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:IfcCurtainWall": {
+      "type": "Data",
+      "attributes": {
+        "globalId": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "String"
+        },
+        "description": {
+          "ref": "String"
+        },
+        "objectType": {
+          "ref": "String"
+        },
+        "tag": {
+          "ref": "String"
+        },
+        "elementType": {
+          "ref": "Code"
+        },
+        "predefinedType": {
+          "ref": "Code"
+        },
+        "shapeType": {
+          "ref": "Code"
+        },
+        "numberOfRiser": {
+          "ref": "Integer"
+        },
+        "numberOfTreads": {
+          "ref": "Integer"
+        },
+        "riserHeight": {
+          "ref": "Measure"
+        },
+        "treadLength": {
+          "ref": "Measure"
+        },
+        "operationType": {
+          "ref": "String"
+        },
+        "capacityByWeight": {
+          "ref": "Measure"
+        },
+        "capacityByNumber": {
+          "ref": "Integer"
+        }
+      }
+    },
+    "uro:IfcDoor": {
+      "type": "Data",
+      "attributes": {
+        "globalId": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "String"
+        },
+        "description": {
+          "ref": "String"
+        },
+        "objectType": {
+          "ref": "String"
+        },
+        "tag": {
+          "ref": "String"
+        },
+        "elementType": {
+          "ref": "Code"
+        },
+        "predefinedType": {
+          "ref": "Code"
+        },
+        "shapeType": {
+          "ref": "Code"
+        },
+        "numberOfRiser": {
+          "ref": "Integer"
+        },
+        "numberOfTreads": {
+          "ref": "Integer"
+        },
+        "riserHeight": {
+          "ref": "Measure"
+        },
+        "treadLength": {
+          "ref": "Measure"
+        },
+        "operationType": {
+          "ref": "String"
+        },
+        "capacityByWeight": {
+          "ref": "Measure"
+        },
+        "capacityByNumber": {
+          "ref": "Integer"
+        },
+        "overallHeight": {
+          "ref": "Measure"
+        },
+        "overallWidth": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:IfcFurnishingElement": {
+      "type": "Data",
+      "attributes": {
+        "globalId": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "String"
+        },
+        "description": {
+          "ref": "String"
+        },
+        "objectType": {
+          "ref": "String"
+        },
+        "tag": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:IfcGroup": {
+      "type": "Data",
+      "attributes": {
+        "globalId": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "String"
+        },
+        "description": {
+          "ref": "String"
+        },
+        "objectType": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:IfcMapConversion": {
+      "type": "Data",
+      "attributes": {
+        "sourceCRS": {
+          "ref": {
+            "Named": "uro:IfcCoordinateReferenceSystemSelectType"
+          }
+        },
+        "targetCRS": {
+          "ref": {
+            "Named": "uro:IfcCoordinateReferenceSystemProperty"
+          }
+        },
+        "eastings": {
+          "ref": "Measure"
+        },
+        "northings": {
+          "ref": "Measure"
+        },
+        "orthogonalHeight": {
+          "ref": "Measure"
+        },
+        "xAxisAbscissa": {
+          "ref": "Double"
+        },
+        "xAxisOrdinate": {
+          "ref": "Double"
+        },
+        "scale": {
+          "ref": "Double"
+        }
+      }
+    },
+    "uro:IfcProjectedCRS": {
+      "type": "Data",
+      "attributes": {
+        "name": {
+          "ref": "String"
+        },
+        "description": {
+          "ref": "String"
+        },
+        "geodeticDatum": {
+          "ref": "String"
+        },
+        "verticalDatum": {
+          "ref": "String"
+        },
+        "mapUnit": {
+          "ref": "String"
+        },
+        "mapProjection": {
+          "ref": "String"
+        },
+        "mapZone": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:IfcCoordinateReferenceSystemProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "uro:IfcCoordinateReferenceSystem"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcProjectedCRS"
+          }
+        }
+      ]
+    },
+    "uro:IfcGeometricRepresentationContext": {
+      "type": "Data",
+      "attributes": {
+        "contextIdentifier": {
+          "ref": "String"
+        },
+        "contextType": {
+          "ref": "String"
+        },
+        "coordinateSpaceDimension": {
+          "ref": "Integer"
+        },
+        "precision": {
+          "ref": "Double"
+        },
+        "worldCoordinateSystem": {
+          "ref": {
+            "Named": "uro:IfcAxis2Placement3D"
+          },
+          "min_occurs": 1
+        },
+        "trueNorth": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:IfcAxis2Placement3D": {
+      "type": "Data",
+      "attributes": {
+        "location": {
+          "ref": "Point"
+        },
+        "axis": {
+          "ref": "String"
+        },
+        "refDirection": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:IfcCoordinateReferenceSystemSelectType": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "uro:IfcCoordinateReferenceSystemProperty"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcGeometricRepresentationContext"
+          }
+        }
+      ]
+    },
+    "uro:IfcOpeningElement": {
+      "type": "Data",
+      "attributes": {
+        "globalId": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "String"
+        },
+        "description": {
+          "ref": "String"
+        },
+        "objectType": {
+          "ref": "String"
+        },
+        "tag": {
+          "ref": "String"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "nominalVolume": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:IfcProject": {
+      "type": "Data",
+      "attributes": {
+        "globalId": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "String"
+        },
+        "description": {
+          "ref": "String"
+        },
+        "objectType": {
+          "ref": "String"
+        },
+        "longName": {
+          "ref": "String"
+        },
+        "phase": {
+          "ref": "String"
+        },
+        "representationContexts": {
+          "ref": {
+            "Named": "uro:IfcGeometricRepresentationContext"
+          }
+        },
+        "unitsInContext": {
+          "ref": {
+            "Named": "uro:IfcUnit"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:IfcUnit": {
+      "type": "Data",
+      "attributes": {
+        "dimensions": {
+          "ref": "Integer"
+        },
+        "unitType": {
+          "ref": "String"
+        },
+        "perfix": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:IfcPsetBuildingCommon": {
+      "type": "Data",
+      "attributes": {
+        "buildingId": {
+          "ref": "String"
+        },
+        "isPermanentId": {
+          "ref": "Boolean"
+        },
+        "mainFireUse": {
+          "ref": "String"
+        },
+        "ancillaryFireUse": {
+          "ref": "String"
+        },
+        "sprinklerProtection": {
+          "ref": "Boolean"
+        },
+        "sprinklerProtectionAutomatic": {
+          "ref": "Boolean"
+        },
+        "occupancyType": {
+          "ref": "Code"
+        },
+        "grossPlannedArea": {
+          "ref": "Measure"
+        },
+        "numberOfStoreys": {
+          "ref": "Integer"
+        },
+        "yearOfConstruction": {
+          "ref": "NonNegativeInteger"
+        },
+        "isLandmarked": {
+          "ref": "Boolean"
+        }
+      }
+    },
+    "uro:IfcPsetDoorCommon": {
+      "type": "Data",
+      "attributes": {
+        "reference": {
+          "ref": "String"
+        },
+        "acousticRating": {
+          "ref": "String"
+        },
+        "firerating": {
+          "ref": "String"
+        },
+        "securityRating": {
+          "ref": "String"
+        },
+        "isExternal": {
+          "ref": "Boolean"
+        },
+        "infiltration": {
+          "ref": "Double"
+        },
+        "thermalTransmittance": {
+          "ref": "Double"
+        },
+        "glazingAreaFraction": {
+          "ref": "Double"
+        },
+        "handicapAccessible": {
+          "ref": "Boolean"
+        },
+        "fireExit": {
+          "ref": "Boolean"
+        },
+        "selfClosing": {
+          "ref": "Boolean"
+        },
+        "smokeStop": {
+          "ref": "Boolean"
+        }
+      }
+    },
+    "uro:IfcPsetOpeningElementCommon": {
+      "type": "Data",
+      "attributes": {
+        "reference": {
+          "ref": "String"
+        },
+        "purpose": {
+          "ref": "String"
+        },
+        "fireExit": {
+          "ref": "Boolean"
+        },
+        "protectedOpening": {
+          "ref": "Boolean"
+        },
+        "parallelJambs": {
+          "ref": "Boolean"
+        }
+      }
+    },
+    "uro:IfcPsetSiteCommon": {
+      "type": "Data",
+      "attributes": {
+        "buildableArea": {
+          "ref": "Measure"
+        },
+        "totalArea": {
+          "ref": "Measure"
+        },
+        "buildingHeightLimit": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:IfcPsetSpaceCommon": {
+      "type": "Data",
+      "attributes": {
+        "reference": {
+          "ref": "String"
+        },
+        "category": {
+          "ref": "String"
+        },
+        "floorCovering": {
+          "ref": "String"
+        },
+        "wallCovering": {
+          "ref": "String"
+        },
+        "ceilingCovering": {
+          "ref": "String"
+        },
+        "skirtingBoard": {
+          "ref": "String"
+        },
+        "grossPlannedArea": {
+          "ref": "Measure"
+        },
+        "netPlannedArea": {
+          "ref": "Measure"
+        },
+        "publiclyAccessible": {
+          "ref": "Boolean"
+        },
+        "handicapAccessible": {
+          "ref": "Boolean"
+        },
+        "concealedFlooring": {
+          "ref": "Boolean"
+        },
+        "concealedCeiling": {
+          "ref": "Boolean"
+        }
+      }
+    },
+    "uro:IfcPsetWindowCommon": {
+      "type": "Data",
+      "attributes": {
+        "reference": {
+          "ref": "String"
+        },
+        "acousticRating": {
+          "ref": "String"
+        },
+        "fireRating": {
+          "ref": "String"
+        },
+        "securityRating": {
+          "ref": "String"
+        },
+        "isExternal": {
+          "ref": "Boolean"
+        },
+        "infiltration": {
+          "ref": "Double"
+        },
+        "thermalTransmittance": {
+          "ref": "Double"
+        },
+        "glazingAreaFraction": {
+          "ref": "Double"
+        },
+        "smokeStop": {
+          "ref": "Boolean"
+        }
+      }
+    },
+    "uro:IfcRoof": {
+      "type": "Data",
+      "attributes": {
+        "globalId": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "String"
+        },
+        "description": {
+          "ref": "String"
+        },
+        "objectType": {
+          "ref": "String"
+        },
+        "tag": {
+          "ref": "String"
+        },
+        "elementType": {
+          "ref": "Code"
+        },
+        "predefinedType": {
+          "ref": "Code"
+        },
+        "shapeType": {
+          "ref": "Code"
+        },
+        "numberOfRiser": {
+          "ref": "Integer"
+        },
+        "numberOfTreads": {
+          "ref": "Integer"
+        },
+        "riserHeight": {
+          "ref": "Measure"
+        },
+        "treadLength": {
+          "ref": "Measure"
+        },
+        "operationType": {
+          "ref": "String"
+        },
+        "capacityByWeight": {
+          "ref": "Measure"
+        },
+        "capacityByNumber": {
+          "ref": "Integer"
+        }
+      }
+    },
+    "uro:IfcSite": {
+      "type": "Data",
+      "attributes": {
+        "globalId": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "String"
+        },
+        "description": {
+          "ref": "String"
+        },
+        "objectType": {
+          "ref": "String"
+        },
+        "longName": {
+          "ref": "String"
+        },
+        "compositionType": {
+          "ref": "String"
+        },
+        "refLongitude": {
+          "ref": "Double"
+        },
+        "refLatitude": {
+          "ref": "Double"
+        },
+        "refElevation": {
+          "ref": "Measure"
+        },
+        "landTitleNumber": {
+          "ref": "String"
+        },
+        "siteAddress": {
+          "ref": {
+            "Named": "core:Address"
+          }
+        }
+      }
+    },
+    "uro:IfcSpace": {
+      "type": "Data",
+      "attributes": {
+        "globalId": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "String"
+        },
+        "description": {
+          "ref": "String"
+        },
+        "objectType": {
+          "ref": "String"
+        },
+        "longName": {
+          "ref": "String"
+        },
+        "compositionType": {
+          "ref": "String"
+        },
+        "interiorOrExteriorSpace": {
+          "ref": "String"
+        },
+        "elevationWithFlooring": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:IfcSpaceBaseQuantity": {
+      "type": "Data",
+      "attributes": {
+        "nominalHeight": {
+          "ref": "Measure"
+        },
+        "clearHeight": {
+          "ref": "Measure"
+        },
+        "finishCeilingHeight": {
+          "ref": "Measure"
+        },
+        "grossPerimeter": {
+          "ref": "Measure"
+        },
+        "netPerimeter": {
+          "ref": "Measure"
+        },
+        "grossCeilingArea": {
+          "ref": "Measure"
+        },
+        "grossFloorArea": {
+          "ref": "Measure"
+        },
+        "netCeilingArea": {
+          "ref": "Measure"
+        },
+        "netFloorArea": {
+          "ref": "Measure"
+        },
+        "grossWallArea": {
+          "ref": "Measure"
+        },
+        "netWallArea": {
+          "ref": "Measure"
+        },
+        "grossVolume": {
+          "ref": "Measure"
+        },
+        "netVolume": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:IfcWall": {
+      "type": "Data",
+      "attributes": {
+        "globalId": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "String"
+        },
+        "description": {
+          "ref": "String"
+        },
+        "objectType": {
+          "ref": "String"
+        },
+        "tag": {
+          "ref": "String"
+        },
+        "elementType": {
+          "ref": "Code"
+        },
+        "predefinedType": {
+          "ref": "Code"
+        },
+        "shapeType": {
+          "ref": "Code"
+        },
+        "numberOfRiser": {
+          "ref": "Integer"
+        },
+        "numberOfTreads": {
+          "ref": "Integer"
+        },
+        "riserHeight": {
+          "ref": "Measure"
+        },
+        "treadLength": {
+          "ref": "Measure"
+        },
+        "operationType": {
+          "ref": "String"
+        },
+        "capacityByWeight": {
+          "ref": "Measure"
+        },
+        "capacityByNumber": {
+          "ref": "Integer"
+        },
+        "nominalLength": {
+          "ref": "Measure"
+        },
+        "nominalWidth": {
+          "ref": "Measure"
+        },
+        "nominalHeight": {
+          "ref": "Measure"
+        },
+        "grossFootPrintArea": {
+          "ref": "Measure"
+        },
+        "netFootPrintArea": {
+          "ref": "Measure"
+        },
+        "grossSideArea": {
+          "ref": "Measure"
+        },
+        "netSideArea": {
+          "ref": "Measure"
+        },
+        "grossSideAreaLeft": {
+          "ref": "Measure"
+        },
+        "netSideAreaLeft": {
+          "ref": "Measure"
+        },
+        "grossSideAreaRight": {
+          "ref": "Measure"
+        },
+        "netSideAreaRight": {
+          "ref": "Measure"
+        },
+        "grossVolume": {
+          "ref": "Measure"
+        },
+        "netVolume": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:IfcWallStandardCase": {
+      "type": "Data",
+      "attributes": {
+        "globalId": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "String"
+        },
+        "description": {
+          "ref": "String"
+        },
+        "objectType": {
+          "ref": "String"
+        },
+        "tag": {
+          "ref": "String"
+        },
+        "elementType": {
+          "ref": "Code"
+        },
+        "predefinedType": {
+          "ref": "Code"
+        },
+        "shapeType": {
+          "ref": "Code"
+        },
+        "numberOfRiser": {
+          "ref": "Integer"
+        },
+        "numberOfTreads": {
+          "ref": "Integer"
+        },
+        "riserHeight": {
+          "ref": "Measure"
+        },
+        "treadLength": {
+          "ref": "Measure"
+        },
+        "operationType": {
+          "ref": "String"
+        },
+        "capacityByWeight": {
+          "ref": "Measure"
+        },
+        "capacityByNumber": {
+          "ref": "Integer"
+        },
+        "nominalLength": {
+          "ref": "Measure"
+        },
+        "nominalWidth": {
+          "ref": "Measure"
+        },
+        "nominalHeight": {
+          "ref": "Measure"
+        },
+        "grossFootPrintArea": {
+          "ref": "Measure"
+        },
+        "netFootPrintArea": {
+          "ref": "Measure"
+        },
+        "grossSideArea": {
+          "ref": "Measure"
+        },
+        "netSideArea": {
+          "ref": "Measure"
+        },
+        "grossSideAreaLeft": {
+          "ref": "Measure"
+        },
+        "netSideAreaLeft": {
+          "ref": "Measure"
+        },
+        "grossSideAreaRight": {
+          "ref": "Measure"
+        },
+        "netSideAreaRight": {
+          "ref": "Measure"
+        },
+        "grossVolume": {
+          "ref": "Measure"
+        },
+        "netVolume": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:IfcWindow": {
+      "type": "Data",
+      "attributes": {
+        "globalId": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "String"
+        },
+        "description": {
+          "ref": "String"
+        },
+        "objectType": {
+          "ref": "String"
+        },
+        "tag": {
+          "ref": "String"
+        },
+        "elementType": {
+          "ref": "Code"
+        },
+        "predefinedType": {
+          "ref": "Code"
+        },
+        "shapeType": {
+          "ref": "Code"
+        },
+        "numberOfRiser": {
+          "ref": "Integer"
+        },
+        "numberOfTreads": {
+          "ref": "Integer"
+        },
+        "riserHeight": {
+          "ref": "Measure"
+        },
+        "treadLength": {
+          "ref": "Measure"
+        },
+        "operationType": {
+          "ref": "String"
+        },
+        "capacityByWeight": {
+          "ref": "Measure"
+        },
+        "capacityByNumber": {
+          "ref": "Integer"
+        },
+        "overallHeight": {
+          "ref": "Measure"
+        },
+        "overallWidth": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:IfcZone": {
+      "type": "Data",
+      "attributes": {
+        "globalId": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "String"
+        },
+        "description": {
+          "ref": "String"
+        },
+        "objectType": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:IfcAttributeProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "uro:IfcBuilding"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcBuildingElement"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcBuildingStorey"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcClassificationReference"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcCoordinateReferenceSystem"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcCurtainWall"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcDoor"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcFurnishingElement"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcGroup"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcMapConversion"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcOpeningElement"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcProject"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcProjectedCRS"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcPsetBuildingCommon"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcPsetDoorCommon"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcPsetOpeningElementCommon"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcPsetSiteCommon"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcPsetSpaceCommon"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcPsetWindowCommon"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcRoof"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcSite"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcSpace"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcSpaceBaseQuantity"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcWall"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcWallStandardCase"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcWindow"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IfcZone"
+          }
+        }
+      ]
+    },
+    "uro:IndoorFacilityAttribute": {
+      "type": "Data",
+      "attributes": {
+        "source": {
+          "ref": "Code"
+        },
+        "weekdayHours": {
+          "ref": "String"
+        },
+        "weekendHours": {
+          "ref": "String"
+        },
+        "phone": {
+          "ref": "String"
+        },
+        "website": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:IndoorFurnishingAttribute": {
+      "type": "Data",
+      "attributes": {
+        "source": {
+          "ref": "Code"
+        },
+        "floorId": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:IndoorPublicTagAttribute": {
+      "type": "Data",
+      "attributes": {
+        "source": {
+          "ref": "Code"
+        },
+        "ucode": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:IndoorSpaceAttribute": {
+      "type": "Data",
+      "attributes": {
+        "source": {
+          "ref": "Code"
+        },
+        "floorId": {
+          "ref": "String"
+        },
+        "isRestricted": {
+          "ref": "Boolean"
+        },
+        "suite": {
+          "ref": "String"
+        },
+        "isPublic": {
+          "ref": "Boolean"
+        },
+        "tollType": {
+          "ref": "Code"
+        }
+      }
+    },
+    "uro:IndoorStoreyAttribute": {
+      "type": "Data",
+      "attributes": {
+        "source": {
+          "ref": "Code"
+        },
+        "category": {
+          "ref": "Boolean"
+        },
+        "ordinal": {
+          "ref": "Double"
+        }
+      }
+    },
+    "uro:IndoorTacatileTileAttribute": {
+      "type": "Data",
+      "attributes": {
+        "source": {
+          "ref": "Code"
+        },
+        "startNode": {
+          "ref": "String"
+        },
+        "endNode": {
+          "ref": "String"
+        },
+        "category": {
+          "ref": "Code"
+        },
+        "roof": {
+          "ref": "String"
+        },
+        "floorId": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:IndoorUserDefinedAttribute": {
+      "type": "Data",
+      "attributes": {
+        "source": {
+          "ref": "Code"
+        },
+        "name": {
+          "ref": "String"
+        },
+        "nominalValue": {
+          "ref": {
+            "Named": "uro:UserDefinedValue"
+          }
+        },
+        "description": {
+          "ref": "String"
+        },
+        "unit": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:UserDefinedValue": {
+      "type": "Data",
+      "attributes": {
+        "stringValue": {
+          "ref": "String"
+        },
+        "intValue": {
+          "ref": "Integer"
+        },
+        "doubleValue": {
+          "ref": "Double"
+        },
+        "codeValue": {
+          "ref": "Code"
+        },
+        "dateValue": {
+          "ref": "Date"
+        },
+        "uriValue": {
+          "ref": "URI"
+        },
+        "measuredValue": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:IndoorZoneAttribute": {
+      "type": "Data",
+      "attributes": {
+        "source": {
+          "ref": "Code"
+        },
+        "floorId": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:IndoorAttributeProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "uro:IndoorFacilityAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IndoorFurnishingAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IndoorPublicTagAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IndoorSpaceAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IndoorStoreyAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IndoorTacatileTileAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IndoorUserDefinedAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:IndoorZoneAttribute"
+          }
+        }
+      ]
+    },
+    "bldg:Window": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "ifcOpeningAttribute": {
+          "ref": {
+            "Named": "uro:IfcAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "indoorOpeningAttribute": {
+          "ref": {
+            "Named": "uro:IndoorAttributeProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "bldg:_OpeningProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "bldg:Door"
+          }
+        },
+        {
+          "ref": {
+            "Named": "bldg:Window"
+          }
+        }
+      ]
+    },
+    "bldg:ClosureSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "bldg:_OpeningProperty"
+          },
+          "max_occurs": null
+        },
+        "ifcBoundarySurfaceAttribute": {
+          "ref": {
+            "Named": "uro:IfcAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "indoorBoundarySurfaceAttribute": {
+          "ref": {
+            "Named": "uro:IndoorAttributeProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "bldg:FloorSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "bldg:_OpeningProperty"
+          },
+          "max_occurs": null
+        },
+        "ifcBoundarySurfaceAttribute": {
+          "ref": {
+            "Named": "uro:IfcAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "indoorBoundarySurfaceAttribute": {
+          "ref": {
+            "Named": "uro:IndoorAttributeProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "bldg:GroundSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "bldg:_OpeningProperty"
+          },
+          "max_occurs": null
+        },
+        "ifcBoundarySurfaceAttribute": {
+          "ref": {
+            "Named": "uro:IfcAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "indoorBoundarySurfaceAttribute": {
+          "ref": {
+            "Named": "uro:IndoorAttributeProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "bldg:InteriorWallSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "bldg:_OpeningProperty"
+          },
+          "max_occurs": null
+        },
+        "ifcBoundarySurfaceAttribute": {
+          "ref": {
+            "Named": "uro:IfcAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "indoorBoundarySurfaceAttribute": {
+          "ref": {
+            "Named": "uro:IndoorAttributeProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "bldg:OuterCeilingSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "bldg:_OpeningProperty"
+          },
+          "max_occurs": null
+        },
+        "ifcBoundarySurfaceAttribute": {
+          "ref": {
+            "Named": "uro:IfcAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "indoorBoundarySurfaceAttribute": {
+          "ref": {
+            "Named": "uro:IndoorAttributeProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "bldg:OuterFloorSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "bldg:_OpeningProperty"
+          },
+          "max_occurs": null
+        },
+        "ifcBoundarySurfaceAttribute": {
+          "ref": {
+            "Named": "uro:IfcAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "indoorBoundarySurfaceAttribute": {
+          "ref": {
+            "Named": "uro:IndoorAttributeProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "bldg:RoofSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "bldg:_OpeningProperty"
+          },
+          "max_occurs": null
+        },
+        "ifcBoundarySurfaceAttribute": {
+          "ref": {
+            "Named": "uro:IfcAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "indoorBoundarySurfaceAttribute": {
+          "ref": {
+            "Named": "uro:IndoorAttributeProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "bldg:WallSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "bldg:_OpeningProperty"
+          },
+          "max_occurs": null
+        },
+        "ifcBoundarySurfaceAttribute": {
+          "ref": {
+            "Named": "uro:IfcAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "indoorBoundarySurfaceAttribute": {
+          "ref": {
+            "Named": "uro:IndoorAttributeProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "bldg:_BoundarySurfaceProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "bldg:CeilingSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "bldg:ClosureSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "bldg:FloorSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "bldg:GroundSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "bldg:InteriorWallSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "bldg:OuterCeilingSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "bldg:OuterFloorSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "bldg:RoofSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "bldg:WallSurface"
+          }
+        }
+      ]
+    },
+    "bldg:Room": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "boundedBy": {
+          "ref": {
+            "Named": "bldg:_BoundarySurfaceProperty"
+          },
+          "max_occurs": null
+        },
+        "interiorFurniture": {
+          "ref": {
+            "Named": "bldg:BuildingFurniture"
+          },
+          "max_occurs": null
+        },
+        "roomInstallation": {
+          "ref": {
+            "Named": "bldg:BuildingInstallation"
+          },
+          "max_occurs": null
+        },
+        "ifcRoomAttribute": {
+          "ref": {
+            "Named": "uro:IfcAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "indoorRoomAttribute": {
+          "ref": {
+            "Named": "uro:IndoorAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "roomDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:RoomDataQualityAttribute"
+          }
+        }
+      }
+    },
+    "bldg:BuildingFurniture": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "ifcBuildingFurnitureAttribute": {
+          "ref": {
+            "Named": "uro:IfcAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "indoorFutnitureAttribute": {
+          "ref": {
+            "Named": "uro:IndoorAttributeProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:RoomDataQualityAttribute": {
+      "type": "Data",
+      "attributes": {
+        "srcScale": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "geometrySrcDesc": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "thematicSrcDesc": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "appearanceSrcDesc": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "lodType": {
+          "ref": "Code"
+        }
+      }
+    },
+    "bldg:BuildingPart": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "yearOfConstruction": {
+          "ref": "String"
+        },
+        "yearOfDemolition": {
+          "ref": "String"
+        },
+        "roofType": {
+          "ref": "Code"
+        },
+        "measuredHeight": {
+          "ref": "Measure"
+        },
+        "storeysAboveGround": {
+          "ref": "NonNegativeInteger"
+        },
+        "storeysBelowGround": {
+          "ref": "NonNegativeInteger"
+        },
+        "storeyHeightsAboveGround": {
+          "ref": "String"
+        },
+        "storeyHeightsBelowGround": {
+          "ref": "String"
+        },
+        "outerBuildingInstallation": {
+          "ref": {
+            "Named": "bldg:BuildingInstallation"
+          },
+          "max_occurs": null
+        },
+        "interiorBuildingInstallation": {
+          "ref": {
+            "Named": "bldg:BuildingInstallation"
+          },
+          "max_occurs": null
+        },
+        "boundedBy": {
+          "ref": {
+            "Named": "bldg:_BoundarySurfaceProperty"
+          },
+          "max_occurs": null
+        },
+        "interiorRoom": {
+          "ref": {
+            "Named": "bldg:Room"
+          },
+          "max_occurs": null
+        },
+        "consistsOfBuildingPart": {
+          "ref": {
+            "Named": "bldg:BuildingPart"
+          },
+          "max_occurs": null
+        },
+        "address": {
+          "ref": {
+            "Named": "core:Address"
+          },
+          "max_occurs": null
+        },
+        "bldgDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "bldgFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "bldgFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "bldgFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "bldgRealEstateIDAttribute": {
+          "ref": {
+            "Named": "uro:RealEstateIDAttribute"
+          }
+        },
+        "buildingDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:BuildingDataQualityAttribute"
+          }
+        },
+        "buildingDetailAttribute": {
+          "ref": {
+            "Named": "uro:BuildingDetailAttribute"
+          },
+          "max_occurs": null
+        },
+        "buildingDisasterRiskAttribute": {
+          "ref": {
+            "Named": "uro:BuildingDisasterRiskAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "buildingIDAttribute": {
+          "ref": {
+            "Named": "uro:BuildingIDAttribute"
+          },
+          "max_occurs": null
+        },
+        "ifcBuildingAttribute": {
+          "ref": {
+            "Named": "uro:IfcAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "indoorBuildingAttribute": {
+          "ref": {
+            "Named": "uro:IndoorAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "keyValuePairAttribute": {
+          "ref": {
+            "Named": "uro:KeyValuePairAttribute"
+          },
+          "max_occurs": null
+        },
+        "largeCustomerFacilityAttribute": {
+          "ref": {
+            "Named": "uro:LargeCustomerFacilityAttribute"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:DmAnnotation": {
+      "type": "Data",
+      "attributes": {
+        "dmCode": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "meshCode": {
+          "ref": "Code"
+        },
+        "dmElement": {
+          "ref": {
+            "Named": "uro:DmElement"
+          }
+        },
+        "geometryType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "shapeType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "label": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "isVertical": {
+          "ref": "Boolean",
+          "min_occurs": 1
+        },
+        "size": {
+          "ref": "Integer",
+          "min_occurs": 1
+        },
+        "orientation": {
+          "ref": "Integer",
+          "min_occurs": 1
+        },
+        "linewidth": {
+          "ref": "Integer",
+          "min_occurs": 1
+        },
+        "spacing": {
+          "ref": "Integer",
+          "min_occurs": 1
+        }
+      }
+    },
+    "uro:DmElement": {
+      "type": "Data",
+      "attributes": {
+        "locationType": {
+          "ref": "Code"
+        },
+        "infoType": {
+          "ref": "Code"
+        },
+        "elementKey": {
+          "ref": "String"
+        },
+        "hierarchyLevel": {
+          "ref": "String"
+        },
+        "dataType": {
+          "ref": "Code"
+        },
+        "annotationType": {
+          "ref": "Code"
+        },
+        "precisionType": {
+          "ref": "Code"
+        },
+        "dislocationType": {
+          "ref": "Code"
+        },
+        "breakType": {
+          "ref": "Code"
+        },
+        "attributeValue": {
+          "ref": "String"
+        },
+        "attributeType": {
+          "ref": "Code"
+        },
+        "attributeValueType": {
+          "ref": "String"
+        },
+        "creationDate": {
+          "ref": "String"
+        },
+        "updateDate": {
+          "ref": "String"
+        },
+        "terminationDate": {
+          "ref": "String"
+        },
+        "freeSpace": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:DmGeometricAttribute": {
+      "type": "Data",
+      "attributes": {
+        "dmCode": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "meshCode": {
+          "ref": "Code"
+        },
+        "dmElement": {
+          "ref": {
+            "Named": "uro:DmElement"
+          }
+        },
+        "geometryType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "mapLevel": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "shapeType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "visibility": {
+          "ref": "Boolean"
+        },
+        "is3d": {
+          "ref": "Boolean"
+        },
+        "isInstallation": {
+          "ref": "Boolean"
+        },
+        "isEdited": {
+          "ref": "Boolean"
+        },
+        "isSupplementarySymbol": {
+          "ref": "Boolean"
+        },
+        "angle": {
+          "ref": "Double"
+        },
+        "elevation": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:DmAttributeProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "uro:DmAnnotation"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:DmGeometricAttribute"
+          }
+        }
+      ]
+    },
+    "uro:CargoHandlingFacility": {
+      "type": "Data",
+      "attributes": {
+        "facilityId": {
+          "ref": "String"
+        },
+        "portFacilityDetailsType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "portName": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "portStatus": {
+          "ref": "Code"
+        },
+        "district": {
+          "ref": "String"
+        },
+        "grantType": {
+          "ref": "Code"
+        },
+        "isDesignated": {
+          "ref": "Boolean"
+        },
+        "degradationLevel": {
+          "ref": "Integer"
+        },
+        "mainCargo": {
+          "ref": "Code"
+        },
+        "mooringFacility": {
+          "ref": "String"
+        },
+        "liftableLoad": {
+          "ref": "Measure"
+        },
+        "ability": {
+          "ref": "Integer"
+        },
+        "packingName": {
+          "ref": "Code"
+        },
+        "acquisitionYear": {
+          "ref": "String"
+        },
+        "innerTotalFloorArea": {
+          "ref": "Measure"
+        },
+        "innerOfSiteArea": {
+          "ref": "Measure"
+        },
+        "outerOfTotalFloorArea": {
+          "ref": "Measure"
+        },
+        "outerSiteArea": {
+          "ref": "Measure"
+        },
+        "mainMaterial": {
+          "ref": "Code"
+        },
+        "totalCost": {
+          "ref": "Integer"
+        },
+        "note": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:CyberportMarinaAndPBS": {
+      "type": "Data",
+      "attributes": {
+        "facilityId": {
+          "ref": "String"
+        },
+        "portFacilityDetailsType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "portName": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "portStatus": {
+          "ref": "Code"
+        },
+        "district": {
+          "ref": "String"
+        },
+        "grantType": {
+          "ref": "Code"
+        },
+        "isDesignated": {
+          "ref": "Boolean"
+        },
+        "degradationLevel": {
+          "ref": "Integer"
+        },
+        "geologicalType": {
+          "ref": "Code"
+        },
+        "obstructingStructures": {
+          "ref": "String"
+        },
+        "mainPartLength": {
+          "ref": "Measure"
+        },
+        "totalLength": {
+          "ref": "Measure"
+        },
+        "waveDissipatorLength": {
+          "ref": "Measure"
+        },
+        "facilityWidth": {
+          "ref": "Measure"
+        },
+        "apronWidth": {
+          "ref": "Measure"
+        },
+        "restrictionStructure": {
+          "ref": "String"
+        },
+        "plannedDepth": {
+          "ref": "Measure"
+        },
+        "currentDepth": {
+          "ref": "Measure"
+        },
+        "innerTotalFloorArea": {
+          "ref": "Measure"
+        },
+        "innerOfSiteArea": {
+          "ref": "Measure"
+        },
+        "outerOfTotalFloorArea": {
+          "ref": "Measure"
+        },
+        "outerSiteArea": {
+          "ref": "Measure"
+        },
+        "ceilingHeight": {
+          "ref": "Measure"
+        },
+        "gravityResistant": {
+          "ref": "Measure"
+        },
+        "form": {
+          "ref": "Code"
+        },
+        "areaType": {
+          "ref": "Code"
+        },
+        "mainVessels": {
+          "ref": "Code"
+        },
+        "isDredged": {
+          "ref": "Boolean"
+        },
+        "mooringPostWeight": {
+          "ref": "Measure"
+        },
+        "numberOfMooringPosts": {
+          "ref": "Integer"
+        },
+        "resistantMaterial": {
+          "ref": "Integer"
+        },
+        "lighting": {
+          "ref": "Integer"
+        },
+        "stairs": {
+          "ref": "Integer"
+        },
+        "lifesaving": {
+          "ref": "String"
+        },
+        "lifesavingNumber": {
+          "ref": "Integer"
+        },
+        "bumper": {
+          "ref": "Measure"
+        },
+        "numberOfVehicleBoardings": {
+          "ref": "Integer"
+        },
+        "vehicleBoardingWidth": {
+          "ref": "Measure"
+        },
+        "shipType": {
+          "ref": "String"
+        },
+        "numberOfSeats": {
+          "ref": "Integer"
+        },
+        "mainCargo": {
+          "ref": "Code"
+        },
+        "storageCapacity": {
+          "ref": "Integer"
+        },
+        "storageCapacityUnit": {
+          "ref": "Code"
+        },
+        "structureType": {
+          "ref": "Code"
+        },
+        "mainMaterial": {
+          "ref": "Code"
+        },
+        "totalCost": {
+          "ref": "Integer"
+        },
+        "subsidy": {
+          "ref": "Integer"
+        },
+        "note": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:FishingPortCapacity": {
+      "type": "Data",
+      "attributes": {
+        "facilityId": {
+          "ref": "String"
+        },
+        "capacity": {
+          "ref": "String"
+        },
+        "weightCapacity": {
+          "ref": "Measure"
+        },
+        "hullForm": {
+          "ref": "Integer"
+        },
+        "shipNumber": {
+          "ref": "Integer"
+        },
+        "waterDepth-2m": {
+          "ref": "Measure"
+        },
+        "waterDepth2-3m": {
+          "ref": "Measure"
+        },
+        "waterDepth3-6m": {
+          "ref": "Measure"
+        },
+        "waterDepth6-m": {
+          "ref": "Measure"
+        },
+        "heightAboveAWL": {
+          "ref": "Measure"
+        },
+        "heightOnFoundations": {
+          "ref": "Measure"
+        },
+        "luminousRange": {
+          "ref": "Measure"
+        },
+        "luminousColor": {
+          "ref": "String"
+        },
+        "candlePower": {
+          "ref": "Integer"
+        },
+        "lightType": {
+          "ref": "String"
+        },
+        "period": {
+          "ref": "String"
+        },
+        "maximumGroundingWeight": {
+          "ref": "Integer"
+        },
+        "handleablePower": {
+          "ref": "Integer"
+        },
+        "maximumWaterSupply": {
+          "ref": "Integer"
+        },
+        "maximumRefueling": {
+          "ref": "String"
+        },
+        "people": {
+          "ref": "Integer"
+        },
+        "other": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:FishingPortFacility": {
+      "type": "Data",
+      "attributes": {
+        "facilityId": {
+          "ref": "String"
+        },
+        "facilityDetailsType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "portName": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "portType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "address": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "designatedArea": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "designation": {
+          "ref": "String",
+          "max_occurs": null
+        },
+        "designatedAdministrator": {
+          "ref": "String",
+          "max_occurs": null
+        },
+        "referenceNumber": {
+          "ref": "String",
+          "max_occurs": null
+        },
+        "grantType": {
+          "ref": "Code"
+        },
+        "administrator": {
+          "ref": "String"
+        },
+        "facilityManager": {
+          "ref": "String"
+        },
+        "structureType": {
+          "ref": "Code"
+        },
+        "mainMaterial": {
+          "ref": "Code"
+        },
+        "otherStructure": {
+          "ref": "String"
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "width": {
+          "ref": "Measure"
+        },
+        "ceilingHeight": {
+          "ref": "Measure"
+        },
+        "depth": {
+          "ref": "Measure"
+        },
+        "area": {
+          "ref": "Measure"
+        },
+        "otherSizeDescription": {
+          "ref": "String"
+        },
+        "dateOfConstructionOrAcquisition": {
+          "ref": "Date"
+        },
+        "cost": {
+          "ref": "Integer"
+        },
+        "note": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:HarborFacility": {
+      "type": "Data",
+      "attributes": {
+        "facilityId": {
+          "ref": "String"
+        },
+        "portFacilityDetailsType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "portName": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "portStatus": {
+          "ref": "Code"
+        },
+        "district": {
+          "ref": "String"
+        },
+        "grantType": {
+          "ref": "Code"
+        },
+        "isDesignated": {
+          "ref": "Boolean"
+        },
+        "degradationLevel": {
+          "ref": "Integer"
+        },
+        "geologicalType": {
+          "ref": "Code"
+        },
+        "obstructingStructures": {
+          "ref": "String"
+        },
+        "structuralLimitations": {
+          "ref": "Measure"
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "minimumWidth": {
+          "ref": "Measure"
+        },
+        "maximumWidth": {
+          "ref": "Measure"
+        },
+        "plannedDepth": {
+          "ref": "Measure"
+        },
+        "currentDepth": {
+          "ref": "Measure"
+        },
+        "isDredged": {
+          "ref": "Boolean"
+        },
+        "areaType": {
+          "ref": "Code"
+        },
+        "innerArea": {
+          "ref": "Measure"
+        },
+        "outerArea": {
+          "ref": "Measure"
+        },
+        "totalCost": {
+          "ref": "Integer"
+        },
+        "subsidy": {
+          "ref": "Integer"
+        },
+        "note": {
+          "ref": "String",
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:MaintenanceHistoryAttribute": {
+      "type": "Data",
+      "attributes": {
+        "facilityId": {
+          "ref": "String"
+        },
+        "maintenanceType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "maintenanceFiscalYear": {
+          "ref": "String"
+        },
+        "maintenanceYear": {
+          "ref": "String"
+        },
+        "maintenanceDate": {
+          "ref": "Date"
+        },
+        "status": {
+          "ref": "String"
+        },
+        "description": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:MooringFacility": {
+      "type": "Data",
+      "attributes": {
+        "facilityId": {
+          "ref": "String"
+        },
+        "portFacilityDetailsType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "portName": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "portStatus": {
+          "ref": "Code"
+        },
+        "district": {
+          "ref": "String"
+        },
+        "grantType": {
+          "ref": "Code"
+        },
+        "isDesignated": {
+          "ref": "Boolean"
+        },
+        "degradationLevel": {
+          "ref": "Integer"
+        },
+        "mainPartLength": {
+          "ref": "Measure"
+        },
+        "totalLength": {
+          "ref": "Measure"
+        },
+        "facilityWidth": {
+          "ref": "Measure"
+        },
+        "apronWidth": {
+          "ref": "Measure"
+        },
+        "plannedDepth": {
+          "ref": "Measure"
+        },
+        "currentDepth": {
+          "ref": "Measure"
+        },
+        "area": {
+          "ref": "Measure"
+        },
+        "ceilingHeight": {
+          "ref": "Measure"
+        },
+        "gravityResistant": {
+          "ref": "Measure"
+        },
+        "form": {
+          "ref": "Code"
+        },
+        "mainVessels": {
+          "ref": "Code"
+        },
+        "mooringPostWeight": {
+          "ref": "Measure"
+        },
+        "numberOfMooringPosts": {
+          "ref": "Integer"
+        },
+        "resistantMaterial": {
+          "ref": "Integer"
+        },
+        "lighting": {
+          "ref": "Integer"
+        },
+        "stairs": {
+          "ref": "Integer"
+        },
+        "lifesavingAppliances": {
+          "ref": "String"
+        },
+        "numberOfLifesavingAppliances": {
+          "ref": "Integer"
+        },
+        "bumper": {
+          "ref": "Measure"
+        },
+        "numberOfVehicleBoardings": {
+          "ref": "Integer"
+        },
+        "vehicleBoardingWidth": {
+          "ref": "Measure"
+        },
+        "shipType": {
+          "ref": "String"
+        },
+        "numberOfSeats": {
+          "ref": "Integer"
+        },
+        "mainCargo": {
+          "ref": "Code"
+        },
+        "structureType": {
+          "ref": "Code"
+        },
+        "mainMaterial": {
+          "ref": "Code"
+        },
+        "totalCost": {
+          "ref": "Integer"
+        },
+        "subsidy": {
+          "ref": "Integer"
+        },
+        "note": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:NavigationAssistanceFacility": {
+      "type": "Data",
+      "attributes": {
+        "facilityId": {
+          "ref": "String"
+        },
+        "portFacilityDetailsType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "portName": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "portStatus": {
+          "ref": "Code"
+        },
+        "district": {
+          "ref": "String"
+        },
+        "grantType": {
+          "ref": "Code"
+        },
+        "isDesignated": {
+          "ref": "Boolean"
+        },
+        "degradationLevel": {
+          "ref": "Integer"
+        },
+        "totalCost": {
+          "ref": "Integer"
+        },
+        "subsidy": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:PortEnvironmentalImprovementFacility": {
+      "type": "Data",
+      "attributes": {
+        "facilityId": {
+          "ref": "String"
+        },
+        "portFacilityDetailsType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "portName": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "portStatus": {
+          "ref": "Code"
+        },
+        "district": {
+          "ref": "String"
+        },
+        "grantType": {
+          "ref": "Code"
+        },
+        "isDesignated": {
+          "ref": "Boolean"
+        },
+        "degradationLevel": {
+          "ref": "Integer"
+        },
+        "usage": {
+          "ref": "String"
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "area": {
+          "ref": "Measure"
+        },
+        "totalFoorArea": {
+          "ref": "Measure"
+        },
+        "totalCost": {
+          "ref": "Integer"
+        },
+        "subsidy": {
+          "ref": "Integer"
+        },
+        "note": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:PortManagementFacility": {
+      "type": "Data",
+      "attributes": {
+        "facilityId": {
+          "ref": "String"
+        },
+        "portFacilityDetailsType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "portName": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "portStatus": {
+          "ref": "Code"
+        },
+        "district": {
+          "ref": "String"
+        },
+        "grantType": {
+          "ref": "Code"
+        },
+        "isDesignated": {
+          "ref": "Boolean"
+        },
+        "degradationLevel": {
+          "ref": "Integer"
+        },
+        "totalFloorArea": {
+          "ref": "Measure"
+        },
+        "numberOfShipTypes": {
+          "ref": "Integer"
+        },
+        "unitOfShipType": {
+          "ref": "Code"
+        },
+        "loadingCapacity": {
+          "ref": "Integer"
+        },
+        "acquisitionYear": {
+          "ref": "String"
+        },
+        "usage": {
+          "ref": "String"
+        },
+        "totalCost": {
+          "ref": "Integer"
+        },
+        "subsidy": {
+          "ref": "Integer"
+        },
+        "note": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:PortPassengerFacility": {
+      "type": "Data",
+      "attributes": {
+        "facilityId": {
+          "ref": "String"
+        },
+        "portFacilityDetailsType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "portName": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "portStatus": {
+          "ref": "Code"
+        },
+        "district": {
+          "ref": "String"
+        },
+        "grantType": {
+          "ref": "Code"
+        },
+        "isDesignated": {
+          "ref": "Boolean"
+        },
+        "degradationLevel": {
+          "ref": "Integer"
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "width": {
+          "ref": "Measure"
+        },
+        "mainMaterial": {
+          "ref": "Code"
+        },
+        "totalFloorArea": {
+          "ref": "Measure"
+        },
+        "acquisitionYear": {
+          "ref": "String"
+        },
+        "totalCost": {
+          "ref": "Integer"
+        },
+        "note": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:PortPollutionControlFacility": {
+      "type": "Data",
+      "attributes": {
+        "facilityId": {
+          "ref": "String"
+        },
+        "portFacilityDetailsType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "portName": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "portStatus": {
+          "ref": "Code"
+        },
+        "district": {
+          "ref": "String"
+        },
+        "grantType": {
+          "ref": "Code"
+        },
+        "isDesignated": {
+          "ref": "Boolean"
+        },
+        "degradationLevel": {
+          "ref": "Integer"
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "width": {
+          "ref": "Measure"
+        },
+        "crossSectionalArea": {
+          "ref": "Measure"
+        },
+        "area": {
+          "ref": "Measure"
+        },
+        "height": {
+          "ref": "Measure"
+        },
+        "mainMaterial": {
+          "ref": "Code"
+        },
+        "totalCost": {
+          "ref": "Integer"
+        },
+        "subsidy": {
+          "ref": "Integer"
+        },
+        "note": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:PortProtectiveFacility": {
+      "type": "Data",
+      "attributes": {
+        "facilityId": {
+          "ref": "String"
+        },
+        "portFacilityDetailsType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "portName": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "portStatus": {
+          "ref": "Code"
+        },
+        "district": {
+          "ref": "String"
+        },
+        "grantType": {
+          "ref": "Code"
+        },
+        "isDesignated": {
+          "ref": "Boolean"
+        },
+        "degradationLevel": {
+          "ref": "Integer"
+        },
+        "structureType": {
+          "ref": "Code"
+        },
+        "mainMaterial": {
+          "ref": "Code"
+        },
+        "totalCost": {
+          "ref": "Integer"
+        },
+        "subsidy": {
+          "ref": "Integer"
+        },
+        "note": {
+          "ref": "String",
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:PortStorageFacility": {
+      "type": "Data",
+      "attributes": {
+        "facilityId": {
+          "ref": "String"
+        },
+        "portFacilityDetailsType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "portName": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "portStatus": {
+          "ref": "Code"
+        },
+        "district": {
+          "ref": "String"
+        },
+        "grantType": {
+          "ref": "Code"
+        },
+        "isDesignated": {
+          "ref": "Boolean"
+        },
+        "degradationLevel": {
+          "ref": "Integer"
+        },
+        "innerTotalFloorArea": {
+          "ref": "Measure"
+        },
+        "innerOfSiteArea": {
+          "ref": "Measure"
+        },
+        "outerOfTotalFloorArea": {
+          "ref": "Measure"
+        },
+        "outerSiteArea": {
+          "ref": "Measure"
+        },
+        "mainCargo": {
+          "ref": "Code"
+        },
+        "storageCapacity": {
+          "ref": "Integer"
+        },
+        "storageCapacityUnit": {
+          "ref": "Code"
+        },
+        "mainMaterial": {
+          "ref": "Code"
+        },
+        "totalCost": {
+          "ref": "Integer"
+        },
+        "note": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:PortTransportationFacility": {
+      "type": "Data",
+      "attributes": {
+        "facilityId": {
+          "ref": "String"
+        },
+        "portFacilityDetailsType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "portName": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "portStatus": {
+          "ref": "Code"
+        },
+        "district": {
+          "ref": "String"
+        },
+        "grantType": {
+          "ref": "Code"
+        },
+        "isDesignated": {
+          "ref": "Boolean"
+        },
+        "degradationLevel": {
+          "ref": "Integer"
+        },
+        "structureType": {
+          "ref": "Code"
+        },
+        "startingPoint": {
+          "ref": "String"
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "area": {
+          "ref": "Measure"
+        },
+        "beddingWidth": {
+          "ref": "Measure"
+        },
+        "numberOfLanes": {
+          "ref": "Integer"
+        },
+        "parkingLotCapacityOfBus": {
+          "ref": "Integer"
+        },
+        "parkingLotCapacityOfCars": {
+          "ref": "Integer"
+        },
+        "routeType": {
+          "ref": "Code"
+        },
+        "heightToDigit": {
+          "ref": "Measure"
+        },
+        "heightLimit": {
+          "ref": "Measure"
+        },
+        "minimumWidth": {
+          "ref": "Measure"
+        },
+        "minimumDepth": {
+          "ref": "Measure"
+        },
+        "numberOfAircraftParkingSpaces": {
+          "ref": "Integer"
+        },
+        "pavementType": {
+          "ref": "Code"
+        },
+        "mainCargo": {
+          "ref": "Code"
+        },
+        "totalCost": {
+          "ref": "Integer"
+        },
+        "subsidy": {
+          "ref": "Integer"
+        },
+        "note": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:PortWasteTreatmentFacility": {
+      "type": "Data",
+      "attributes": {
+        "facilityId": {
+          "ref": "String"
+        },
+        "portFacilityDetailsType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "portName": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "portStatus": {
+          "ref": "Code"
+        },
+        "district": {
+          "ref": "String"
+        },
+        "grantType": {
+          "ref": "Code"
+        },
+        "isDesignated": {
+          "ref": "Boolean"
+        },
+        "degradationLevel": {
+          "ref": "Integer"
+        },
+        "structureType": {
+          "ref": "Code"
+        },
+        "perimeter": {
+          "ref": "Measure"
+        },
+        "mainPartLength": {
+          "ref": "Measure"
+        },
+        "innerShoreLength": {
+          "ref": "Measure"
+        },
+        "ceilingHeight": {
+          "ref": "Measure"
+        },
+        "waveDissipatorLength": {
+          "ref": "Measure"
+        },
+        "mainMaterial": {
+          "ref": "Code"
+        },
+        "wasteType": {
+          "ref": "Code"
+        },
+        "plannedDisposalArea": {
+          "ref": "Measure"
+        },
+        "plannedDisposalAmount": {
+          "ref": "Integer"
+        },
+        "receivingCapacity": {
+          "ref": "Integer"
+        },
+        "shipType": {
+          "ref": "String"
+        },
+        "unitOfReceivingCapacity": {
+          "ref": "Code"
+        },
+        "acquisitionYear": {
+          "ref": "String"
+        },
+        "totalCost": {
+          "ref": "Integer"
+        },
+        "subsidy": {
+          "ref": "Integer"
+        },
+        "note": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:PortWelfareFacility": {
+      "type": "Data",
+      "attributes": {
+        "facilityId": {
+          "ref": "String"
+        },
+        "portFacilityDetailsType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "portName": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "portStatus": {
+          "ref": "Code"
+        },
+        "district": {
+          "ref": "String"
+        },
+        "grantType": {
+          "ref": "Code"
+        },
+        "isDesignated": {
+          "ref": "Boolean"
+        },
+        "degradationLevel": {
+          "ref": "Integer"
+        },
+        "totalFloorArea": {
+          "ref": "Measure"
+        },
+        "totalCost": {
+          "ref": "Integer"
+        },
+        "note": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:ShipServiceFacility": {
+      "type": "Data",
+      "attributes": {
+        "facilityId": {
+          "ref": "String"
+        },
+        "portFacilityDetailsType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "portName": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "portStatus": {
+          "ref": "Code"
+        },
+        "district": {
+          "ref": "String"
+        },
+        "grantType": {
+          "ref": "Code"
+        },
+        "isDesignated": {
+          "ref": "Boolean"
+        },
+        "degradationLevel": {
+          "ref": "Integer"
+        },
+        "shipType": {
+          "ref": "String"
+        },
+        "supplyAbility": {
+          "ref": "Integer"
+        },
+        "supplyAbilityUnit": {
+          "ref": "Code"
+        },
+        "mooringPlace": {
+          "ref": "String"
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "width": {
+          "ref": "Measure"
+        },
+        "area": {
+          "ref": "Measure"
+        },
+        "acquisitionYear": {
+          "ref": "String"
+        },
+        "totalCost": {
+          "ref": "Integer"
+        },
+        "note": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:FacilityAttributeProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "uro:CargoHandlingFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:CyberportMarinaAndPBS"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:FishingPortCapacity"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:FishingPortFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:HarborFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:MaintenanceHistoryAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:MooringFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:NavigationAssistanceFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:PortEnvironmentalImprovementFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:PortManagementFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:PortPassengerFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:PortPollutionControlFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:PortProtectiveFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:PortStorageFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:PortTransportationFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:PortWasteTreatmentFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:PortWelfareFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:ShipServiceFacility"
+          }
+        }
+      ]
+    },
+    "uro:FacilityIdAttribute": {
+      "type": "Data",
+      "attributes": {
+        "id": {
+          "ref": "String"
+        },
+        "partId": {
+          "ref": "String"
+        },
+        "branchId": {
+          "ref": "String"
+        },
+        "prefecture": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "city": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "route": {
+          "ref": "String"
+        },
+        "startPost": {
+          "ref": "String"
+        },
+        "endPost": {
+          "ref": "String"
+        },
+        "startLat": {
+          "ref": "Double"
+        },
+        "startLong": {
+          "ref": "Double"
+        },
+        "alternativeName": {
+          "ref": "String",
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:RiverFacilityIdAttribute": {
+      "type": "Data",
+      "attributes": {
+        "id": {
+          "ref": "String"
+        },
+        "partId": {
+          "ref": "String"
+        },
+        "branchId": {
+          "ref": "String"
+        },
+        "prefecture": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "city": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "route": {
+          "ref": "String"
+        },
+        "startPost": {
+          "ref": "String"
+        },
+        "endPost": {
+          "ref": "String"
+        },
+        "startLat": {
+          "ref": "Double"
+        },
+        "startLong": {
+          "ref": "Double"
+        },
+        "alternativeName": {
+          "ref": "String",
+          "max_occurs": null
+        },
+        "riverCode": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "riverName": {
+          "ref": "String"
+        },
+        "sideType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "leftPost": {
+          "ref": "Measure"
+        },
+        "leftDistance": {
+          "ref": "Measure"
+        },
+        "rightPost": {
+          "ref": "Measure"
+        },
+        "rightDistance": {
+          "ref": "Measure"
+        },
+        "leftStartPost": {
+          "ref": "Measure"
+        },
+        "leftStartDistance": {
+          "ref": "Measure"
+        },
+        "leftEndPost": {
+          "ref": "Measure"
+        },
+        "lefEndDistance": {
+          "ref": "Measure"
+        },
+        "rightStartPost": {
+          "ref": "Measure"
+        },
+        "rightStartDistance": {
+          "ref": "Measure"
+        },
+        "rightEndPost": {
+          "ref": "Measure"
+        },
+        "rightEndDistance": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:FacilityIdAttributeProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "uro:FacilityIdAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:RiverFacilityIdAttribute"
+          }
+        }
+      ]
+    },
+    "uro:FacilityTypeAttribute": {
+      "type": "Data",
+      "attributes": {
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:RealEstateIDAttribute": {
+      "type": "Data",
+      "attributes": {
+        "realEstateIDOfBuilding": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "numberOfBuildingUnitOwnership": {
+          "ref": "Integer"
+        },
+        "realEstateIDOfBuildingUnitOwnership": {
+          "ref": "String",
+          "max_occurs": null
+        },
+        "numberOfRealEstateIDOfLand": {
+          "ref": "Integer"
+        },
+        "realEstateIDOfLand": {
+          "ref": "String",
+          "max_occurs": null
+        },
+        "matchingScore": {
+          "ref": "Integer",
+          "min_occurs": 1
+        }
+      }
+    },
+    "uro:BuildingDataQualityAttribute": {
+      "type": "Data",
+      "attributes": {
+        "srcScale": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "geometrySrcDesc": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "thematicSrcDesc": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "appearanceSrcDesc": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "lod1HeightType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "lodType": {
+          "ref": "Code",
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:BuildingDetailAttribute": {
+      "type": "Data",
+      "attributes": {
+        "serialNumberOfBuildingCertification": {
+          "ref": "String"
+        },
+        "siteArea": {
+          "ref": "Measure"
+        },
+        "totalFloorArea": {
+          "ref": "Measure"
+        },
+        "buildingFootprintArea": {
+          "ref": "Measure"
+        },
+        "buildingRoofEdgeArea": {
+          "ref": "Measure"
+        },
+        "developmentArea": {
+          "ref": "Measure"
+        },
+        "buildingStructureType": {
+          "ref": "Code"
+        },
+        "buildingStructureOrgType": {
+          "ref": "Code"
+        },
+        "fireproofStructureType": {
+          "ref": "Code"
+        },
+        "implementingBody": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "districtsAndZonesType": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "landUseType": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "String"
+        },
+        "majorUsage": {
+          "ref": "Code"
+        },
+        "majorUsage2": {
+          "ref": "Code"
+        },
+        "orgUsage": {
+          "ref": "Code"
+        },
+        "orgUsage2": {
+          "ref": "Code"
+        },
+        "detailedUsage": {
+          "ref": "Code"
+        },
+        "detailedUsage2": {
+          "ref": "Code"
+        },
+        "detailedUsage3": {
+          "ref": "Code"
+        },
+        "groundFloorUsage": {
+          "ref": "Code"
+        },
+        "secondFloorUsage": {
+          "ref": "Code"
+        },
+        "thirdFloorUsage": {
+          "ref": "Code"
+        },
+        "basementUsage": {
+          "ref": "Code"
+        },
+        "basementFirstUsage": {
+          "ref": "Code"
+        },
+        "basementSecondUsage": {
+          "ref": "Code"
+        },
+        "vacancy": {
+          "ref": "Code"
+        },
+        "buildingCoverageRate": {
+          "ref": "Double"
+        },
+        "floorAreaRate": {
+          "ref": "Double"
+        },
+        "specifiedBuildingCoverageRate": {
+          "ref": "Double"
+        },
+        "specifiedFloorAreaRate": {
+          "ref": "Double"
+        },
+        "standardFloorAreaRate": {
+          "ref": "Double"
+        },
+        "buildingHeight": {
+          "ref": "Measure"
+        },
+        "eaveHeight": {
+          "ref": "Measure"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String",
+          "min_occurs": 1
+        }
+      }
+    },
+    "uro:BuildingHighTideRiskAttribute": {
+      "type": "Data",
+      "attributes": {
+        "description": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "rank": {
+          "ref": "Code"
+        },
+        "rankOrg": {
+          "ref": "Code"
+        },
+        "depth": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:BuildingInlandFloodingRiskAttribute": {
+      "type": "Data",
+      "attributes": {
+        "description": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "rank": {
+          "ref": "Code"
+        },
+        "rankOrg": {
+          "ref": "Code"
+        },
+        "depth": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:BuildingLandSlideRiskAttribute": {
+      "type": "Data",
+      "attributes": {
+        "description": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "areaType": {
+          "ref": "Code",
+          "min_occurs": 1
+        }
+      }
+    },
+    "uro:BuildingRiverFloodingRiskAttribute": {
+      "type": "Data",
+      "attributes": {
+        "description": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "rank": {
+          "ref": "Code"
+        },
+        "rankOrg": {
+          "ref": "Code"
+        },
+        "depth": {
+          "ref": "Measure"
+        },
+        "adminType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "scale": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "duration": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:BuildingTsunamiRiskAttribute": {
+      "type": "Data",
+      "attributes": {
+        "description": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "rank": {
+          "ref": "Code"
+        },
+        "rankOrg": {
+          "ref": "Code"
+        },
+        "depth": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:BuildingDisasterRiskAttributeProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "uro:BuildingHighTideRiskAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:BuildingInlandFloodingRiskAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:BuildingLandSlideRiskAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:BuildingRiverFloodingRiskAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:BuildingTsunamiRiskAttribute"
+          }
+        }
+      ]
+    },
+    "uro:BuildingIDAttribute": {
+      "type": "Data",
+      "attributes": {
+        "buildingID": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "branchID": {
+          "ref": "Integer"
+        },
+        "partID": {
+          "ref": "Integer"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code",
+          "min_occurs": 1
+        }
+      }
+    },
+    "uro:KeyValuePairAttribute": {
+      "type": "Data",
+      "attributes": {
+        "key": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "codeValue": {
+          "ref": "Code"
+        }
+      }
+    },
+    "uro:LargeCustomerFacilityAttribute": {
+      "type": "Data",
+      "attributes": {
+        "class": {
+          "ref": "Code"
+        },
+        "name": {
+          "ref": "String"
+        },
+        "capacity": {
+          "ref": "Integer"
+        },
+        "owner": {
+          "ref": "String"
+        },
+        "totalFloorArea": {
+          "ref": "Measure"
+        },
+        "totalStoreFloorArea": {
+          "ref": "Measure"
+        },
+        "inauguralDate": {
+          "ref": "Date"
+        },
+        "yearOpened": {
+          "ref": "String"
+        },
+        "yearClosed": {
+          "ref": "String"
+        },
+        "keyTenants": {
+          "ref": "String"
+        },
+        "availability": {
+          "ref": "Boolean"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "districtsAndZonesType": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "landUseType": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String",
+          "min_occurs": 1
+        }
+      }
+    },
+    "tran:Road": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "tranDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "trafficArea": {
+          "ref": {
+            "Named": "tran:TrafficArea"
+          },
+          "max_occurs": null
+        },
+        "auxiliaryTrafficArea": {
+          "ref": {
+            "Named": "tran:AuxiliaryTrafficArea"
+          },
+          "max_occurs": null
+        },
+        "tranDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:TransportationDataQualityAttribute"
+          }
+        },
+        "tranFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "tranFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "tranFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "roadStatus": {
+          "ref": {
+            "Named": "uro:RoadType"
+          },
+          "max_occurs": null
+        },
+        "roadStructureAttribute": {
+          "ref": {
+            "Named": "uro:RoadStructureAttribute"
+          },
+          "max_occurs": null
+        },
+        "trafficVolumeAttribute": {
+          "ref": {
+            "Named": "uro:TrafficVolumeAttribute"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "tran:TrafficArea": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "tranDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "surfaceMaterial": {
+          "ref": "Code"
+        },
+        "railwayTrackAttribute": {
+          "ref": {
+            "Named": "uro:RailwayTrackAttribute"
+          },
+          "max_occurs": null
+        },
+        "trafficAreaStructureAttribute": {
+          "ref": {
+            "Named": "uro:TrafficAreaStructureAttribute"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:RailwayTrackAttribute": {
+      "type": "Data",
+      "attributes": {
+        "routeName": {
+          "ref": "String"
+        },
+        "directionType": {
+          "ref": "Code"
+        },
+        "trackType": {
+          "ref": "Code"
+        },
+        "startPost": {
+          "ref": "String"
+        },
+        "endPost": {
+          "ref": "String"
+        },
+        "alignmentType": {
+          "ref": "Code"
+        },
+        "controlPoint": {
+          "ref": {
+            "Named": "uro:ControlPoint"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:ControlPoint": {
+      "type": "Data",
+      "attributes": {
+        "startPost": {
+          "ref": "String"
+        },
+        "endPost": {
+          "ref": "String"
+        },
+        "function": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "parameter": {
+          "ref": {
+            "Named": "uro:ControlPointType"
+          },
+          "min_occurs": 1
+        },
+        "startPoint": {
+          "ref": "Point"
+        },
+        "endPoint": {
+          "ref": "Point"
+        }
+      }
+    },
+    "uro:CircularCurveType": {
+      "type": "Data",
+      "attributes": {
+        "radius": {
+          "ref": "Measure",
+          "min_occurs": 1
+        },
+        "intersection": {
+          "ref": "Double",
+          "min_occurs": 1
+        },
+        "cutLength": {
+          "ref": "Measure",
+          "min_occurs": 1
+        },
+        "curveLength": {
+          "ref": "Measure",
+          "min_occurs": 1
+        }
+      }
+    },
+    "uro:TransitionCurveType": {
+      "type": "Data",
+      "attributes": {
+        "intersection": {
+          "ref": "Measure",
+          "min_occurs": 1
+        },
+        "distance": {
+          "ref": "Measure",
+          "min_occurs": 1
+        },
+        "curveLength": {
+          "ref": "Measure",
+          "min_occurs": 1
+        }
+      }
+    },
+    "uro:SlopeType": {
+      "type": "Data",
+      "attributes": {
+        "angle": {
+          "ref": "Double",
+          "min_occurs": 1
+        },
+        "elevation": {
+          "ref": "Measure",
+          "min_occurs": 1
+        }
+      }
+    },
+    "uro:VerticalCurveType": {
+      "type": "Data",
+      "attributes": {
+        "length": {
+          "ref": "Measure",
+          "min_occurs": 1
+        },
+        "verticalDistance": {
+          "ref": "Measure",
+          "min_occurs": 1
+        }
+      }
+    },
+    "uro:ControlPointType": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "uro:CircularCurveType"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:TransitionCurveType"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:SlopeType"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:VerticalCurveType"
+          }
+        }
+      ]
+    },
+    "uro:TrafficAreaStructureAttribute": {
+      "type": "Data",
+      "attributes": {
+        "numberOfLanes": {
+          "ref": "Integer"
+        }
+      }
+    },
+    "tran:AuxiliaryTrafficArea": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "tranDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "surfaceMaterial": {
+          "ref": "Code"
+        }
+      }
+    },
+    "uro:TransportationDataQualityAttribute": {
+      "type": "Data",
+      "attributes": {
+        "srcScale": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "geometrySrcDesc": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "thematicSrcDesc": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "appearanceSrcDesc": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "lodType": {
+          "ref": "Code"
+        }
+      }
+    },
+    "uro:RoadType": {
+      "type": "Data",
+      "attributes": {
+        "id": {
+          "ref": "String"
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "isTemporary": {
+          "ref": "Boolean"
+        },
+        "roadType": {
+          "ref": "Code"
+        },
+        "widthType": {
+          "ref": "Code"
+        },
+        "isTollRoad": {
+          "ref": "Boolean"
+        },
+        "separator": {
+          "ref": "Measure"
+        },
+        "isHighWay": {
+          "ref": "Boolean"
+        }
+      }
+    },
+    "uro:RoadStructureAttribute": {
+      "type": "Data",
+      "attributes": {
+        "widthType": {
+          "ref": "Code"
+        },
+        "width": {
+          "ref": "Measure"
+        },
+        "numberOfLanes": {
+          "ref": "Integer"
+        },
+        "sectionType": {
+          "ref": "Code"
+        }
+      }
+    },
+    "uro:TrafficVolumeAttribute": {
+      "type": "Data",
+      "attributes": {
+        "sectionID": {
+          "ref": "String"
+        },
+        "routeName": {
+          "ref": "String"
+        },
+        "weekday12hourTrafficVolume": {
+          "ref": "Integer"
+        },
+        "weekday24hourTrafficVolume": {
+          "ref": "Integer"
+        },
+        "largeVehicleRate": {
+          "ref": "Double"
+        },
+        "congestionRate": {
+          "ref": "Double"
+        },
+        "averageTravelSpeedInCongestion": {
+          "ref": "Double"
+        },
+        "averageInboundTravelSpeedInCongestion": {
+          "ref": "Double"
+        },
+        "averageOutboundTravelSpeedInCongestion": {
+          "ref": "Double"
+        },
+        "averageInboundTravelSpeedNotCongestion": {
+          "ref": "Double"
+        },
+        "averageOutboundTravelSpeedNotCongestion": {
+          "ref": "Double"
+        },
+        "observationPointName": {
+          "ref": "String"
+        },
+        "reference": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        }
+      }
+    },
+    "tran:Railway": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "tranDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "trafficArea": {
+          "ref": {
+            "Named": "tran:TrafficArea"
+          },
+          "max_occurs": null
+        },
+        "auxiliaryTrafficArea": {
+          "ref": {
+            "Named": "tran:AuxiliaryTrafficArea"
+          },
+          "max_occurs": null
+        },
+        "tranDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:TransportationDataQualityAttribute"
+          }
+        },
+        "tranFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "tranFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "tranFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "railwayRouteAttribute": {
+          "ref": {
+            "Named": "uro:RailwayRouteAttribute"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:RailwayRouteAttribute": {
+      "type": "Data",
+      "attributes": {
+        "operatorType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "operator": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "alternativeName": {
+          "ref": "String",
+          "max_occurs": null
+        },
+        "railwayType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "startStation": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "endStation": {
+          "ref": "String",
+          "min_occurs": 1
+        }
+      }
+    },
+    "tran:Track": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "tranDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "trafficArea": {
+          "ref": {
+            "Named": "tran:TrafficArea"
+          },
+          "max_occurs": null
+        },
+        "auxiliaryTrafficArea": {
+          "ref": {
+            "Named": "tran:AuxiliaryTrafficArea"
+          },
+          "max_occurs": null
+        },
+        "tranDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:TransportationDataQualityAttribute"
+          }
+        },
+        "tranFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "tranFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "tranFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "trackAttribute": {
+          "ref": {
+            "Named": "uro:TrackAttribute"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:TrackAttribute": {
+      "type": "Data",
+      "attributes": {
+        "alternativeName": {
+          "ref": "String",
+          "max_occurs": null
+        },
+        "adminType": {
+          "ref": "Code"
+        },
+        "relativeLevel": {
+          "ref": "Integer"
+        },
+        "widthType": {
+          "ref": "Code"
+        },
+        "structureType": {
+          "ref": "Code"
+        },
+        "isTollRoad": {
+          "ref": "Boolean"
+        },
+        "separator": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "tran:Square": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "tranDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "trafficArea": {
+          "ref": {
+            "Named": "tran:TrafficArea"
+          },
+          "max_occurs": null
+        },
+        "auxiliaryTrafficArea": {
+          "ref": {
+            "Named": "tran:AuxiliaryTrafficArea"
+          },
+          "max_occurs": null
+        },
+        "tranDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:TransportationDataQualityAttribute"
+          }
+        },
+        "tranFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "tranFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "tranFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "squareUrbanPlanAttribute": {
+          "ref": {
+            "Named": "uro:SquareUrbanPlanAttributeProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:SquareUrbanPlanAttribute": {
+      "type": "Data",
+      "attributes": {
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "urbanPlanningAreaName": {
+          "ref": "String"
+        },
+        "enforcer": {
+          "ref": "String",
+          "max_occurs": null
+        },
+        "dateOfDecision": {
+          "ref": "Date"
+        },
+        "dateOfRevision": {
+          "ref": "Date",
+          "max_occurs": null
+        },
+        "areaPlanned": {
+          "ref": "Measure"
+        },
+        "areaInService": {
+          "ref": "Measure"
+        },
+        "remarks": {
+          "ref": "String"
+        },
+        "status": {
+          "ref": "Code"
+        },
+        "areaImproved": {
+          "ref": "Measure"
+        },
+        "areaCompleted": {
+          "ref": "Measure"
+        },
+        "projectStartDate": {
+          "ref": "Date"
+        },
+        "projectEndDate": {
+          "ref": "Date"
+        },
+        "isCompleted": {
+          "ref": "Boolean"
+        },
+        "isAuthorized": {
+          "ref": "Boolean"
+        },
+        "purpose": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:StationSquareAttribute": {
+      "type": "Data",
+      "attributes": {
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "urbanPlanningAreaName": {
+          "ref": "String"
+        },
+        "enforcer": {
+          "ref": "String",
+          "max_occurs": null
+        },
+        "dateOfDecision": {
+          "ref": "Date"
+        },
+        "dateOfRevision": {
+          "ref": "Date",
+          "max_occurs": null
+        },
+        "areaPlanned": {
+          "ref": "Measure"
+        },
+        "areaInService": {
+          "ref": "Measure"
+        },
+        "remarks": {
+          "ref": "String"
+        },
+        "status": {
+          "ref": "Code"
+        },
+        "areaImproved": {
+          "ref": "Measure"
+        },
+        "areaCompleted": {
+          "ref": "Measure"
+        },
+        "projectStartDate": {
+          "ref": "Date"
+        },
+        "projectEndDate": {
+          "ref": "Date"
+        },
+        "isCompleted": {
+          "ref": "Boolean"
+        },
+        "isAuthorized": {
+          "ref": "Boolean"
+        },
+        "purpose": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "station": {
+          "ref": "String",
+          "max_occurs": null
+        },
+        "route": {
+          "ref": "String",
+          "max_occurs": null
+        },
+        "railwayType": {
+          "ref": "Code",
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:TerminalAttribute": {
+      "type": "Data",
+      "attributes": {
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "urbanPlanningAreaName": {
+          "ref": "String"
+        },
+        "enforcer": {
+          "ref": "String",
+          "max_occurs": null
+        },
+        "dateOfDecision": {
+          "ref": "Date"
+        },
+        "dateOfRevision": {
+          "ref": "Date",
+          "max_occurs": null
+        },
+        "areaPlanned": {
+          "ref": "Measure"
+        },
+        "areaInService": {
+          "ref": "Measure"
+        },
+        "remarks": {
+          "ref": "String"
+        },
+        "status": {
+          "ref": "Code"
+        },
+        "areaImproved": {
+          "ref": "Measure"
+        },
+        "areaCompleted": {
+          "ref": "Measure"
+        },
+        "projectStartDate": {
+          "ref": "Date"
+        },
+        "projectEndDate": {
+          "ref": "Date"
+        },
+        "isCompleted": {
+          "ref": "Boolean"
+        },
+        "isAuthorized": {
+          "ref": "Boolean"
+        },
+        "purpose": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "terminalType": {
+          "ref": "Code"
+        },
+        "structure": {
+          "ref": "String"
+        },
+        "numberOfBerthsPlanned": {
+          "ref": "Integer"
+        },
+        "numberOfBerthsInService": {
+          "ref": "Integer"
+        },
+        "userType": {
+          "ref": "Code"
+        }
+      }
+    },
+    "uro:SquareUrbanPlanAttributeProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "uro:SquareUrbanPlanAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:StationSquareAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:TerminalAttribute"
+          }
+        }
+      ]
+    },
+    "brid:Bridge": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "yearOfConstruction": {
+          "ref": "String"
+        },
+        "yearOfDemolition": {
+          "ref": "String"
+        },
+        "isMovable": {
+          "ref": "Boolean"
+        },
+        "outerBridgeConstruction": {
+          "ref": {
+            "Named": "brid:BridgeConstructionElement"
+          },
+          "max_occurs": null
+        },
+        "outerBridgeInstallation": {
+          "ref": {
+            "Named": "brid:BridgeInstallation"
+          },
+          "max_occurs": null
+        },
+        "interiorBridgeInstallation": {
+          "ref": {
+            "Named": "brid:BridgeInstallation"
+          },
+          "max_occurs": null
+        },
+        "boundedBy": {
+          "ref": {
+            "Named": "brid:_BoundarySurfaceProperty"
+          },
+          "max_occurs": null
+        },
+        "interiorBridgeRoom": {
+          "ref": {
+            "Named": "brid:BridgeRoom"
+          },
+          "max_occurs": null
+        },
+        "consistsOfBridgePart": {
+          "ref": {
+            "Named": "brid:BridgePart"
+          },
+          "max_occurs": null
+        },
+        "address": {
+          "ref": {
+            "Named": "core:Address"
+          },
+          "max_occurs": null
+        },
+        "bridBaseAttribute": {
+          "ref": {
+            "Named": "uro:ConstructionBaseAttribute"
+          },
+          "max_occurs": null
+        },
+        "bridDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:ConstructionDataQualityAttribute"
+          }
+        },
+        "bridDisasterRiskAttribute": {
+          "ref": {
+            "Named": "uro:DisasterRiskAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "bridDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "bridFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "bridFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "bridFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "bridFunctionalAttribute": {
+          "ref": {
+            "Named": "uro:BridgeFunctionalAttribute"
+          },
+          "max_occurs": null
+        },
+        "bridRiskAssessmentAttribute": {
+          "ref": {
+            "Named": "uro:ConstructionRiskAssessmentAttribute"
+          },
+          "max_occurs": null
+        },
+        "bridStructureAttribute": {
+          "ref": {
+            "Named": "uro:BridgeStructureAttribute"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "brid:BridgeConstructionElement": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "boundedBy": {
+          "ref": {
+            "Named": "brid:_BoundarySurfaceProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "brid:CeilingSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "bldg:_OpeningProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "brid:ClosureSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "bldg:_OpeningProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "brid:FloorSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "bldg:_OpeningProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "brid:GroundSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "bldg:_OpeningProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "brid:InteriorWallSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "bldg:_OpeningProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "brid:OuterCeilingSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "bldg:_OpeningProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "brid:OuterFloorSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "bldg:_OpeningProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "brid:RoofSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "bldg:_OpeningProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "brid:WallSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "bldg:_OpeningProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "brid:_BoundarySurfaceProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "brid:CeilingSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "brid:ClosureSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "brid:FloorSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "brid:GroundSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "brid:InteriorWallSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "brid:OuterCeilingSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "brid:OuterFloorSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "brid:RoofSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "brid:WallSurface"
+          }
+        }
+      ]
+    },
+    "brid:BridgeInstallation": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "boundedBy": {
+          "ref": {
+            "Named": "brid:_BoundarySurfaceProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "brid:BridgeRoom": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "boundedBy": {
+          "ref": {
+            "Named": "brid:_BoundarySurfaceProperty"
+          },
+          "max_occurs": null
+        },
+        "interiorFurniture": {
+          "ref": {
+            "Named": "brid:BridgeFurniture"
+          },
+          "max_occurs": null
+        },
+        "bridgeRoomInstallation": {
+          "ref": {
+            "Named": "brid:BridgeInstallation"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "brid:BridgeFurniture": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        }
+      }
+    },
+    "brid:BridgePart": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "yearOfConstruction": {
+          "ref": "String"
+        },
+        "yearOfDemolition": {
+          "ref": "String"
+        },
+        "isMovable": {
+          "ref": "Boolean"
+        },
+        "outerBridgeConstruction": {
+          "ref": {
+            "Named": "brid:BridgeConstructionElement"
+          },
+          "max_occurs": null
+        },
+        "outerBridgeInstallation": {
+          "ref": {
+            "Named": "brid:BridgeInstallation"
+          },
+          "max_occurs": null
+        },
+        "interiorBridgeInstallation": {
+          "ref": {
+            "Named": "brid:BridgeInstallation"
+          },
+          "max_occurs": null
+        },
+        "boundedBy": {
+          "ref": {
+            "Named": "brid:_BoundarySurfaceProperty"
+          },
+          "max_occurs": null
+        },
+        "interiorBridgeRoom": {
+          "ref": {
+            "Named": "brid:BridgeRoom"
+          },
+          "max_occurs": null
+        },
+        "consistsOfBridgePart": {
+          "ref": {
+            "Named": "brid:BridgePart"
+          },
+          "max_occurs": null
+        },
+        "address": {
+          "ref": {
+            "Named": "core:Address"
+          },
+          "max_occurs": null
+        },
+        "bridBaseAttribute": {
+          "ref": {
+            "Named": "uro:ConstructionBaseAttribute"
+          },
+          "max_occurs": null
+        },
+        "bridDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:ConstructionDataQualityAttribute"
+          }
+        },
+        "bridDisasterRiskAttribute": {
+          "ref": {
+            "Named": "uro:DisasterRiskAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "bridDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "bridFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "bridFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "bridFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "bridFunctionalAttribute": {
+          "ref": {
+            "Named": "uro:BridgeFunctionalAttribute"
+          },
+          "max_occurs": null
+        },
+        "bridRiskAssessmentAttribute": {
+          "ref": {
+            "Named": "uro:ConstructionRiskAssessmentAttribute"
+          },
+          "max_occurs": null
+        },
+        "bridStructureAttribute": {
+          "ref": {
+            "Named": "uro:BridgeStructureAttribute"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:ConstructionBaseAttribute": {
+      "type": "Data",
+      "attributes": {
+        "adminType": {
+          "ref": "Code"
+        },
+        "administorator": {
+          "ref": "String"
+        },
+        "adminOffice": {
+          "ref": "String"
+        },
+        "operatorType": {
+          "ref": "Code"
+        },
+        "installerType": {
+          "ref": "Code"
+        },
+        "installer": {
+          "ref": "String"
+        },
+        "structureOrdinance": {
+          "ref": "String"
+        },
+        "specification": {
+          "ref": "String"
+        },
+        "kana": {
+          "ref": "String"
+        },
+        "constructionStartYear": {
+          "ref": "String"
+        },
+        "completionYear": {
+          "ref": "String"
+        },
+        "facilityAge": {
+          "ref": "Integer"
+        },
+        "update": {
+          "ref": "Date"
+        },
+        "purpose": {
+          "ref": "Code"
+        }
+      }
+    },
+    "uro:ConstructionDataQualityAttribute": {
+      "type": "Data",
+      "attributes": {
+        "srcScale": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "geometrySrcDesc": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "thematicSrcDesc": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "appearanceSrcDesc": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "dataAcquisition": {
+          "ref": "String"
+        },
+        "photoScale": {
+          "ref": "Integer"
+        },
+        "lod1HeightType": {
+          "ref": "Code"
+        },
+        "lodType": {
+          "ref": "Code",
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:HighTideRiskAttribute": {
+      "type": "Data",
+      "attributes": {
+        "description": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "rank": {
+          "ref": "Code"
+        },
+        "rankOrg": {
+          "ref": "Code"
+        },
+        "depth": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:InlandFloodingRiskAttribute": {
+      "type": "Data",
+      "attributes": {
+        "description": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "rank": {
+          "ref": "Code"
+        },
+        "rankOrg": {
+          "ref": "Code"
+        },
+        "depth": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:LandSlideRiskAttribute": {
+      "type": "Data",
+      "attributes": {
+        "description": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "areaType": {
+          "ref": "Code",
+          "min_occurs": 1
+        }
+      }
+    },
+    "uro:RiverFloodingRiskAttribute": {
+      "type": "Data",
+      "attributes": {
+        "description": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "rank": {
+          "ref": "Code"
+        },
+        "rankOrg": {
+          "ref": "Code"
+        },
+        "depth": {
+          "ref": "Measure"
+        },
+        "adminType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "scale": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "duration": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:TsunamiRiskAttribute": {
+      "type": "Data",
+      "attributes": {
+        "description": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "rank": {
+          "ref": "Code"
+        },
+        "rankOrg": {
+          "ref": "Code"
+        },
+        "depth": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:DisasterRiskAttributeProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "uro:HighTideRiskAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:InlandFloodingRiskAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:LandSlideRiskAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:RiverFloodingRiskAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:TsunamiRiskAttribute"
+          }
+        }
+      ]
+    },
+    "uro:BridgeFunctionalAttribute": {
+      "type": "Data",
+      "attributes": {
+        "directionType": {
+          "ref": "Code"
+        },
+        "userType": {
+          "ref": "Code"
+        }
+      }
+    },
+    "uro:ConstructionRiskAssessmentAttribute": {
+      "type": "Data",
+      "attributes": {
+        "surveyYear": {
+          "ref": "String"
+        },
+        "riskType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "status": {
+          "ref": "Code"
+        },
+        "referenceDate": {
+          "ref": "Date",
+          "min_occurs": 1
+        }
+      }
+    },
+    "uro:BridgeStructureAttribute": {
+      "type": "Data",
+      "attributes": {
+        "material": {
+          "ref": "Code"
+        },
+        "bridgeType": {
+          "ref": "Code"
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "width": {
+          "ref": "Measure"
+        },
+        "area": {
+          "ref": "Measure"
+        },
+        "weightRestriction": {
+          "ref": "Measure"
+        },
+        "heightRestriction": {
+          "ref": "Measure"
+        },
+        "widthRestriction": {
+          "ref": "Measure"
+        },
+        "underGirderHeight": {
+          "ref": "Measure"
+        },
+        "slopeType": {
+          "ref": "Code"
+        },
+        "escalator": {
+          "ref": "Boolean"
+        }
+      }
+    },
+    "frn:CityFurniture": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "cityFurnitureDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDataQualityAttribute"
+          }
+        },
+        "cityFurnitureDetailAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDetailAttribute"
+          },
+          "max_occurs": null
+        },
+        "frnDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "frnFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:CityFurnitureDataQualityAttribute": {
+      "type": "Data",
+      "attributes": {
+        "srcScale": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "geometrySrcDesc": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "thematicSrcDesc": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "appearanceSrcDesc": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "lodType": {
+          "ref": "Code"
+        }
+      }
+    },
+    "uro:CityFurnitureDetailAttribute": {
+      "type": "Data",
+      "attributes": {
+        "facilityType": {
+          "ref": "Code"
+        },
+        "description": {
+          "ref": "String"
+        }
+      }
+    },
+    "veg:SolitaryVegetationObject": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "vegDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "vegFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "vegFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "vegFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "vegetationDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:VegetationDataQualityAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "species": {
+          "ref": "Code"
+        },
+        "height": {
+          "ref": "Measure"
+        },
+        "trunkDiameter": {
+          "ref": "Measure"
+        },
+        "crownDiameter": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:VegetationDataQualityAttribute": {
+      "type": "Data",
+      "attributes": {
+        "srcScale": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "geometrySrcDesc": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "thematicSrcDesc": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "appearanceSrcDesc": {
+          "ref": "Code",
+          "max_occurs": null
+        }
+      }
+    },
+    "veg:PlantCover": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "vegDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "vegFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "vegFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "vegFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "vegetationDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:VegetationDataQualityAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "averageHeight": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "luse:LandUse": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "ifcLandUseAttribute": {
+          "ref": {
+            "Named": "uro:IfcAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "landUseDetailAttribute": {
+          "ref": {
+            "Named": "uro:LandUseDetailAttribute"
+          },
+          "max_occurs": null
+        },
+        "luseDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:LandUseDataQualityAttribute"
+          }
+        },
+        "luseDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "luseFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "luseFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "luseFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:LandUseDetailAttribute": {
+      "type": "Data",
+      "attributes": {
+        "id": {
+          "ref": "String"
+        },
+        "orgLandUse": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "ownerType": {
+          "ref": "Code"
+        },
+        "owner": {
+          "ref": "String"
+        },
+        "areaInSquareMeter": {
+          "ref": "Measure"
+        },
+        "areaInHa": {
+          "ref": "Measure"
+        },
+        "buildingCoverageRate": {
+          "ref": "Double"
+        },
+        "floorAreaRate": {
+          "ref": "Double"
+        },
+        "specifiedBuildingCoverageRate": {
+          "ref": "Double"
+        },
+        "specifiedFloorAreaRate": {
+          "ref": "Double"
+        },
+        "standardFloorAreaRate": {
+          "ref": "Double"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "districtsAndZonesType": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:LandUseDataQualityAttribute": {
+      "type": "Data",
+      "attributes": {
+        "srcScale": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "geometrySrcDesc": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "thematicSrcDesc": {
+          "ref": "Code",
+          "max_occurs": null
+        }
+      }
+    },
+    "tun:Tunnel": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "yearOfConstruction": {
+          "ref": "String"
+        },
+        "yearOfDemolition": {
+          "ref": "String"
+        },
+        "outerTunnelInstallation": {
+          "ref": {
+            "Named": "tun:TunnelInstallation"
+          },
+          "max_occurs": null
+        },
+        "interiorTunnelInstallation": {
+          "ref": {
+            "Named": "tun:TunnelInstallation"
+          },
+          "max_occurs": null
+        },
+        "boundedBy": {
+          "ref": {
+            "Named": "tun:_BoundarySurfaceProperty"
+          },
+          "max_occurs": null
+        },
+        "interiorHollowSpace": {
+          "ref": {
+            "Named": "tun:HollowSpace"
+          },
+          "max_occurs": null
+        },
+        "consistsOfTunnelPart": {
+          "ref": {
+            "Named": "tun:TunnelPart"
+          },
+          "max_occurs": null
+        },
+        "tunBaseAttribute": {
+          "ref": {
+            "Named": "uro:ConstructionBaseAttribute"
+          },
+          "max_occurs": null
+        },
+        "tunDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:ConstructionDataQualityAttribute"
+          }
+        },
+        "tunDisasterRiskAttribute": {
+          "ref": {
+            "Named": "uro:DisasterRiskAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "tunDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "tunFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "tunFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "tunFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "tunFunctionalAttribute": {
+          "ref": {
+            "Named": "uro:TunnelFunctionalAttribute"
+          },
+          "max_occurs": null
+        },
+        "tunRiskAssessmentAttribute": {
+          "ref": {
+            "Named": "uro:ConstructionRiskAssessmentAttribute"
+          },
+          "max_occurs": null
+        },
+        "tunStructureAttribute": {
+          "ref": {
+            "Named": "uro:TunnelStructureAttribute"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "tun:TunnelInstallation": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "boundedBy": {
+          "ref": {
+            "Named": "tun:_BoundarySurfaceProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "tun:CeilingSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "tun:_OpeningProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "tun:Door": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        }
+      }
+    },
+    "tun:Window": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        }
+      }
+    },
+    "tun:_OpeningProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "tun:Door"
+          }
+        },
+        {
+          "ref": {
+            "Named": "tun:Window"
+          }
+        }
+      ]
+    },
+    "tun:ClosureSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "tun:_OpeningProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "tun:FloorSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "tun:_OpeningProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "tun:GroundSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "tun:_OpeningProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "tun:InteriorWallSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "tun:_OpeningProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "tun:OuterCeilingSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "tun:_OpeningProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "tun:OuterFloorSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "tun:_OpeningProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "tun:RoofSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "tun:_OpeningProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "tun:WallSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "opening": {
+          "ref": {
+            "Named": "tun:_OpeningProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "tun:_BoundarySurfaceProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "tun:CeilingSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "tun:ClosureSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "tun:FloorSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "tun:GroundSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "tun:InteriorWallSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "tun:OuterCeilingSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "tun:OuterFloorSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "tun:RoofSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "tun:WallSurface"
+          }
+        }
+      ]
+    },
+    "tun:HollowSpace": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "boundedBy": {
+          "ref": {
+            "Named": "tun:_BoundarySurfaceProperty"
+          },
+          "max_occurs": null
+        },
+        "interiorFurniture": {
+          "ref": {
+            "Named": "tun:TunnelFurniture"
+          },
+          "max_occurs": null
+        },
+        "hollowSpaceInstallation": {
+          "ref": {
+            "Named": "tun:TunnelInstallation"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "tun:TunnelFurniture": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        }
+      }
+    },
+    "tun:TunnelPart": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "yearOfConstruction": {
+          "ref": "String"
+        },
+        "yearOfDemolition": {
+          "ref": "String"
+        },
+        "outerTunnelInstallation": {
+          "ref": {
+            "Named": "tun:TunnelInstallation"
+          },
+          "max_occurs": null
+        },
+        "interiorTunnelInstallation": {
+          "ref": {
+            "Named": "tun:TunnelInstallation"
+          },
+          "max_occurs": null
+        },
+        "boundedBy": {
+          "ref": {
+            "Named": "tun:_BoundarySurfaceProperty"
+          },
+          "max_occurs": null
+        },
+        "interiorHollowSpace": {
+          "ref": {
+            "Named": "tun:HollowSpace"
+          },
+          "max_occurs": null
+        },
+        "consistsOfTunnelPart": {
+          "ref": {
+            "Named": "tun:TunnelPart"
+          },
+          "max_occurs": null
+        },
+        "tunBaseAttribute": {
+          "ref": {
+            "Named": "uro:ConstructionBaseAttribute"
+          },
+          "max_occurs": null
+        },
+        "tunDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:ConstructionDataQualityAttribute"
+          }
+        },
+        "tunDisasterRiskAttribute": {
+          "ref": {
+            "Named": "uro:DisasterRiskAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "tunDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "tunFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "tunFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "tunFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "tunFunctionalAttribute": {
+          "ref": {
+            "Named": "uro:TunnelFunctionalAttribute"
+          },
+          "max_occurs": null
+        },
+        "tunRiskAssessmentAttribute": {
+          "ref": {
+            "Named": "uro:ConstructionRiskAssessmentAttribute"
+          },
+          "max_occurs": null
+        },
+        "tunStructureAttribute": {
+          "ref": {
+            "Named": "uro:TunnelStructureAttribute"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:TunnelFunctionalAttribute": {
+      "type": "Data",
+      "attributes": {
+        "directionType": {
+          "ref": "Code"
+        },
+        "userType": {
+          "ref": "Code"
+        }
+      }
+    },
+    "uro:TunnelStructureAttribute": {
+      "type": "Data",
+      "attributes": {
+        "tunnelType": {
+          "ref": "Code"
+        },
+        "tunnelSubtype": {
+          "ref": "Code"
+        },
+        "mouthType": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "width": {
+          "ref": "Measure"
+        },
+        "area": {
+          "ref": "Measure"
+        },
+        "innerHeight": {
+          "ref": "Measure"
+        },
+        "effectiveHeight": {
+          "ref": "Measure"
+        },
+        "slopeType": {
+          "ref": "Code"
+        }
+      }
+    },
+    "dem:ReliefFeature": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "lod": {
+          "ref": "NonNegativeInteger",
+          "min_occurs": 1
+        },
+        "reliefComponent": {
+          "ref": {
+            "Named": "dem:_ReliefComponentProperty"
+          },
+          "min_occurs": 1,
+          "max_occurs": null
+        }
+      }
+    },
+    "dem:BreaklineRelief": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "lod": {
+          "ref": "NonNegativeInteger",
+          "min_occurs": 1
+        },
+        "demDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "dem:MassPointRelief": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "lod": {
+          "ref": "NonNegativeInteger",
+          "min_occurs": 1
+        },
+        "demDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "dem:RasterRelief": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "lod": {
+          "ref": "NonNegativeInteger",
+          "min_occurs": 1
+        },
+        "demDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "grid": {
+          "ref": {
+            "Named": "gml:RectifiedGridCoverage"
+          },
+          "min_occurs": 1
+        }
+      }
+    },
+    "gml:RectifiedGridCoverage": {
+      "type": "Data",
+      "attributes": {
+        "rectifiedGridDomain": {
+          "ref": {
+            "Named": "gml:RectifiedGridDomain"
+          },
+          "min_occurs": 1
+        },
+        "coverageFunction": {
+          "ref": {
+            "Named": "gml:CoverageFunction"
+          }
+        }
+      }
+    },
+    "gml:RectifiedGridDomain": {
+      "type": "Data",
+      "attributes": {
+        "RectifiedGrid": {
+          "ref": {
+            "Named": "gml:RectifiedGrid"
+          },
+          "min_occurs": 1
+        }
+      }
+    },
+    "gml:RectifiedGrid": {
+      "type": "Data",
+      "attributes": {
+        "limits": {
+          "ref": {
+            "Named": "gml:GridEnvelope"
+          },
+          "min_occurs": 1
+        },
+        "axisName": {
+          "ref": "String",
+          "min_occurs": 1,
+          "max_occurs": null
+        },
+        "origin": {
+          "ref": "Point",
+          "min_occurs": 1
+        },
+        "offsetVector": {
+          "ref": "Point",
+          "min_occurs": 1,
+          "max_occurs": null
+        }
+      }
+    },
+    "gml:GridEnvelope": {
+      "type": "Data",
+      "attributes": {}
+    },
+    "gml:CoverageFunction": {
+      "type": "Data",
+      "attributes": {
+        "MappingRule": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "GridFunction": {
+          "ref": {
+            "Named": "gml:GridFunction"
+          },
+          "min_occurs": 1
+        }
+      }
+    },
+    "gml:GridFunction": {
+      "type": "Data",
+      "attributes": {}
+    },
+    "dem:TINRelief": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "lod": {
+          "ref": "NonNegativeInteger",
+          "min_occurs": 1
+        },
+        "demDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "dem:_ReliefComponentProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "dem:BreaklineRelief"
+          }
+        },
+        {
+          "ref": {
+            "Named": "dem:MassPointRelief"
+          }
+        },
+        {
+          "ref": {
+            "Named": "dem:RasterRelief"
+          }
+        },
+        {
+          "ref": {
+            "Named": "dem:TINRelief"
+          }
+        }
+      ]
+    },
+    "wtr:WaterBody": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "boundedBy": {
+          "ref": {
+            "Named": "wtr:_WaterBoundarySurfaceProperty"
+          },
+          "max_occurs": null
+        },
+        "floodingRiskAttribute": {
+          "ref": {
+            "Named": "uro:WaterBodyFloodingRiskAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "waterBodyDetailAttribute": {
+          "ref": {
+            "Named": "uro:WaterBodyDetailAttribute"
+          },
+          "max_occurs": null
+        },
+        "wtrDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "wtrFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "wtrFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "wtrFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "wtr:WaterClosureSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        }
+      }
+    },
+    "wtr:WaterGroundSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        }
+      }
+    },
+    "wtr:WaterSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "waterLevel": {
+          "ref": "Code"
+        }
+      }
+    },
+    "wtr:_WaterBoundarySurfaceProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "wtr:WaterClosureSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "wtr:WaterGroundSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "wtr:WaterSurface"
+          }
+        }
+      ]
+    },
+    "uro:WaterBodyHighTideRiskAttribute": {
+      "type": "Data",
+      "attributes": {
+        "description": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "rank": {
+          "ref": "Code"
+        },
+        "rankOrg": {
+          "ref": "Code"
+        },
+        "depth": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:WaterBodyInlandFloodingRiskAttribute": {
+      "type": "Data",
+      "attributes": {
+        "description": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "rank": {
+          "ref": "Code"
+        },
+        "rankOrg": {
+          "ref": "Code"
+        },
+        "depth": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:WaterBodyRiverFloodingRiskAttribute": {
+      "type": "Data",
+      "attributes": {
+        "description": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "rank": {
+          "ref": "Code"
+        },
+        "rankOrg": {
+          "ref": "Code"
+        },
+        "depth": {
+          "ref": "Measure"
+        },
+        "adminType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "scale": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "duration": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:WaterBodyTsunamiRiskAttribute": {
+      "type": "Data",
+      "attributes": {
+        "description": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "rank": {
+          "ref": "Code"
+        },
+        "rankOrg": {
+          "ref": "Code"
+        },
+        "depth": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:WaterBodyFloodingRiskAttributeProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "uro:WaterBodyHighTideRiskAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:WaterBodyInlandFloodingRiskAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:WaterBodyRiverFloodingRiskAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:WaterBodyTsunamiRiskAttribute"
+          }
+        }
+      ]
+    },
+    "uro:WaterBodyDetailAttribute": {
+      "type": "Data",
+      "attributes": {
+        "kana": {
+          "ref": "String"
+        },
+        "waterSystemCode": {
+          "ref": "Code"
+        },
+        "riverCode": {
+          "ref": "Code"
+        },
+        "adminType": {
+          "ref": "Code"
+        },
+        "flowDirection": {
+          "ref": "Boolean"
+        },
+        "maximumDepth": {
+          "ref": "Measure"
+        },
+        "waterSurfaceElevation": {
+          "ref": "Measure"
+        },
+        "area": {
+          "ref": "Measure"
+        },
+        "measurementYearMonth": {
+          "ref": "String"
+        },
+        "prefecture": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "city": {
+          "ref": "Code",
+          "max_occurs": null
+        }
+      }
+    },
+    "gen:GenericCityObject": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        }
+      }
+    },
+    "grp:CityObjectGroup": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "groupMember": {
+          "ref": {
+            "Named": "grp:_CityObjectOrRef"
+          },
+          "max_occurs": null
+        },
+        "parent": {
+          "ref": {
+            "Named": "grp:_CityObjectOrRef"
+          }
+        },
+        "fiscalYearOfPublication": {
+          "ref": "String",
+          "max_occurs": null
+        },
+        "ifcBuildingStoreyAttribute": {
+          "ref": {
+            "Named": "uro:IfcAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "indoorStoreyAttribute": {
+          "ref": {
+            "Named": "uro:IndoorAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "language": {
+          "ref": "Code",
+          "max_occurs": null
+        }
+      }
+    },
+    "grp:_CityObjectOrRef": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "href": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:Waterway": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "tranDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "trafficArea": {
+          "ref": {
+            "Named": "tran:TrafficArea"
+          },
+          "max_occurs": null
+        },
+        "auxiliaryTrafficArea": {
+          "ref": {
+            "Named": "tran:AuxiliaryTrafficArea"
+          },
+          "max_occurs": null
+        },
+        "tranDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:TransportationDataQualityAttribute"
+          }
+        },
+        "tranFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "tranFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "tranFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "waterwayDetailAttribute": {
+          "ref": {
+            "Named": "uro:WaterwayDetailAttribute"
+          }
+        }
+      }
+    },
+    "uro:WaterwayDetailAttribute": {
+      "type": "Data",
+      "attributes": {
+        "routeId": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "routeDirection": {
+          "ref": "Code"
+        },
+        "minimumWidth": {
+          "ref": "Measure"
+        },
+        "maximumWidth": {
+          "ref": "Measure"
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "navigation": {
+          "ref": "String"
+        },
+        "plannedDepth": {
+          "ref": "Measure"
+        },
+        "speedLimit": {
+          "ref": "Measure"
+        },
+        "targetShipType": {
+          "ref": "String",
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:OtherConstruction": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "conditionOfConstruction": {
+          "ref": "String"
+        },
+        "dateOfConstruction": {
+          "ref": "Date"
+        },
+        "dateOfDemolition": {
+          "ref": "Date"
+        },
+        "constructionEvent": {
+          "ref": {
+            "Named": "uro:ConstructionEvent"
+          },
+          "max_occurs": null
+        },
+        "elevation": {
+          "ref": {
+            "Named": "uro:Elevation"
+          },
+          "max_occurs": null
+        },
+        "height": {
+          "ref": {
+            "Named": "uro:Height"
+          },
+          "max_occurs": null
+        },
+        "occupancy": {
+          "ref": {
+            "Named": "uro:Occupancy"
+          },
+          "max_occurs": null
+        },
+        "consFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "consFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "consFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "consBaseAttribute": {
+          "ref": {
+            "Named": "uro:ConstructionBaseAttribute"
+          }
+        },
+        "consStructureAttribute": {
+          "ref": {
+            "Named": "uro:ConstructionStructureAttributeProperty"
+          }
+        },
+        "consDisasterRiskAttribute": {
+          "ref": {
+            "Named": "uro:DisasterRiskAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "consDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "consDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:ConstructionDataQualityAttribute"
+          }
+        },
+        "boundedBy": {
+          "ref": {
+            "Named": "uro:_BoundarySurfaceProperty"
+          },
+          "max_occurs": null
+        },
+        "constructionInstallation": {
+          "ref": {
+            "Named": "uro:ConstructionInstallation"
+          },
+          "max_occurs": null
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:ConstructionEvent": {
+      "type": "Data",
+      "attributes": {
+        "event": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "dateOfEvent": {
+          "ref": "Date",
+          "min_occurs": 1
+        },
+        "description": {
+          "ref": "String"
+        }
+      }
+    },
+    "uro:Elevation": {
+      "type": "Data",
+      "attributes": {
+        "elevationReference": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "elevationValue": {
+          "ref": "Point",
+          "min_occurs": 1
+        }
+      }
+    },
+    "uro:Height": {
+      "type": "Data",
+      "attributes": {
+        "highReference": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "lowReference": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "status": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "value": {
+          "ref": "Measure",
+          "min_occurs": 1
+        }
+      }
+    },
+    "uro:Occupancy": {
+      "type": "Data",
+      "attributes": {
+        "interval": {
+          "ref": "Code"
+        },
+        "numberofOccupants": {
+          "ref": "Integer",
+          "min_occurs": 1
+        },
+        "occupantType": {
+          "ref": "Code"
+        }
+      }
+    },
+    "uro:ConstructionStructureAttribute": {
+      "type": "Data",
+      "attributes": {
+        "structureType": {
+          "ref": "Code"
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "width": {
+          "ref": "Measure"
+        },
+        "depth": {
+          "ref": "Measure"
+        },
+        "volume": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:DamAttribute": {
+      "type": "Data",
+      "attributes": {
+        "structureType": {
+          "ref": "Code"
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "width": {
+          "ref": "Measure"
+        },
+        "depth": {
+          "ref": "Measure"
+        },
+        "volume": {
+          "ref": "Measure"
+        },
+        "damCode": {
+          "ref": "Code"
+        },
+        "totalWaterStorage": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:EmbankmentAttribute": {
+      "type": "Data",
+      "attributes": {
+        "structureType": {
+          "ref": "Code"
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "width": {
+          "ref": "Measure"
+        },
+        "depth": {
+          "ref": "Measure"
+        },
+        "volume": {
+          "ref": "Measure"
+        },
+        "mainPartLength": {
+          "ref": "Measure"
+        },
+        "ceilingHeight": {
+          "ref": "Measure"
+        },
+        "waveDissipatorLength": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:ConstructionStructureAttributeProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "uro:ConstructionStructureAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:DamAttribute"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:EmbankmentAttribute"
+          }
+        }
+      ]
+    },
+    "uro:ClosureSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        }
+      }
+    },
+    "uro:GroundSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        }
+      }
+    },
+    "uro:OuterCeilingSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        }
+      }
+    },
+    "uro:OuterFloorSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        }
+      }
+    },
+    "uro:RoofSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        }
+      }
+    },
+    "uro:WallSurface": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        }
+      }
+    },
+    "uro:_BoundarySurfaceProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "uro:ClosureSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:GroundSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:OuterCeilingSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:OuterFloorSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:RoofSurface"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:WallSurface"
+          }
+        }
+      ]
+    },
+    "uro:ConstructionInstallation": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:UndergroundBuilding": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "yearOfConstruction": {
+          "ref": "String"
+        },
+        "yearOfDemolition": {
+          "ref": "String"
+        },
+        "roofType": {
+          "ref": "Code"
+        },
+        "measuredHeight": {
+          "ref": "Measure"
+        },
+        "storeysAboveGround": {
+          "ref": "NonNegativeInteger"
+        },
+        "storeysBelowGround": {
+          "ref": "NonNegativeInteger"
+        },
+        "storeyHeightsAboveGround": {
+          "ref": "String"
+        },
+        "storeyHeightsBelowGround": {
+          "ref": "String"
+        },
+        "outerBuildingInstallation": {
+          "ref": {
+            "Named": "bldg:BuildingInstallation"
+          },
+          "max_occurs": null
+        },
+        "interiorBuildingInstallation": {
+          "ref": {
+            "Named": "bldg:BuildingInstallation"
+          },
+          "max_occurs": null
+        },
+        "boundedBy": {
+          "ref": {
+            "Named": "bldg:_BoundarySurfaceProperty"
+          },
+          "max_occurs": null
+        },
+        "interiorRoom": {
+          "ref": {
+            "Named": "bldg:Room"
+          },
+          "max_occurs": null
+        },
+        "consistsOfBuildingPart": {
+          "ref": {
+            "Named": "bldg:BuildingPart"
+          },
+          "max_occurs": null
+        },
+        "address": {
+          "ref": {
+            "Named": "core:Address"
+          },
+          "max_occurs": null
+        },
+        "bldgDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "bldgFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "bldgFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "bldgFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "bldgRealEstateIDAttribute": {
+          "ref": {
+            "Named": "uro:RealEstateIDAttribute"
+          }
+        },
+        "buildingDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:BuildingDataQualityAttribute"
+          }
+        },
+        "buildingDetailAttribute": {
+          "ref": {
+            "Named": "uro:BuildingDetailAttribute"
+          },
+          "max_occurs": null
+        },
+        "buildingDisasterRiskAttribute": {
+          "ref": {
+            "Named": "uro:BuildingDisasterRiskAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "buildingIDAttribute": {
+          "ref": {
+            "Named": "uro:BuildingIDAttribute"
+          },
+          "max_occurs": null
+        },
+        "ifcBuildingAttribute": {
+          "ref": {
+            "Named": "uro:IfcAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "indoorBuildingAttribute": {
+          "ref": {
+            "Named": "uro:IndoorAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "keyValuePairAttribute": {
+          "ref": {
+            "Named": "uro:KeyValuePairAttribute"
+          },
+          "max_occurs": null
+        },
+        "largeCustomerFacilityAttribute": {
+          "ref": {
+            "Named": "uro:LargeCustomerFacilityAttribute"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "uro:Appurtenance": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "cityFurnitureDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDataQualityAttribute"
+          }
+        },
+        "cityFurnitureDetailAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDetailAttribute"
+          },
+          "max_occurs": null
+        },
+        "frnDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "frnFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "occupierType": {
+          "ref": "Code"
+        },
+        "occupierName": {
+          "ref": "Code"
+        },
+        "year": {
+          "ref": "String"
+        },
+        "yearType": {
+          "ref": "Code"
+        },
+        "administrator": {
+          "ref": "Code"
+        },
+        "offsetDepth": {
+          "ref": {
+            "Named": "uro:OffsetDepth"
+          },
+          "max_occurs": null
+        },
+        "thematicShape": {
+          "ref": {
+            "Named": "uro:ThematicShape"
+          },
+          "max_occurs": null
+        },
+        "previousLink": {
+          "ref": "String",
+          "max_occurs": null
+        },
+        "nextLink": {
+          "ref": "String",
+          "max_occurs": null
+        },
+        "rotationAngle": {
+          "ref": "Double"
+        },
+        "appurtenanceType": {
+          "ref": "Code"
+        }
+      }
+    },
+    "uro:OffsetDepth": {
+      "type": "Data",
+      "attributes": {
+        "pos": {
+          "ref": "Point"
+        },
+        "offset": {
+          "ref": "Measure"
+        },
+        "depth": {
+          "ref": "Measure"
+        },
+        "minDepth": {
+          "ref": "Measure"
+        },
+        "maxDepth": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:ThematicShape": {
+      "type": "Data",
+      "attributes": {
+        "horizontalType": {
+          "ref": "Code"
+        },
+        "heightType": {
+          "ref": "Code"
+        }
+      }
+    },
+    "uro:Cable": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "cityFurnitureDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDataQualityAttribute"
+          }
+        },
+        "cityFurnitureDetailAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDetailAttribute"
+          },
+          "max_occurs": null
+        },
+        "frnDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "frnFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "occupierType": {
+          "ref": "Code"
+        },
+        "occupierName": {
+          "ref": "Code"
+        },
+        "year": {
+          "ref": "String"
+        },
+        "yearType": {
+          "ref": "Code"
+        },
+        "administrator": {
+          "ref": "Code"
+        },
+        "offsetDepth": {
+          "ref": {
+            "Named": "uro:OffsetDepth"
+          },
+          "max_occurs": null
+        },
+        "thematicShape": {
+          "ref": {
+            "Named": "uro:ThematicShape"
+          },
+          "max_occurs": null
+        },
+        "routeStartNode": {
+          "ref": "String"
+        },
+        "startNode": {
+          "ref": "String"
+        },
+        "routeEndNode": {
+          "ref": "String"
+        },
+        "endNode": {
+          "ref": "String"
+        },
+        "depth": {
+          "ref": "Measure"
+        },
+        "minDepth": {
+          "ref": "Measure"
+        },
+        "maxDepth": {
+          "ref": "Measure"
+        },
+        "maxWidth": {
+          "ref": "Measure"
+        },
+        "offset": {
+          "ref": "Measure"
+        },
+        "material": {
+          "ref": "Code"
+        },
+        "lengthAttribute": {
+          "ref": {
+            "Named": "uro:LengthAttribute"
+          },
+          "max_occurs": null
+        },
+        "columns": {
+          "ref": "Integer"
+        },
+        "rows": {
+          "ref": "Integer"
+        },
+        "cables": {
+          "ref": "Integer"
+        }
+      }
+    },
+    "uro:LengthAttribute": {
+      "type": "Data",
+      "attributes": {
+        "length": {
+          "ref": "Measure"
+        },
+        "mesureType": {
+          "ref": "Code"
+        },
+        "phaseType": {
+          "ref": "Code"
+        }
+      }
+    },
+    "uro:Duct": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "cityFurnitureDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDataQualityAttribute"
+          }
+        },
+        "cityFurnitureDetailAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDetailAttribute"
+          },
+          "max_occurs": null
+        },
+        "frnDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "frnFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "occupierType": {
+          "ref": "Code"
+        },
+        "occupierName": {
+          "ref": "Code"
+        },
+        "year": {
+          "ref": "String"
+        },
+        "yearType": {
+          "ref": "Code"
+        },
+        "administrator": {
+          "ref": "Code"
+        },
+        "offsetDepth": {
+          "ref": {
+            "Named": "uro:OffsetDepth"
+          },
+          "max_occurs": null
+        },
+        "thematicShape": {
+          "ref": {
+            "Named": "uro:ThematicShape"
+          },
+          "max_occurs": null
+        },
+        "routeStartNode": {
+          "ref": "String"
+        },
+        "startNode": {
+          "ref": "String"
+        },
+        "routeEndNode": {
+          "ref": "String"
+        },
+        "endNode": {
+          "ref": "String"
+        },
+        "depth": {
+          "ref": "Measure"
+        },
+        "minDepth": {
+          "ref": "Measure"
+        },
+        "maxDepth": {
+          "ref": "Measure"
+        },
+        "maxWidth": {
+          "ref": "Measure"
+        },
+        "offset": {
+          "ref": "Measure"
+        },
+        "material": {
+          "ref": "Code"
+        },
+        "lengthAttribute": {
+          "ref": {
+            "Named": "uro:LengthAttribute"
+          },
+          "max_occurs": null
+        },
+        "width": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:ElectricityCable": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "cityFurnitureDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDataQualityAttribute"
+          }
+        },
+        "cityFurnitureDetailAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDetailAttribute"
+          },
+          "max_occurs": null
+        },
+        "frnDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "frnFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "occupierType": {
+          "ref": "Code"
+        },
+        "occupierName": {
+          "ref": "Code"
+        },
+        "year": {
+          "ref": "String"
+        },
+        "yearType": {
+          "ref": "Code"
+        },
+        "administrator": {
+          "ref": "Code"
+        },
+        "offsetDepth": {
+          "ref": {
+            "Named": "uro:OffsetDepth"
+          },
+          "max_occurs": null
+        },
+        "thematicShape": {
+          "ref": {
+            "Named": "uro:ThematicShape"
+          },
+          "max_occurs": null
+        },
+        "routeStartNode": {
+          "ref": "String"
+        },
+        "startNode": {
+          "ref": "String"
+        },
+        "routeEndNode": {
+          "ref": "String"
+        },
+        "endNode": {
+          "ref": "String"
+        },
+        "depth": {
+          "ref": "Measure"
+        },
+        "minDepth": {
+          "ref": "Measure"
+        },
+        "maxDepth": {
+          "ref": "Measure"
+        },
+        "maxWidth": {
+          "ref": "Measure"
+        },
+        "offset": {
+          "ref": "Measure"
+        },
+        "material": {
+          "ref": "Code"
+        },
+        "lengthAttribute": {
+          "ref": {
+            "Named": "uro:LengthAttribute"
+          },
+          "max_occurs": null
+        },
+        "columns": {
+          "ref": "Integer"
+        },
+        "rows": {
+          "ref": "Integer"
+        },
+        "cables": {
+          "ref": "Integer"
+        }
+      }
+    },
+    "uro:Handhole": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "cityFurnitureDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDataQualityAttribute"
+          }
+        },
+        "cityFurnitureDetailAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDetailAttribute"
+          },
+          "max_occurs": null
+        },
+        "frnDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "frnFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "occupierType": {
+          "ref": "Code"
+        },
+        "occupierName": {
+          "ref": "Code"
+        },
+        "year": {
+          "ref": "String"
+        },
+        "yearType": {
+          "ref": "Code"
+        },
+        "administrator": {
+          "ref": "Code"
+        },
+        "offsetDepth": {
+          "ref": {
+            "Named": "uro:OffsetDepth"
+          },
+          "max_occurs": null
+        },
+        "thematicShape": {
+          "ref": {
+            "Named": "uro:ThematicShape"
+          },
+          "max_occurs": null
+        },
+        "containerType": {
+          "ref": "Code"
+        },
+        "innerDiamiterLong": {
+          "ref": "Measure"
+        },
+        "outerDiamiterLong": {
+          "ref": "Measure"
+        },
+        "innerDiamiterShort": {
+          "ref": "Measure"
+        },
+        "outerDiamiterShort": {
+          "ref": "Measure"
+        },
+        "depth": {
+          "ref": "Measure"
+        },
+        "appurtenance": {
+          "ref": "String",
+          "max_occurs": null
+        },
+        "rotationAngle": {
+          "ref": "Double"
+        }
+      }
+    },
+    "uro:Manhole": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "cityFurnitureDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDataQualityAttribute"
+          }
+        },
+        "cityFurnitureDetailAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDetailAttribute"
+          },
+          "max_occurs": null
+        },
+        "frnDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "frnFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "occupierType": {
+          "ref": "Code"
+        },
+        "occupierName": {
+          "ref": "Code"
+        },
+        "year": {
+          "ref": "String"
+        },
+        "yearType": {
+          "ref": "Code"
+        },
+        "administrator": {
+          "ref": "Code"
+        },
+        "offsetDepth": {
+          "ref": {
+            "Named": "uro:OffsetDepth"
+          },
+          "max_occurs": null
+        },
+        "thematicShape": {
+          "ref": {
+            "Named": "uro:ThematicShape"
+          },
+          "max_occurs": null
+        },
+        "containerType": {
+          "ref": "Code"
+        },
+        "innerDiamiterLong": {
+          "ref": "Measure"
+        },
+        "outerDiamiterLong": {
+          "ref": "Measure"
+        },
+        "innerDiamiterShort": {
+          "ref": "Measure"
+        },
+        "outerDiamiterShort": {
+          "ref": "Measure"
+        },
+        "depth": {
+          "ref": "Measure"
+        },
+        "appurtenance": {
+          "ref": "String",
+          "max_occurs": null
+        },
+        "rotationAngle": {
+          "ref": "Double"
+        }
+      }
+    },
+    "uro:OilGasChemicalsPipe": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "cityFurnitureDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDataQualityAttribute"
+          }
+        },
+        "cityFurnitureDetailAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDetailAttribute"
+          },
+          "max_occurs": null
+        },
+        "frnDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "frnFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "occupierType": {
+          "ref": "Code"
+        },
+        "occupierName": {
+          "ref": "Code"
+        },
+        "year": {
+          "ref": "String"
+        },
+        "yearType": {
+          "ref": "Code"
+        },
+        "administrator": {
+          "ref": "Code"
+        },
+        "offsetDepth": {
+          "ref": {
+            "Named": "uro:OffsetDepth"
+          },
+          "max_occurs": null
+        },
+        "thematicShape": {
+          "ref": {
+            "Named": "uro:ThematicShape"
+          },
+          "max_occurs": null
+        },
+        "routeStartNode": {
+          "ref": "String"
+        },
+        "startNode": {
+          "ref": "String"
+        },
+        "routeEndNode": {
+          "ref": "String"
+        },
+        "endNode": {
+          "ref": "String"
+        },
+        "depth": {
+          "ref": "Measure"
+        },
+        "minDepth": {
+          "ref": "Measure"
+        },
+        "maxDepth": {
+          "ref": "Measure"
+        },
+        "maxWidth": {
+          "ref": "Measure"
+        },
+        "offset": {
+          "ref": "Measure"
+        },
+        "material": {
+          "ref": "Code"
+        },
+        "lengthAttribute": {
+          "ref": {
+            "Named": "uro:LengthAttribute"
+          },
+          "max_occurs": null
+        },
+        "innerDiamiter": {
+          "ref": "Measure"
+        },
+        "outerDiamiter": {
+          "ref": "Measure"
+        },
+        "sleeveType": {
+          "ref": "Code"
+        }
+      }
+    },
+    "uro:Pipe": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "cityFurnitureDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDataQualityAttribute"
+          }
+        },
+        "cityFurnitureDetailAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDetailAttribute"
+          },
+          "max_occurs": null
+        },
+        "frnDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "frnFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "occupierType": {
+          "ref": "Code"
+        },
+        "occupierName": {
+          "ref": "Code"
+        },
+        "year": {
+          "ref": "String"
+        },
+        "yearType": {
+          "ref": "Code"
+        },
+        "administrator": {
+          "ref": "Code"
+        },
+        "offsetDepth": {
+          "ref": {
+            "Named": "uro:OffsetDepth"
+          },
+          "max_occurs": null
+        },
+        "thematicShape": {
+          "ref": {
+            "Named": "uro:ThematicShape"
+          },
+          "max_occurs": null
+        },
+        "routeStartNode": {
+          "ref": "String"
+        },
+        "startNode": {
+          "ref": "String"
+        },
+        "routeEndNode": {
+          "ref": "String"
+        },
+        "endNode": {
+          "ref": "String"
+        },
+        "depth": {
+          "ref": "Measure"
+        },
+        "minDepth": {
+          "ref": "Measure"
+        },
+        "maxDepth": {
+          "ref": "Measure"
+        },
+        "maxWidth": {
+          "ref": "Measure"
+        },
+        "offset": {
+          "ref": "Measure"
+        },
+        "material": {
+          "ref": "Code"
+        },
+        "lengthAttribute": {
+          "ref": {
+            "Named": "uro:LengthAttribute"
+          },
+          "max_occurs": null
+        },
+        "innerDiamiter": {
+          "ref": "Measure"
+        },
+        "outerDiamiter": {
+          "ref": "Measure"
+        },
+        "sleeveType": {
+          "ref": "Code"
+        }
+      }
+    },
+    "uro:SewerPipe": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "cityFurnitureDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDataQualityAttribute"
+          }
+        },
+        "cityFurnitureDetailAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDetailAttribute"
+          },
+          "max_occurs": null
+        },
+        "frnDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "frnFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "occupierType": {
+          "ref": "Code"
+        },
+        "occupierName": {
+          "ref": "Code"
+        },
+        "year": {
+          "ref": "String"
+        },
+        "yearType": {
+          "ref": "Code"
+        },
+        "administrator": {
+          "ref": "Code"
+        },
+        "offsetDepth": {
+          "ref": {
+            "Named": "uro:OffsetDepth"
+          },
+          "max_occurs": null
+        },
+        "thematicShape": {
+          "ref": {
+            "Named": "uro:ThematicShape"
+          },
+          "max_occurs": null
+        },
+        "routeStartNode": {
+          "ref": "String"
+        },
+        "startNode": {
+          "ref": "String"
+        },
+        "routeEndNode": {
+          "ref": "String"
+        },
+        "endNode": {
+          "ref": "String"
+        },
+        "depth": {
+          "ref": "Measure"
+        },
+        "minDepth": {
+          "ref": "Measure"
+        },
+        "maxDepth": {
+          "ref": "Measure"
+        },
+        "maxWidth": {
+          "ref": "Measure"
+        },
+        "offset": {
+          "ref": "Measure"
+        },
+        "material": {
+          "ref": "Code"
+        },
+        "lengthAttribute": {
+          "ref": {
+            "Named": "uro:LengthAttribute"
+          },
+          "max_occurs": null
+        },
+        "innerDiamiter": {
+          "ref": "Measure"
+        },
+        "outerDiamiter": {
+          "ref": "Measure"
+        },
+        "sleeveType": {
+          "ref": "Code"
+        },
+        "slope": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "uro:TelecommunicationsCable": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "cityFurnitureDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDataQualityAttribute"
+          }
+        },
+        "cityFurnitureDetailAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDetailAttribute"
+          },
+          "max_occurs": null
+        },
+        "frnDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "frnFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "occupierType": {
+          "ref": "Code"
+        },
+        "occupierName": {
+          "ref": "Code"
+        },
+        "year": {
+          "ref": "String"
+        },
+        "yearType": {
+          "ref": "Code"
+        },
+        "administrator": {
+          "ref": "Code"
+        },
+        "offsetDepth": {
+          "ref": {
+            "Named": "uro:OffsetDepth"
+          },
+          "max_occurs": null
+        },
+        "thematicShape": {
+          "ref": {
+            "Named": "uro:ThematicShape"
+          },
+          "max_occurs": null
+        },
+        "routeStartNode": {
+          "ref": "String"
+        },
+        "startNode": {
+          "ref": "String"
+        },
+        "routeEndNode": {
+          "ref": "String"
+        },
+        "endNode": {
+          "ref": "String"
+        },
+        "depth": {
+          "ref": "Measure"
+        },
+        "minDepth": {
+          "ref": "Measure"
+        },
+        "maxDepth": {
+          "ref": "Measure"
+        },
+        "maxWidth": {
+          "ref": "Measure"
+        },
+        "offset": {
+          "ref": "Measure"
+        },
+        "material": {
+          "ref": "Code"
+        },
+        "lengthAttribute": {
+          "ref": {
+            "Named": "uro:LengthAttribute"
+          },
+          "max_occurs": null
+        },
+        "columns": {
+          "ref": "Integer"
+        },
+        "rows": {
+          "ref": "Integer"
+        },
+        "cables": {
+          "ref": "Integer"
+        }
+      }
+    },
+    "uro:ThermalPipe": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "cityFurnitureDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDataQualityAttribute"
+          }
+        },
+        "cityFurnitureDetailAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDetailAttribute"
+          },
+          "max_occurs": null
+        },
+        "frnDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "frnFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "occupierType": {
+          "ref": "Code"
+        },
+        "occupierName": {
+          "ref": "Code"
+        },
+        "year": {
+          "ref": "String"
+        },
+        "yearType": {
+          "ref": "Code"
+        },
+        "administrator": {
+          "ref": "Code"
+        },
+        "offsetDepth": {
+          "ref": {
+            "Named": "uro:OffsetDepth"
+          },
+          "max_occurs": null
+        },
+        "thematicShape": {
+          "ref": {
+            "Named": "uro:ThematicShape"
+          },
+          "max_occurs": null
+        },
+        "routeStartNode": {
+          "ref": "String"
+        },
+        "startNode": {
+          "ref": "String"
+        },
+        "routeEndNode": {
+          "ref": "String"
+        },
+        "endNode": {
+          "ref": "String"
+        },
+        "depth": {
+          "ref": "Measure"
+        },
+        "minDepth": {
+          "ref": "Measure"
+        },
+        "maxDepth": {
+          "ref": "Measure"
+        },
+        "maxWidth": {
+          "ref": "Measure"
+        },
+        "offset": {
+          "ref": "Measure"
+        },
+        "material": {
+          "ref": "Code"
+        },
+        "lengthAttribute": {
+          "ref": {
+            "Named": "uro:LengthAttribute"
+          },
+          "max_occurs": null
+        },
+        "innerDiamiter": {
+          "ref": "Measure"
+        },
+        "outerDiamiter": {
+          "ref": "Measure"
+        },
+        "sleeveType": {
+          "ref": "Code"
+        }
+      }
+    },
+    "uro:WaterPipe": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "cityFurnitureDataQualityAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDataQualityAttribute"
+          }
+        },
+        "cityFurnitureDetailAttribute": {
+          "ref": {
+            "Named": "uro:CityFurnitureDetailAttribute"
+          },
+          "max_occurs": null
+        },
+        "frnDmAttribute": {
+          "ref": {
+            "Named": "uro:DmAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityAttribute": {
+          "ref": {
+            "Named": "uro:FacilityAttributeProperty"
+          },
+          "max_occurs": null
+        },
+        "frnFacilityIdAttribute": {
+          "ref": {
+            "Named": "uro:FacilityIdAttributeProperty"
+          }
+        },
+        "frnFacilityTypeAttribute": {
+          "ref": {
+            "Named": "uro:FacilityTypeAttribute"
+          },
+          "max_occurs": null
+        },
+        "occupierType": {
+          "ref": "Code"
+        },
+        "occupierName": {
+          "ref": "Code"
+        },
+        "year": {
+          "ref": "String"
+        },
+        "yearType": {
+          "ref": "Code"
+        },
+        "administrator": {
+          "ref": "Code"
+        },
+        "offsetDepth": {
+          "ref": {
+            "Named": "uro:OffsetDepth"
+          },
+          "max_occurs": null
+        },
+        "thematicShape": {
+          "ref": {
+            "Named": "uro:ThematicShape"
+          },
+          "max_occurs": null
+        },
+        "routeStartNode": {
+          "ref": "String"
+        },
+        "startNode": {
+          "ref": "String"
+        },
+        "routeEndNode": {
+          "ref": "String"
+        },
+        "endNode": {
+          "ref": "String"
+        },
+        "depth": {
+          "ref": "Measure"
+        },
+        "minDepth": {
+          "ref": "Measure"
+        },
+        "maxDepth": {
+          "ref": "Measure"
+        },
+        "maxWidth": {
+          "ref": "Measure"
+        },
+        "offset": {
+          "ref": "Measure"
+        },
+        "material": {
+          "ref": "Code"
+        },
+        "lengthAttribute": {
+          "ref": {
+            "Named": "uro:LengthAttribute"
+          },
+          "max_occurs": null
+        },
+        "innerDiamiter": {
+          "ref": "Measure"
+        },
+        "outerDiamiter": {
+          "ref": "Measure"
+        },
+        "sleeveType": {
+          "ref": "Code"
+        }
+      }
+    },
+    "urf:Zone": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:Boundary": {
+      "type": "Data",
+      "attributes": {
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "offset": {
+          "ref": "Measure"
+        },
+        "offsetDirection": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:Agreement": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "applicableArea": {
+          "ref": "Measure"
+        },
+        "expiration": {
+          "ref": "Date"
+        }
+      }
+    },
+    "urf:AircraftNoiseControlZone": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:AreaClassification": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "population": {
+          "ref": "Integer"
+        }
+      }
+    },
+    "urf:CollectiveFacilitiesForReconstruction": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        },
+        "housingFacilities": {
+          "ref": "String"
+        },
+        "supecificBusinessFacilities": {
+          "ref": "String"
+        },
+        "publicFacilities": {
+          "ref": "String"
+        },
+        "utilityFacilities": {
+          "ref": "String"
+        },
+        "maximumBuildingHeight": {
+          "ref": "Measure"
+        },
+        "minimumBuildingHeight": {
+          "ref": "Measure"
+        },
+        "maximumFloorAreaRate": {
+          "ref": "Double"
+        },
+        "minimumFloorAreaRate": {
+          "ref": "Double"
+        },
+        "maximumBuildingCoverageRate": {
+          "ref": "Double"
+        }
+      }
+    },
+    "urf:ThreeDimensionalExtent": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "minimumDistance": {
+          "ref": "Measure"
+        },
+        "maximumLoad": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:CollectiveFacilitiesForReconstructionAndRevitalization": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        },
+        "housingFacilities": {
+          "ref": "String"
+        },
+        "supecificBusinessFacilities": {
+          "ref": "String"
+        },
+        "publicFacilities": {
+          "ref": "String"
+        },
+        "utilityFacilities": {
+          "ref": "String"
+        },
+        "maximumBuildingHeight": {
+          "ref": "Measure"
+        },
+        "minimumBuildingHeight": {
+          "ref": "Measure"
+        },
+        "maximumFloorAreaRate": {
+          "ref": "Double"
+        },
+        "minimumFloorAreaRate": {
+          "ref": "Double"
+        },
+        "maximumBuildingCoverageRate": {
+          "ref": "Double"
+        }
+      }
+    },
+    "urf:CollectiveFacilitiesForTsunamiDisasterPrevention": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        },
+        "housingFacilities": {
+          "ref": "String"
+        },
+        "supecificBusinessFacilities": {
+          "ref": "String"
+        },
+        "publicFacilities": {
+          "ref": "String"
+        },
+        "utilityFacilities": {
+          "ref": "String"
+        },
+        "maximumBuildingHeight": {
+          "ref": "Measure"
+        },
+        "minimumBuildingHeight": {
+          "ref": "Measure"
+        },
+        "maximumFloorAreaRate": {
+          "ref": "Double"
+        },
+        "minimumFloorAreaRate": {
+          "ref": "Double"
+        },
+        "maximumBuildingCoverageRate": {
+          "ref": "Double"
+        }
+      }
+    },
+    "urf:CollectiveGovernmentAndPublicOfficeFacilities": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        },
+        "buildingCoverageRate": {
+          "ref": "Double"
+        },
+        "floorAreaRate": {
+          "ref": "Double"
+        },
+        "publicFacilitiesAllocationPolicy": {
+          "ref": "String"
+        },
+        "scheduledExecutor": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:CollectiveHousingFacilities": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        },
+        "buildingCoverageRate": {
+          "ref": "Double"
+        },
+        "floorAreaRate": {
+          "ref": "Double"
+        },
+        "numberOfLowRiseHousing": {
+          "ref": "Integer"
+        },
+        "numberOfMiddleRiseHousing": {
+          "ref": "Integer"
+        },
+        "numberOfHighRiseHousing": {
+          "ref": "Integer"
+        },
+        "totalNumberOfHousing": {
+          "ref": "Integer"
+        },
+        "publicFacilitiesAllocationPolicy": {
+          "ref": "String"
+        },
+        "scheduledExecutor": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:CollectiveUrbanDisasterPreventionFacilities": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        },
+        "specificUtilityAndPublicFacilities": {
+          "ref": "String"
+        },
+        "maximumBuildingHeight": {
+          "ref": "Measure"
+        },
+        "minimumBuildingHeight": {
+          "ref": "Measure"
+        },
+        "maximumFloorAreaRate": {
+          "ref": "Double"
+        },
+        "minimumFloorAreaRate": {
+          "ref": "Double"
+        },
+        "maximumBuildingCoverageRate": {
+          "ref": "Double"
+        }
+      }
+    },
+    "urf:ConservationZoneForClustersOfTraditionalStructures": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:DisasterPreventionBlockImprovementProject": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "scheduledExecutor": {
+          "ref": "String"
+        },
+        "disasterPreventionPublicFacilityAllocation": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "otherPublicFacilityAllocation": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "developmentPlan": {
+          "ref": "String",
+          "min_occurs": 1
+        }
+      }
+    },
+    "urf:DisasterPreventionBlockImprovementZonePlan": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "objectives": {
+          "ref": "String"
+        },
+        "policy": {
+          "ref": "String"
+        },
+        "districtDevelopmentPlan": {
+          "ref": {
+            "Named": "urf:DistrictDevelopmentPlanProperty"
+          },
+          "max_occurs": null
+        },
+        "promotionDistrict": {
+          "ref": {
+            "Named": "urf:PromotionDistrict"
+          },
+          "max_occurs": null
+        },
+        "zonalDisasterPreventionFacilitiesAllocation": {
+          "ref": "String"
+        },
+        "specifiedZonalDisasterPreventionFacilitiesAllocation": {
+          "ref": "String"
+        },
+        "zonalDisasterPreventionFacilities": {
+          "ref": {
+            "Named": "urf:ZonalDisasterPreventionFacility"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "urf:DistrictDevelopmentPlan": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "districtFacilitiesAllocation": {
+          "ref": "String"
+        },
+        "buildingRestrictions": {
+          "ref": "String"
+        },
+        "urbanGreenSpaceConservation": {
+          "ref": "String"
+        },
+        "activityRestrictionInFarmland": {
+          "ref": "String"
+        },
+        "landuseRestrictions": {
+          "ref": "String"
+        },
+        "districtFacility": {
+          "ref": {
+            "Named": "urf:DistrictFacilityProperty"
+          },
+          "max_occurs": null
+        },
+        "district": {
+          "ref": {
+            "Named": "urf:District"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "urf:DistrictFacility": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:RoadsideDistrictFacility": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:RuralDistrictFacility": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:DistrictFacilityProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "urf:DistrictFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:RoadsideDistrictFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:RuralDistrictFacility"
+          }
+        }
+      ]
+    },
+    "urf:District": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "buildingRestrictions": {
+          "ref": "String"
+        },
+        "useRestrictions": {
+          "ref": "String"
+        },
+        "maximumFloorAreaRate": {
+          "ref": "Double"
+        },
+        "minimumFloorAreaRate": {
+          "ref": "Double"
+        },
+        "maximumBuildingCoverageRate": {
+          "ref": "Double"
+        },
+        "minimumBuildingCoverageRate": {
+          "ref": "Double"
+        },
+        "minimumSiteArea": {
+          "ref": "Measure"
+        },
+        "minimumBuildingArea": {
+          "ref": "Measure"
+        },
+        "minimumGroundHeight": {
+          "ref": "Measure"
+        },
+        "setbackSize": {
+          "ref": "String"
+        },
+        "structurePlacementRestrictions": {
+          "ref": "String"
+        },
+        "maximumBuildingHeight": {
+          "ref": "Measure"
+        },
+        "minimumBuildingHeight": {
+          "ref": "Measure"
+        },
+        "minimumFloorHeight": {
+          "ref": "Measure"
+        },
+        "buildingDesignRestriction": {
+          "ref": "String"
+        },
+        "minimumGreeningRate": {
+          "ref": "Double"
+        },
+        "fenceGuideline": {
+          "ref": "String"
+        },
+        "restrictionsForFireProtection": {
+          "ref": "String"
+        },
+        "restrictionsForNoiseProtection": {
+          "ref": "String"
+        },
+        "minimumFrontageRate": {
+          "ref": "Double"
+        }
+      }
+    },
+    "urf:DistrictImprovementPlanForDisasterPreventionBlockImprovementZonePlan": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "districtFacilitiesAllocation": {
+          "ref": "String"
+        },
+        "buildingRestrictions": {
+          "ref": "String"
+        },
+        "urbanGreenSpaceConservation": {
+          "ref": "String"
+        },
+        "activityRestrictionInFarmland": {
+          "ref": "String"
+        },
+        "landuseRestrictions": {
+          "ref": "String"
+        },
+        "districtFacility": {
+          "ref": {
+            "Named": "urf:DistrictFacilityProperty"
+          },
+          "max_occurs": null
+        },
+        "district": {
+          "ref": {
+            "Named": "urf:District"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "urf:DistrictImprovementPlanForHistoricSceneryMaintenanceAndImprovementDistrict": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "districtFacilitiesAllocation": {
+          "ref": "String"
+        },
+        "buildingRestrictions": {
+          "ref": "String"
+        },
+        "urbanGreenSpaceConservation": {
+          "ref": "String"
+        },
+        "activityRestrictionInFarmland": {
+          "ref": "String"
+        },
+        "landuseRestrictions": {
+          "ref": "String"
+        },
+        "districtFacility": {
+          "ref": {
+            "Named": "urf:DistrictFacilityProperty"
+          },
+          "max_occurs": null
+        },
+        "district": {
+          "ref": {
+            "Named": "urf:District"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "urf:RoadsideDistrictImprovementPlan": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "districtFacilitiesAllocation": {
+          "ref": "String"
+        },
+        "buildingRestrictions": {
+          "ref": "String"
+        },
+        "urbanGreenSpaceConservation": {
+          "ref": "String"
+        },
+        "activityRestrictionInFarmland": {
+          "ref": "String"
+        },
+        "landuseRestrictions": {
+          "ref": "String"
+        },
+        "districtFacility": {
+          "ref": {
+            "Named": "urf:DistrictFacilityProperty"
+          },
+          "max_occurs": null
+        },
+        "district": {
+          "ref": {
+            "Named": "urf:District"
+          },
+          "max_occurs": null
+        },
+        "roadsideDistrictFacilitiesAllocation": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:RuralDistrictImprovementPlan": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "districtFacilitiesAllocation": {
+          "ref": "String"
+        },
+        "buildingRestrictions": {
+          "ref": "String"
+        },
+        "urbanGreenSpaceConservation": {
+          "ref": "String"
+        },
+        "activityRestrictionInFarmland": {
+          "ref": "String"
+        },
+        "landuseRestrictions": {
+          "ref": "String"
+        },
+        "districtFacility": {
+          "ref": {
+            "Named": "urf:DistrictFacilityProperty"
+          },
+          "max_occurs": null
+        },
+        "district": {
+          "ref": {
+            "Named": "urf:District"
+          },
+          "max_occurs": null
+        },
+        "ruralDistrictFacilitiesAllocation": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:SpecifiedBuildingZoneImprovementPlan": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "districtFacilitiesAllocation": {
+          "ref": "String"
+        },
+        "buildingRestrictions": {
+          "ref": "String"
+        },
+        "urbanGreenSpaceConservation": {
+          "ref": "String"
+        },
+        "activityRestrictionInFarmland": {
+          "ref": "String"
+        },
+        "landuseRestrictions": {
+          "ref": "String"
+        },
+        "districtFacility": {
+          "ref": {
+            "Named": "urf:DistrictFacilityProperty"
+          },
+          "max_occurs": null
+        },
+        "district": {
+          "ref": {
+            "Named": "urf:District"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "urf:DistrictDevelopmentPlanProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "urf:DistrictDevelopmentPlan"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:DistrictImprovementPlanForDisasterPreventionBlockImprovementZonePlan"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:DistrictImprovementPlanForHistoricSceneryMaintenanceAndImprovementDistrict"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:RoadsideDistrictImprovementPlan"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:RuralDistrictImprovementPlan"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:SpecifiedBuildingZoneImprovementPlan"
+          }
+        }
+      ]
+    },
+    "urf:PromotionDistrict": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:ZonalDisasterPreventionFacility": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "facilityType": {
+          "ref": "Code",
+          "min_occurs": 1
+        }
+      }
+    },
+    "urf:DistributionBusinessPark": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        },
+        "distributionBusinessPark": {
+          "ref": "String"
+        },
+        "publicAndUtilityFacilities": {
+          "ref": "String"
+        },
+        "buildingCoverageRate": {
+          "ref": "Double"
+        },
+        "floorAreaRate": {
+          "ref": "Double"
+        },
+        "maximumBuildingHeight": {
+          "ref": "Measure"
+        },
+        "minimumBuildingHeight": {
+          "ref": "Measure"
+        },
+        "setbackSize": {
+          "ref": "String"
+        },
+        "scheduledExecutor": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:DistributionBusinessZone": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        },
+        "guidelinePublicationDate": {
+          "ref": "Date"
+        }
+      }
+    },
+    "urf:DistrictPlan": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "objectives": {
+          "ref": "String"
+        },
+        "policy": {
+          "ref": "String"
+        },
+        "districtDevelopmentPlan": {
+          "ref": {
+            "Named": "urf:DistrictDevelopmentPlanProperty"
+          },
+          "max_occurs": null
+        },
+        "promotionDistrict": {
+          "ref": {
+            "Named": "urf:PromotionDistrict"
+          },
+          "max_occurs": null
+        },
+        "facilityAllocation": {
+          "ref": "String"
+        },
+        "landUsePolicy": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:DistrictsAndZones": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:EducationalAndCulturalFacility": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "urf:ExceptionalFloorAreaRateDistrict": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        },
+        "buildingHeightLimits": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:FirePreventionDistrict": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:FireProtectionFacility": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "width": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:FloodPreventionFacility": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "width": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:GlobalHubCityDevelopmentProject": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "implementationBody": {
+          "ref": "String"
+        },
+        "implementationPeriod": {
+          "ref": "String"
+        },
+        "plan": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:GreenSpaceConservationDistrict": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:HeightControlDistrict": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        },
+        "maximumBuildingHeight": {
+          "ref": "Measure"
+        },
+        "minimumBuildingHeight": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:HighLevelUseDistrict": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        },
+        "maximumFloorAreaRate": {
+          "ref": "Double",
+          "min_occurs": 1,
+          "max_occurs": null
+        },
+        "minimumFloorAreaRate": {
+          "ref": "Double",
+          "min_occurs": 1,
+          "max_occurs": null
+        },
+        "maximumBuildingCoverageRate": {
+          "ref": "Double",
+          "min_occurs": 1,
+          "max_occurs": null
+        },
+        "minimumBuildingArea": {
+          "ref": "Measure",
+          "min_occurs": 1,
+          "max_occurs": null
+        },
+        "setbackSize": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:HighRiseResidentialAttractionDistrict": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        },
+        "floorAreaRate": {
+          "ref": "Double",
+          "min_occurs": 1
+        },
+        "maximumBuildingCoverageRate": {
+          "ref": "Double"
+        },
+        "minimumSiteArea": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:HistoricSceneryMaintenanceAndImprovementDistrictPlan": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "objectives": {
+          "ref": "String"
+        },
+        "policy": {
+          "ref": "String"
+        },
+        "districtDevelopmentPlan": {
+          "ref": {
+            "Named": "urf:DistrictDevelopmentPlanProperty"
+          },
+          "max_occurs": null
+        },
+        "promotionDistrict": {
+          "ref": {
+            "Named": "urf:PromotionDistrict"
+          },
+          "max_occurs": null
+        },
+        "landUsePolicy": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:HousingControlArea": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:IndustrialParkDevelopmentProject": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "scheduledExecutor": {
+          "ref": "String"
+        },
+        "publicFacilityAllocation": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "residentialLandUsePlan": {
+          "ref": "String",
+          "min_occurs": 1
+        }
+      }
+    },
+    "urf:LandReadjustmentProject": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "scheduledExecutor": {
+          "ref": "String"
+        },
+        "publicFacilityAllocation": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "buildingLotDevelopment": {
+          "ref": "String",
+          "min_occurs": 1
+        }
+      }
+    },
+    "urf:LandReadjustmentPromotionArea": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "developmentPolicy": {
+          "ref": "String"
+        },
+        "publicFacilitiesPlans": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:LandReadjustmentPromotionAreasForCoreBusinessUrbanDevelopment": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "developmentPolicy": {
+          "ref": "String"
+        },
+        "publicFacilitiesPlans": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:LandscapeZone": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        },
+        "buildingDesignRestriction": {
+          "ref": "String"
+        },
+        "maximumBuildingHeight": {
+          "ref": "Measure"
+        },
+        "minimumBuildingHeight": {
+          "ref": "Measure"
+        },
+        "setbackSize": {
+          "ref": "String"
+        },
+        "minimumSiteArea": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:MarketsSlaughterhousesCrematoria": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "urf:MedicalFacility": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "urf:NewHousingAndUrbanDevelopmentProject": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "scheduledExecutor": {
+          "ref": "String"
+        },
+        "housing": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "publicFacilityAllocation": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "residentialLandUsePlan": {
+          "ref": "String",
+          "min_occurs": 1
+        }
+      }
+    },
+    "urf:NewUrbanInfrastructureProject": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "scheduledExecutor": {
+          "ref": "String"
+        },
+        "landForCentralPublicFacilities": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "districtsAllocation": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "landUsePlan": {
+          "ref": "String",
+          "min_occurs": 1
+        }
+      }
+    },
+    "urf:OpenSpaceForPublicUse": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        },
+        "parkAttribute": {
+          "ref": {
+            "Named": "urf:ParkAttribute"
+          }
+        }
+      }
+    },
+    "urf:ParkAttribute": {
+      "type": "Data",
+      "attributes": {
+        "parkTypeNumber": {
+          "ref": "Code"
+        },
+        "parkSizeNumber": {
+          "ref": "Code"
+        },
+        "parkSerialNumber": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:ParkingPlaceDevelopmentZone": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:PortZone": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        },
+        "floorAreaRate": {
+          "ref": "Double"
+        }
+      }
+    },
+    "urf:PrivateUrbanRenewalProjectPlan": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "developer": {
+          "ref": "String"
+        },
+        "plan": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:ProductiveGreenZone": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        },
+        "zoneNumber": {
+          "ref": "String"
+        },
+        "specification": {
+          "ref": "Code"
+        }
+      }
+    },
+    "urf:ProjectPromotionArea": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "developmentPolicy": {
+          "ref": "String"
+        },
+        "publicFacilitiesPlans": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:QuasiUrbanPlanningArea": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "population": {
+          "ref": "Integer"
+        },
+        "cityArea": {
+          "ref": "Measure"
+        },
+        "cityPopulation": {
+          "ref": "Integer"
+        }
+      }
+    },
+    "urf:Regulation": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:ResidenceAttractionArea": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:ResidentialBlockConstructionProject": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "scheduledExecutor": {
+          "ref": "String"
+        },
+        "publicFacilityAllocation": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "developmentPlan": {
+          "ref": "String"
+        },
+        "siteArea": {
+          "ref": "Measure"
+        },
+        "totalFloorArea": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:ResidentialBlockConstructionPromotionArea": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "developmentPolicy": {
+          "ref": "String"
+        },
+        "publicFacilitiesPlans": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:ResidentialEnvironmentImprovementDistrict": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        },
+        "useToBeInduced": {
+          "ref": "String"
+        },
+        "maximumFloorAreaRate": {
+          "ref": "Double"
+        },
+        "maximumBuildingCoverageRate": {
+          "ref": "Double"
+        },
+        "maximumBuildingHeight": {
+          "ref": "String"
+        },
+        "setbackSize": {
+          "ref": "String"
+        },
+        "otherRestrictions": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:RoadsideDistrictPlan": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "objectives": {
+          "ref": "String"
+        },
+        "policy": {
+          "ref": "String"
+        },
+        "districtDevelopmentPlan": {
+          "ref": {
+            "Named": "urf:DistrictDevelopmentPlanProperty"
+          },
+          "max_occurs": null
+        },
+        "promotionDistrict": {
+          "ref": {
+            "Named": "urf:PromotionDistrict"
+          },
+          "max_occurs": null
+        },
+        "facilitiesAllocation": {
+          "ref": "String"
+        },
+        "landUsePolicy": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:RuralDistrictPlan": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "objectives": {
+          "ref": "String"
+        },
+        "policy": {
+          "ref": "String"
+        },
+        "districtDevelopmentPlan": {
+          "ref": {
+            "Named": "urf:DistrictDevelopmentPlanProperty"
+          },
+          "max_occurs": null
+        },
+        "promotionDistrict": {
+          "ref": {
+            "Named": "urf:PromotionDistrict"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "urf:SandControlFacility": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "width": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:ScenicDistrict": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        },
+        "buildingCoverageRate": {
+          "ref": "Double"
+        },
+        "buildingHeightLimits": {
+          "ref": "Measure"
+        },
+        "wallSetbackDistanceWithRoad": {
+          "ref": "Measure"
+        },
+        "wallSetbackDistanceWithAdjoiningLand": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:ScheduledAreaForCollectiveGovernmentAndPublicOfficeFacilities": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "scheduledExecutor": {
+          "ref": "String",
+          "min_occurs": 1
+        }
+      }
+    },
+    "urf:ScheduledAreaForCollectiveHousingFacilities": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "scheduledExecutor": {
+          "ref": "String",
+          "min_occurs": 1
+        }
+      }
+    },
+    "urf:ScheduledAreaForDistributionBusinessPark": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "scheduledExecutor": {
+          "ref": "String",
+          "min_occurs": 1
+        }
+      }
+    },
+    "urf:ScheduledAreaForIndustrialParkDevelopmentProjects": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "scheduledExecutor": {
+          "ref": "String",
+          "min_occurs": 1
+        }
+      }
+    },
+    "urf:ScheduledAreaForNewHousingAndUrbanDevelopmentProjects": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "scheduledExecutor": {
+          "ref": "String",
+          "min_occurs": 1
+        }
+      }
+    },
+    "urf:ScheduledAreaForNewUrbanInfrastructureProjects": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "scheduledExecutor": {
+          "ref": "String",
+          "min_occurs": 1
+        }
+      }
+    },
+    "urf:ScheduledAreaForUrbanDevelopmentProject": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "scheduledExecutor": {
+          "ref": "String",
+          "min_occurs": 1
+        }
+      }
+    },
+    "urf:SedimentDisasterProneArea": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "disasterType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "areaType": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "zoneNumber": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "zoneName": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "status": {
+          "ref": "Code"
+        }
+      }
+    },
+    "urf:SnowProtectionFacility": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "width": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:SocialWelfareFacility": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "urf:SpecialGreenSpaceConservationDistrict": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        },
+        "requirement": {
+          "ref": "Code"
+        }
+      }
+    },
+    "urf:SpecialUrbanRenaissanceDistrict": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        },
+        "useToBeInduced": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "maximumFloorAreaRate": {
+          "ref": "Double",
+          "min_occurs": 1
+        },
+        "minimumFloorAreaRate": {
+          "ref": "Double",
+          "min_occurs": 1
+        },
+        "maximumBuildingCoverageRate": {
+          "ref": "Double",
+          "min_occurs": 1
+        },
+        "minimumBuildingArea": {
+          "ref": "Measure",
+          "min_occurs": 1
+        },
+        "maximumBuildingHeight": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "setbackSize": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "otherRestrictions": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:SpecialUseAttractionDistrict": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        },
+        "useToBeInduced": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "maximumFloorAreaRate": {
+          "ref": "Double",
+          "min_occurs": 1
+        },
+        "minimumFloorAreaRate": {
+          "ref": "Double"
+        },
+        "minimumBuildingArea": {
+          "ref": "Measure"
+        },
+        "maximumBuildingHeight": {
+          "ref": "String"
+        },
+        "otherRestrictions": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:SpecialUseDistrict": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        },
+        "buildingRestrictions": {
+          "ref": "String"
+        },
+        "otherRestrictions": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:SpecialUseRestrictionDistrict": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        },
+        "buildingRestrictions": {
+          "ref": "String"
+        },
+        "otherRestrictions": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:SpecialZoneForPreservationOfHistoricalLandscape": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:SpecifiedBlock": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        },
+        "floorAreaRate": {
+          "ref": "Double",
+          "min_occurs": 1
+        },
+        "maximumBuildingHeight": {
+          "ref": "Measure",
+          "min_occurs": 1
+        },
+        "setbackSize": {
+          "ref": "String",
+          "min_occurs": 1
+        }
+      }
+    },
+    "urf:SpecifiedDisasterPreventionBlockImprovementZone": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        },
+        "minimumSiteArea": {
+          "ref": "Measure",
+          "min_occurs": 1
+        },
+        "setbackSize": {
+          "ref": "String"
+        },
+        "minimumFrontageRate": {
+          "ref": "Double"
+        },
+        "minimumBuildingHeight": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:SpecifiedUrgentUrbanRenewalArea": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "developmentPolicy": {
+          "ref": "String"
+        },
+        "privateProject": {
+          "ref": {
+            "Named": "urf:PrivateUrbanRenewalProjectPlan"
+          },
+          "max_occurs": null
+        },
+        "specifiedArea": {
+          "ref": {
+            "Named": "urf:SpecifiedUrgentUrbanRenewalArea"
+          },
+          "max_occurs": null
+        },
+        "specialDistrict": {
+          "ref": {
+            "Named": "urf:SpecialUrbanRenaissanceDistrict"
+          },
+          "max_occurs": null
+        },
+        "developmentProject": {
+          "ref": {
+            "Named": "urf:GlobalHubCityDevelopmentProject"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "urf:SupplyFacility": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        },
+        "waterWorksAttribute": {
+          "ref": {
+            "Named": "urf:WaterWorksAttribute"
+          }
+        }
+      }
+    },
+    "urf:WaterWorksAttribute": {
+      "type": "Data",
+      "attributes": {
+        "startLocation": {
+          "ref": "String"
+        },
+        "endLocation": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:TelecommunicationFacility": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "width": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:TideFacility": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "width": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:TrafficFacility": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        },
+        "startLocation": {
+          "ref": "String"
+        },
+        "endLocation": {
+          "ref": "String"
+        },
+        "viaLocations": {
+          "ref": "String"
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "width": {
+          "ref": "Measure"
+        },
+        "urbanRoadAttribute": {
+          "ref": {
+            "Named": "urf:UrbanRoadAttribute"
+          }
+        },
+        "urbanRapidTransitRailroadAttribute": {
+          "ref": {
+            "Named": "urf:UrbanRapidTransitRailroadAttribute"
+          }
+        },
+        "parkingPlaceAttribute": {
+          "ref": {
+            "Named": "urf:ParkingPlaceAttribute"
+          }
+        },
+        "vehicleTerminalAttribute": {
+          "ref": {
+            "Named": "urf:VehicleTerminalAttribute"
+          }
+        }
+      }
+    },
+    "urf:UrbanRoadAttribute": {
+      "type": "Data",
+      "attributes": {
+        "routeTypeNumber": {
+          "ref": "Code"
+        },
+        "routeSizeNumber": {
+          "ref": "Code"
+        },
+        "routeSerialNumber": {
+          "ref": "String"
+        },
+        "roadType": {
+          "ref": "Code"
+        },
+        "numberOfLanes": {
+          "ref": "Integer"
+        },
+        "roadStructure": {
+          "ref": "String"
+        },
+        "structureType": {
+          "ref": "Code"
+        },
+        "crossType": {
+          "ref": "Code"
+        },
+        "trafficPlazas": {
+          "ref": "Code"
+        },
+        "structuralDetails": {
+          "ref": {
+            "Named": "urf:StructureDetails"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "urf:StructureDetails": {
+      "type": "Data",
+      "attributes": {
+        "startLocation": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "endLocation": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "viaLocations": {
+          "ref": "String"
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "structureType": {
+          "ref": "Code"
+        },
+        "minimumWidth": {
+          "ref": "Measure"
+        },
+        "maximumWidth": {
+          "ref": "Measure"
+        },
+        "standardWidth": {
+          "ref": "Measure"
+        },
+        "crossType": {
+          "ref": "Code"
+        }
+      }
+    },
+    "urf:UrbanRapidTransitRailroadAttribute": {
+      "type": "Data",
+      "attributes": {
+        "structureType": {
+          "ref": "Code"
+        },
+        "crossType": {
+          "ref": "Code"
+        },
+        "structuralDetails": {
+          "ref": {
+            "Named": "urf:StructureDetails"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "urf:ParkingPlaceAttribute": {
+      "type": "Data",
+      "attributes": {
+        "storeysAboveGround": {
+          "ref": "NonNegativeInteger",
+          "min_occurs": 1
+        },
+        "storeysBelowGround": {
+          "ref": "NonNegativeInteger",
+          "min_occurs": 1
+        }
+      }
+    },
+    "urf:VehicleTerminalAttribute": {
+      "type": "Data",
+      "attributes": {
+        "terminalType": {
+          "ref": "Code",
+          "min_occurs": 1
+        }
+      }
+    },
+    "urf:TreatmentFacility": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        },
+        "sewerSystemsAttribute": {
+          "ref": {
+            "Named": "urf:SewerSystemAttribute"
+          }
+        }
+      }
+    },
+    "urf:SewerSystemAttribute": {
+      "type": "Data",
+      "attributes": {
+        "startLocation": {
+          "ref": "String"
+        },
+        "endLocation": {
+          "ref": "String"
+        },
+        "systemType": {
+          "ref": "Code"
+        },
+        "drainageArea": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:TreePlantingDistrict": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        },
+        "minimumGreeningRate": {
+          "ref": "Double",
+          "min_occurs": 1
+        }
+      }
+    },
+    "urf:UnclassifiedBlankArea": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:UnclassifiedUseDistrict": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:UnusedLandUsePromotionArea": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:UrbanDevelopmentProject": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "scheduledExecutor": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:UrbanDisasterRecoveryPromotionArea": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "expirationDate": {
+          "ref": "Date",
+          "min_occurs": 1
+        },
+        "emergencyRecoveryPolicy": {
+          "ref": "String"
+        },
+        "plannedProjectType": {
+          "ref": "Code"
+        }
+      }
+    },
+    "urf:UrbanFacility": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "urf:UrbanFacilityStipulatedByCabinetOrder": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "width": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:UrbanFunctionAttractionArea": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:UrbanPlanningArea": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaClassification": {
+          "ref": "Code",
+          "min_occurs": 1
+        },
+        "reasonForAreaClassification": {
+          "ref": "String"
+        },
+        "policyForAreaClassification": {
+          "ref": "String"
+        },
+        "purposeForUrbanPlan": {
+          "ref": "String"
+        },
+        "policyForUrbanPlanDecision": {
+          "ref": "String"
+        },
+        "population": {
+          "ref": "Integer"
+        },
+        "cityArea": {
+          "ref": "Measure"
+        },
+        "cityPopulation": {
+          "ref": "Integer"
+        }
+      }
+    },
+    "urf:UrbanRedevelopmentProject": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "scheduledExecutor": {
+          "ref": "String"
+        },
+        "publicFacilityAllocation": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "developmentPlan": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "housingTarget": {
+          "ref": "String"
+        },
+        "siteArea": {
+          "ref": "Measure"
+        },
+        "totalFloorArea": {
+          "ref": "Measure"
+        },
+        "numberOfHousing": {
+          "ref": "Integer"
+        }
+      }
+    },
+    "urf:UrbanRedevelopmentPromotionArea": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "developmentPolicy": {
+          "ref": "String"
+        },
+        "publicFacilitiesPlans": {
+          "ref": "String"
+        },
+        "publicFacilities": {
+          "ref": "String",
+          "min_occurs": 1
+        },
+        "unitArea": {
+          "ref": "String",
+          "min_occurs": 1
+        }
+      }
+    },
+    "urf:UrbanRenewalProject": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "scheduledExecutor": {
+          "ref": "String"
+        },
+        "storeysAboveGround": {
+          "ref": "NonNegativeInteger"
+        },
+        "storeysBelowGround": {
+          "ref": "NonNegativeInteger"
+        },
+        "setbackSize": {
+          "ref": "String"
+        },
+        "floorAreaRate": {
+          "ref": "Double"
+        },
+        "buildingUsage": {
+          "ref": "String"
+        },
+        "siteArea": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:UrgentUrbanRenewalArea": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "developmentPolicy": {
+          "ref": "String"
+        },
+        "privateProject": {
+          "ref": {
+            "Named": "urf:PrivateUrbanRenewalProjectPlan"
+          },
+          "max_occurs": null
+        },
+        "specifiedArea": {
+          "ref": {
+            "Named": "urf:SpecifiedUrgentUrbanRenewalArea"
+          },
+          "max_occurs": null
+        },
+        "specialDistrict": {
+          "ref": {
+            "Named": "urf:SpecialUrbanRenaissanceDistrict"
+          },
+          "max_occurs": null
+        }
+      }
+    },
+    "urf:UseDistrict": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        },
+        "floorAreaRate": {
+          "ref": "Double",
+          "min_occurs": 1
+        },
+        "minimumSiteArea": {
+          "ref": "Measure"
+        },
+        "buildingCoverageRate": {
+          "ref": "Double"
+        },
+        "wallSetbackDistance": {
+          "ref": "String"
+        },
+        "buildingHeightLimits": {
+          "ref": "Measure"
+        },
+        "buildingRestrictions": {
+          "ref": "String"
+        },
+        "otherRestrictions": {
+          "ref": "String"
+        },
+        "setbackRestrictions": {
+          "ref": "String"
+        },
+        "frontRoadRestrictions": {
+          "ref": "String"
+        },
+        "adjacentLandRestrictions": {
+          "ref": "String"
+        },
+        "northDirectionRestrictions": {
+          "ref": "String"
+        },
+        "shadeRegulation": {
+          "ref": "String"
+        }
+      }
+    },
+    "urf:Waterway": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        },
+        "startLocation": {
+          "ref": "String"
+        },
+        "endLocation": {
+          "ref": "String"
+        },
+        "structure": {
+          "ref": "Code"
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "width": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:WindProtectionFacility": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "number": {
+          "ref": "String"
+        },
+        "threeDimensionalExtent": {
+          "ref": {
+            "Named": "urf:ThreeDimensionalExtent"
+          },
+          "max_occurs": null
+        },
+        "length": {
+          "ref": "Measure"
+        },
+        "width": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "urf:ZoneForPreservationOfHistoricalLandscape": {
+      "type": "Feature",
+      "attributes": {
+        "description": {
+          "ref": "String"
+        },
+        "name": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "creationDate": {
+          "ref": "Date"
+        },
+        "terminationDate": {
+          "ref": "Date"
+        },
+        "genericAttribute": {
+          "ref": {
+            "Named": "gen:genericAttribute"
+          }
+        },
+        "class": {
+          "ref": "Code"
+        },
+        "function": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "usage": {
+          "ref": "Code",
+          "max_occurs": null
+        },
+        "validFrom": {
+          "ref": "Date"
+        },
+        "validFromType": {
+          "ref": "Code"
+        },
+        "enactmentFiscalYear": {
+          "ref": "String"
+        },
+        "validTo": {
+          "ref": "Date"
+        },
+        "validToType": {
+          "ref": "Code"
+        },
+        "expirationFiscalYear": {
+          "ref": "String"
+        },
+        "legalGrounds": {
+          "ref": "String"
+        },
+        "custodian": {
+          "ref": "String"
+        },
+        "notificationNumber": {
+          "ref": "String"
+        },
+        "finalNotificationDate": {
+          "ref": "Date"
+        },
+        "finalNotificationNumber": {
+          "ref": "String"
+        },
+        "urbanPlanType": {
+          "ref": "Code"
+        },
+        "areaClassificationType": {
+          "ref": "Code"
+        },
+        "nominalArea": {
+          "ref": "Measure"
+        },
+        "prefecture": {
+          "ref": "Code"
+        },
+        "city": {
+          "ref": "Code"
+        },
+        "reference": {
+          "ref": "URI"
+        },
+        "reason": {
+          "ref": "String"
+        },
+        "note": {
+          "ref": "String"
+        },
+        "surveyYear": {
+          "ref": "String"
+        },
+        "boundary": {
+          "ref": {
+            "Named": "urf:Boundary"
+          },
+          "max_occurs": null
+        },
+        "location": {
+          "ref": "String"
+        },
+        "areaInTotal": {
+          "ref": "Measure"
+        }
+      }
+    },
+    "_:TopLevelFeatureProperty": {
+      "type": "Property",
+      "members": [
+        {
+          "ref": {
+            "Named": "bldg:Building"
+          }
+        },
+        {
+          "ref": {
+            "Named": "tran:Road"
+          }
+        },
+        {
+          "ref": {
+            "Named": "tran:Railway"
+          }
+        },
+        {
+          "ref": {
+            "Named": "tran:Track"
+          }
+        },
+        {
+          "ref": {
+            "Named": "tran:Square"
+          }
+        },
+        {
+          "ref": {
+            "Named": "brid:Bridge"
+          }
+        },
+        {
+          "ref": {
+            "Named": "frn:CityFurniture"
+          }
+        },
+        {
+          "ref": {
+            "Named": "veg:SolitaryVegetationObject"
+          }
+        },
+        {
+          "ref": {
+            "Named": "veg:PlantCover"
+          }
+        },
+        {
+          "ref": {
+            "Named": "luse:LandUse"
+          }
+        },
+        {
+          "ref": {
+            "Named": "tun:Tunnel"
+          }
+        },
+        {
+          "ref": {
+            "Named": "dem:ReliefFeature"
+          }
+        },
+        {
+          "ref": {
+            "Named": "wtr:WaterBody"
+          }
+        },
+        {
+          "ref": {
+            "Named": "gen:GenericCityObject"
+          }
+        },
+        {
+          "ref": {
+            "Named": "grp:CityObjectGroup"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:Waterway"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:OtherConstruction"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:UndergroundBuilding"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:Appurtenance"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:Cable"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:Duct"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:ElectricityCable"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:Handhole"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:Manhole"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:OilGasChemicalsPipe"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:Pipe"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:SewerPipe"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:TelecommunicationsCable"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:ThermalPipe"
+          }
+        },
+        {
+          "ref": {
+            "Named": "uro:WaterPipe"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:Zone"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:Agreement"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:AircraftNoiseControlZone"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:AreaClassification"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:CollectiveFacilitiesForReconstruction"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:CollectiveFacilitiesForReconstructionAndRevitalization"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:CollectiveFacilitiesForTsunamiDisasterPrevention"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:CollectiveGovernmentAndPublicOfficeFacilities"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:CollectiveHousingFacilities"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:CollectiveUrbanDisasterPreventionFacilities"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:ConservationZoneForClustersOfTraditionalStructures"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:DisasterPreventionBlockImprovementProject"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:DisasterPreventionBlockImprovementZonePlan"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:DistributionBusinessPark"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:DistributionBusinessZone"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:District"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:DistrictDevelopmentPlan"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:DistrictFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:DistrictImprovementPlanForDisasterPreventionBlockImprovementZonePlan"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:DistrictImprovementPlanForHistoricSceneryMaintenanceAndImprovementDistrict"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:DistrictPlan"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:DistrictsAndZones"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:EducationalAndCulturalFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:ExceptionalFloorAreaRateDistrict"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:FirePreventionDistrict"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:FireProtectionFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:FloodPreventionFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:GlobalHubCityDevelopmentProject"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:GreenSpaceConservationDistrict"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:HeightControlDistrict"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:HighLevelUseDistrict"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:HighRiseResidentialAttractionDistrict"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:HistoricSceneryMaintenanceAndImprovementDistrictPlan"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:HousingControlArea"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:IndustrialParkDevelopmentProject"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:LandReadjustmentProject"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:LandReadjustmentPromotionArea"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:LandReadjustmentPromotionAreasForCoreBusinessUrbanDevelopment"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:LandscapeZone"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:MarketsSlaughterhousesCrematoria"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:MedicalFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:NewHousingAndUrbanDevelopmentProject"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:NewUrbanInfrastructureProject"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:OpenSpaceForPublicUse"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:ParkingPlaceDevelopmentZone"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:PortZone"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:PrivateUrbanRenewalProjectPlan"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:ProductiveGreenZone"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:ProjectPromotionArea"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:PromotionDistrict"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:QuasiUrbanPlanningArea"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:Regulation"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:ResidenceAttractionArea"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:ResidentialBlockConstructionProject"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:ResidentialBlockConstructionPromotionArea"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:ResidentialEnvironmentImprovementDistrict"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:RoadsideDistrictFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:RoadsideDistrictImprovementPlan"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:RoadsideDistrictPlan"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:RuralDistrictFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:RuralDistrictImprovementPlan"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:RuralDistrictPlan"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:SandControlFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:ScenicDistrict"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:ScheduledAreaForCollectiveGovernmentAndPublicOfficeFacilities"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:ScheduledAreaForCollectiveHousingFacilities"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:ScheduledAreaForDistributionBusinessPark"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:ScheduledAreaForIndustrialParkDevelopmentProjects"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:ScheduledAreaForNewHousingAndUrbanDevelopmentProjects"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:ScheduledAreaForNewUrbanInfrastructureProjects"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:ScheduledAreaForUrbanDevelopmentProject"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:SedimentDisasterProneArea"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:SnowProtectionFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:SocialWelfareFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:SpecialGreenSpaceConservationDistrict"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:SpecialUrbanRenaissanceDistrict"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:SpecialUseAttractionDistrict"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:SpecialUseDistrict"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:SpecialUseRestrictionDistrict"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:SpecialZoneForPreservationOfHistoricalLandscape"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:SpecifiedBlock"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:SpecifiedBuildingZoneImprovementPlan"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:SpecifiedDisasterPreventionBlockImprovementZone"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:SpecifiedUrgentUrbanRenewalArea"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:SupplyFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:TelecommunicationFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:TideFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:TrafficFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:TreatmentFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:TreePlantingDistrict"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:UnclassifiedBlankArea"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:UnclassifiedUseDistrict"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:UnusedLandUsePromotionArea"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:UrbanDevelopmentProject"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:UrbanDisasterRecoveryPromotionArea"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:UrbanFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:UrbanFacilityStipulatedByCabinetOrder"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:UrbanFunctionAttractionArea"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:UrbanPlanningArea"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:UrbanRedevelopmentProject"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:UrbanRedevelopmentPromotionArea"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:UrbanRenewalProject"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:UrgentUrbanRenewalArea"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:UseDistrict"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:Waterway"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:WindProtectionFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:ZonalDisasterPreventionFacility"
+          }
+        },
+        {
+          "ref": {
+            "Named": "urf:ZoneForPreservationOfHistoricalLandscape"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/nusamai/src/main.rs
+++ b/nusamai/src/main.rs
@@ -9,11 +9,11 @@ use nusamai::sink::{
     gpkg::GpkgSinkProvider, mvt::MVTSinkProvider, noop::NoopSinkProvider, serde::SerdeSinkProvider,
 };
 use nusamai::sink::{DataSink, DataSinkProvider};
-use nusamai::source::citygml::CityGMLSourceProvider;
+use nusamai::source::citygml::CityGmlSourceProvider;
 use nusamai::source::{DataSource, DataSourceProvider};
 use nusamai::transformer::builder::{NusamaiTransformBuilder, TransformBuilder};
 use nusamai::transformer::runner::MultiThreadTransformer;
-use nusamai_citygml::CityGMLElement;
+use nusamai_citygml::CityGmlElement;
 use nusamai_plateau::models::TopLevelCityObject;
 
 #[derive(clap::Parser)]
@@ -92,7 +92,7 @@ fn main() {
     }
 
     let source = {
-        let source_provider: Box<dyn DataSourceProvider> = Box::new(CityGMLSourceProvider {
+        let source_provider: Box<dyn DataSourceProvider> = Box::new(CityGmlSourceProvider {
             filenames: args.filenames,
         });
         let mut source_params = source_provider.parameters();

--- a/nusamai/src/parameters/mod.rs
+++ b/nusamai/src/parameters/mod.rs
@@ -14,7 +14,7 @@ macro_rules! get_parameter_value {
         let ParameterType::$param_type(inner) = &entry.parameter else {
             unreachable!();
         };
-        inner.value.as_ref()
+        &inner.value
     }};
 }
 
@@ -116,6 +116,7 @@ impl ParameterEntry {
         match &self.parameter {
             ParameterType::FileSystemPath(p) => p.validate(self.required),
             ParameterType::String(p) => p.validate(self.required),
+            ParameterType::Boolean(p) => p.validate(self.required),
         }
     }
 
@@ -124,6 +125,7 @@ impl ParameterEntry {
         match &mut self.parameter {
             ParameterType::FileSystemPath(p) => p.update_value_with_str(s),
             ParameterType::String(p) => p.update_value_with_str(s),
+            ParameterType::Boolean(p) => p.update_value_with_str(s),
         }
     }
 
@@ -132,6 +134,7 @@ impl ParameterEntry {
         match &mut self.parameter {
             ParameterType::FileSystemPath(p) => p.update_value_with_json(v),
             ParameterType::String(p) => p.update_value_with_json(v),
+            ParameterType::Boolean(p) => p.update_value_with_json(v),
         }
     }
 }
@@ -140,6 +143,7 @@ impl ParameterEntry {
 pub enum ParameterType {
     FileSystemPath(FileSystemPathParameter),
     String(StringParameter),
+    Boolean(BooleanParameter),
     // and so on ...
 }
 
@@ -203,6 +207,41 @@ impl StringParameter {
     pub fn update_value_with_json(&mut self, v: &serde_json::Value) -> Result<(), Error> {
         if let serde_json::Value::String(s) = v {
             self.value = Some(s.clone());
+            Ok(())
+        } else {
+            Err(Error::InvalidValue("Invalid value type.".into()))
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct BooleanParameter {
+    pub value: Option<bool>,
+}
+
+impl BooleanParameter {
+    pub fn validate(&self, required: bool) -> Result<(), Error> {
+        if required {
+            match &self.value {
+                Some(_) => Ok(()),
+                _ => Err(Error::RequiredValueNotProvided),
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn update_value_with_str(&mut self, s: &str) -> Result<(), Error> {
+        let Ok(v) = s.parse::<bool>() else {
+            return Err(Error::InvalidValue("Invalid value type.".into()));
+        };
+        self.value = Some(v);
+        Ok(())
+    }
+
+    pub fn update_value_with_json(&mut self, v: &serde_json::Value) -> Result<(), Error> {
+        if let &serde_json::Value::Bool(s) = v {
+            self.value = Some(s);
             Ok(())
         } else {
             Err(Error::InvalidValue("Invalid value type.".into()))

--- a/nusamai/src/sink/geojson/mod.rs
+++ b/nusamai/src/sink/geojson/mod.rs
@@ -47,7 +47,7 @@ impl DataSinkProvider for GeoJsonSinkProvider {
         let output_path = get_parameter_value!(params, "@output", FileSystemPath);
 
         Box::<GeoJsonSink>::new(GeoJsonSink {
-            output_path: output_path.unwrap().into(),
+            output_path: output_path.as_ref().unwrap().into(),
         })
     }
 }

--- a/nusamai/src/sink/geojson_transform_exp/mod.rs
+++ b/nusamai/src/sink/geojson_transform_exp/mod.rs
@@ -50,7 +50,7 @@ impl DataSinkProvider for GeoJsonTransformExpSinkProvider {
         let output_path = get_parameter_value!(params, "@output", FileSystemPath);
 
         Box::<GeoJsonTfExpSink>::new(GeoJsonTfExpSink {
-            output_path: output_path.unwrap().into(),
+            output_path: output_path.as_ref().unwrap().into(),
         })
     }
 }

--- a/nusamai/src/sink/geojson_transform_exp/transform.rs
+++ b/nusamai/src/sink/geojson_transform_exp/transform.rs
@@ -161,7 +161,7 @@ fn flatten(
                         };
 
                         if do_flatten {
-                            for mut value in child_arr.drain(..) {
+                            for mut value in child_arr {
                                 flatten(&mut value, do_flatten_feature, do_flatten_data, out);
                                 out.push(value);
                             }

--- a/nusamai/src/sink/gpkg/mod.rs
+++ b/nusamai/src/sink/gpkg/mod.rs
@@ -42,10 +42,10 @@ impl DataSinkProvider for GpkgSinkProvider {
     }
 
     fn create(&self, params: &Parameters) -> Box<dyn DataSink> {
-        let output_path = get_parameter_value!(params, "@output", FileSystemPath).unwrap();
+        let output_path = get_parameter_value!(params, "@output", FileSystemPath);
 
         Box::<GpkgSink>::new(GpkgSink {
-            output_path: output_path.clone(),
+            output_path: output_path.as_ref().unwrap().into(),
         })
     }
 }

--- a/nusamai/src/sink/mvt/mod.rs
+++ b/nusamai/src/sink/mvt/mod.rs
@@ -61,7 +61,7 @@ impl DataSinkProvider for MVTSinkProvider {
         let output_path = get_parameter_value!(params, "@output", FileSystemPath);
 
         Box::<MVTSink>::new(MVTSink {
-            output_path: output_path.unwrap().into(),
+            output_path: output_path.as_ref().unwrap().into(),
         })
     }
 }

--- a/nusamai/src/sink/noop/mod.rs
+++ b/nusamai/src/sink/noop/mod.rs
@@ -2,17 +2,25 @@
 //!
 //! This is a demo sync that only counts the number of features and vertices and does not generate any output.
 
+use std::io::Write;
+
 use nusamai_citygml::schema::Schema;
 
-use crate::parameters::{FileSystemPathParameter, ParameterEntry, ParameterType, Parameters};
+use crate::parameters::{
+    BooleanParameter, FileSystemPathParameter, ParameterEntry, ParameterType, Parameters,
+};
 use crate::pipeline::{Feedback, Receiver};
 use crate::sink::{DataSink, DataSinkProvider, SinkInfo};
+
+use crate::get_parameter_value;
 
 pub struct NoopSinkProvider {}
 
 impl DataSinkProvider for NoopSinkProvider {
-    fn create(&self, _params: &Parameters) -> Box<dyn DataSink> {
+    fn create(&self, params: &Parameters) -> Box<dyn DataSink> {
+        let write_schema = get_parameter_value!(params, "schema", Boolean);
         Box::new(NoopSink {
+            write_schema: write_schema.unwrap_or_default(),
             num_features: 0,
             num_vertices: 0,
         })
@@ -37,17 +45,32 @@ impl DataSinkProvider for NoopSinkProvider {
                 }),
             },
         );
+        params.define(
+            "schema".into(),
+            ParameterEntry {
+                description: "Output schema file".into(),
+                required: false,
+                parameter: ParameterType::Boolean(BooleanParameter { value: None }),
+            },
+        );
         params
     }
 }
 
 pub struct NoopSink {
+    write_schema: bool,
     num_features: usize,
     num_vertices: usize,
 }
 
 impl DataSink for NoopSink {
-    fn run(&mut self, upstream: Receiver, feedback: &Feedback, _schema: &Schema) {
+    fn run(&mut self, upstream: Receiver, feedback: &Feedback, schema: &Schema) {
+        if self.write_schema {
+            let mut file = std::fs::File::create("schema.json").unwrap();
+            file.write_all(serde_json::to_string_pretty(schema).unwrap().as_bytes())
+                .unwrap();
+        }
+
         for parcel in upstream {
             if feedback.is_cancelled() {
                 log::info!("sink cancelled");

--- a/nusamai/src/sink/serde/mod.rs
+++ b/nusamai/src/sink/serde/mod.rs
@@ -44,7 +44,7 @@ impl DataSinkProvider for SerdeSinkProvider {
         let output_path = get_parameter_value!(params, "@output", FileSystemPath);
 
         Box::<SerdeSink>::new(SerdeSink {
-            output_path: output_path.unwrap().into(),
+            output_path: output_path.as_ref().unwrap().into(),
             ..Default::default()
         })
     }

--- a/nusamai/src/source/citygml.rs
+++ b/nusamai/src/source/citygml.rs
@@ -12,16 +12,16 @@ use crate::parameters::Parameters;
 use crate::pipeline::{Feedback, Parcel, Sender};
 use crate::source::{DataSource, DataSourceProvider, SourceInfo};
 use nusamai_citygml::object::Entity;
-use nusamai_citygml::{CityGMLElement, CityGMLReader, ParseError, SubTreeReader};
+use nusamai_citygml::{CityGmlElement, CityGmlReader, ParseError, SubTreeReader};
 
-pub struct CityGMLSourceProvider {
+pub struct CityGmlSourceProvider {
     // FIXME: Use the configuration mechanism
     pub filenames: Vec<String>,
 }
 
-impl DataSourceProvider for CityGMLSourceProvider {
+impl DataSourceProvider for CityGmlSourceProvider {
     fn create(&self, _params: &Parameters) -> Box<dyn DataSource> {
-        Box::new(CityGMLSource {
+        Box::new(CityGmlSource {
             filenames: self.filenames.clone(),
         })
     }
@@ -37,11 +37,11 @@ impl DataSourceProvider for CityGMLSourceProvider {
     }
 }
 
-pub struct CityGMLSource {
+pub struct CityGmlSource {
     filenames: Vec<String>,
 }
 
-impl DataSource for CityGMLSource {
+impl DataSource for CityGmlSource {
     fn run(&mut self, downstream: Sender, feedback: &Feedback) {
         let code_resolver = nusamai_plateau::codelist::Resolver::new();
 
@@ -56,7 +56,7 @@ impl DataSource for CityGMLSource {
                 Url::from_file_path(fs::canonicalize(Path::new(filename)).unwrap()).unwrap();
 
             let context = nusamai_citygml::ParseContext::new(source_url, &code_resolver);
-            let mut citygml_reader = CityGMLReader::new(context);
+            let mut citygml_reader = CityGmlReader::new(context);
 
             match citygml_reader.start_root(&mut xml_reader) {
                 Ok(mut st) => match toplevel_dispatcher(&mut st, &downstream, feedback) {

--- a/nusamai/src/transformer/builder.rs
+++ b/nusamai/src/transformer/builder.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use nusamai_citygml::schema::Schema;
-use nusamai_projection::vshift::JGD2011ToWGS84;
+use nusamai_projection::vshift::Jgd2011ToWgs84;
 
 use super::{
-    transform::{ProjectionTransform, SerialTransform},
+    transform::{NamespaceRemovalTransform, ProjectionTransform, SerialTransform},
     Transform,
 };
 
@@ -17,7 +17,7 @@ pub trait TransformBuilder: Send + Sync {
 }
 
 pub struct NusamaiTransformBuilder {
-    jgd2wgs: Arc<JGD2011ToWGS84>,
+    jgd2wgs: Arc<Jgd2011ToWgs84>,
 }
 
 impl TransformBuilder for NusamaiTransformBuilder {
@@ -25,6 +25,7 @@ impl TransformBuilder for NusamaiTransformBuilder {
         let mut transforms = SerialTransform::default();
         // TODO: build transforming graph from config
         transforms.push(Box::new(ProjectionTransform::new(self.jgd2wgs.clone())));
+        transforms.push(Box::<NamespaceRemovalTransform>::default());
         Box::new(transforms)
     }
 }
@@ -32,7 +33,7 @@ impl TransformBuilder for NusamaiTransformBuilder {
 impl Default for NusamaiTransformBuilder {
     fn default() -> Self {
         Self {
-            jgd2wgs: JGD2011ToWGS84::default().into(),
+            jgd2wgs: Jgd2011ToWgs84::default().into(),
         }
     }
 }

--- a/nusamai/src/transformer/transform/attr_key.rs
+++ b/nusamai/src/transformer/transform/attr_key.rs
@@ -1,0 +1,42 @@
+use crate::transformer::Transform;
+
+use indexmap::map::MutableKeys;
+use nusamai_citygml::object::Entity;
+use nusamai_citygml::schema::Schema;
+use nusamai_citygml::schema::TypeDef;
+
+/// Transform to remove the namespace prefix from the attribute name.
+///
+/// e.g) bldg:measuredHeight -> measuredHeight
+#[derive(Default)]
+pub struct NamespaceRemovalTransform {}
+
+impl Transform for NamespaceRemovalTransform {
+    fn transform(&mut self, mut entity: Entity, out: &mut Vec<Entity>) {
+        entity.root.traverse_object_mut(|obj| {
+            obj.attributes.retain2(|key, _| {
+                if let Some(pos) = key.find(':') {
+                    *key = key[pos + 1..].to_string();
+                }
+                true
+            });
+        });
+        out.push(entity);
+    }
+
+    fn transform_schema(&self, schema: &mut Schema) {
+        for ty in schema.types.values_mut() {
+            let atrs = match ty {
+                TypeDef::Data(data) => &mut data.attributes,
+                TypeDef::Feature(feat) => &mut feat.attributes,
+                TypeDef::Property(_) => continue,
+            };
+            atrs.retain2(|key, _| {
+                if let Some(pos) = key.find(':') {
+                    *key = key[pos + 1..].to_string();
+                }
+                true
+            });
+        }
+    }
+}

--- a/nusamai/src/transformer/transform/projection.rs
+++ b/nusamai/src/transformer/transform/projection.rs
@@ -5,10 +5,10 @@ use crate::transformer::Transform;
 use nusamai_citygml::object::Entity;
 use nusamai_citygml::schema::Schema;
 use nusamai_projection::crs::*;
-use nusamai_projection::vshift::JGD2011ToWGS84;
+use nusamai_projection::vshift::Jgd2011ToWgs84;
 
 pub struct ProjectionTransform {
-    jgd2wgs: Arc<JGD2011ToWGS84>,
+    jgd2wgs: Arc<Jgd2011ToWgs84>,
 }
 
 impl Transform for ProjectionTransform {
@@ -38,7 +38,7 @@ impl Transform for ProjectionTransform {
 }
 
 impl ProjectionTransform {
-    pub fn new(jgd2wgs: Arc<JGD2011ToWGS84>) -> Self {
+    pub fn new(jgd2wgs: Arc<Jgd2011ToWgs84>) -> Self {
         Self { jgd2wgs }
     }
 }

--- a/nusamai/tests/sink.rs
+++ b/nusamai/tests/sink.rs
@@ -1,15 +1,15 @@
 use nusamai::sink::DataSinkProvider;
-use nusamai::source::citygml::CityGMLSourceProvider;
+use nusamai::source::citygml::CityGmlSourceProvider;
 use nusamai::source::DataSourceProvider;
 use nusamai::transformer::builder::{NusamaiTransformBuilder, TransformBuilder};
 use nusamai::transformer::runner::MultiThreadTransformer;
 
 use nusamai::sink;
-use nusamai_citygml::CityGMLElement;
+use nusamai_citygml::CityGmlElement;
 use nusamai_plateau::models::TopLevelCityObject;
 
 pub(crate) fn simple_run_sink<S: DataSinkProvider>(sink_provider: S, output: Option<&str>) {
-    let source_provider: Box<dyn DataSourceProvider> = Box::new(CityGMLSourceProvider {
+    let source_provider: Box<dyn DataSourceProvider> = Box::new(CityGmlSourceProvider {
         filenames: vec![
             "../nusamai-plateau/tests/data/plateau-3_0/udx/rwy/53395518_rwy_6697.gml".to_string(),
             "../nusamai-plateau/tests/data/plateau-3_0/udx/brid/51324378_brid_6697.gml".to_string(),


### PR DESCRIPTION
Transform のテスト実装として、属性名から名前空間のプリフィックスを除去するだけの Transform を設けました。

`bldg:measuredHeight` -> `measuredHeight` のように変換します。パイプラインを流れるデータ (Entity) だけでなく、Schema 情報の属性名も変更します。

種々のリファクタリングを兼ねてしまっているため、コードの変更箇所が膨大になっています。重要なものは `nusamai/src/transformer/transform/attr_key.rs` だけです。
