### PR TITLE
gpkg: GeometryRefを用いたジオメトリ出力

### DIFF
--- a/nusamai/src/sink/gpkg/mod.rs
+++ b/nusamai/src/sink/gpkg/mod.rs
@@ -11,7 +11,7 @@ use crate::pipeline::{Feedback, Receiver};
 use crate::sink::{DataSink, DataSinkProvider, SinkInfo};
 use crate::{get_parameter_value, transformer};
 
-use nusamai_citygml::object::{Entity, ObjectStereotype, Value};
+use nusamai_citygml::object::{ObjectStereotype, Value};
 use nusamai_citygml::schema::Schema;
 use nusamai_citygml::GeometryType;
 use nusamai_gpkg::geometry::write_indexed_multipolygon;


### PR DESCRIPTION
close #224

GeoJSON（ #222 ）, Shapefile（ #214 ）での例と同様。


処理の関数への切り出しなどは、このPRでは行なっていない、あくまで従来処理からミニマルに変更してGeometryRefを使うようにしている。