### PR TITLE
schema: JSON String であることを示せるようにする

### DIFF
--- a/nusamai-citygml/src/schema.rs
+++ b/nusamai-citygml/src/schema.rs
@@ -76,11 +76,14 @@ pub enum TypeRef {
     NonNegativeInteger,
     Double,
     Boolean,
+    /// String containing a valid JSON.
+    JsonString,
     URI,
     Date,
     DataTime,
     Measure,
     Point,
+    /// Reference to a user type defined in the schema.
     Named(String),
 }
 


### PR DESCRIPTION
一部のデータを Jsonify するケースのために、スキーマ情報の型の一種として JsonString を設けるだけです。

Closes #215