### PR TITLE
アプリへ「Shapefile形式」オプションを追加

### DIFF
--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -8,7 +8,7 @@ use nusamai::pipeline::Canceller;
 use nusamai::sink::DataSinkProvider;
 use nusamai::sink::{
     geojson::GeoJsonSinkProvider, gpkg::GpkgSinkProvider, mvt::MVTSinkProvider,
-    serde::SerdeSinkProvider,
+    serde::SerdeSinkProvider, shapefile::ShapefileSinkProvider,
 };
 use nusamai::source::citygml::CityGmlSourceProvider;
 use nusamai::source::DataSourceProvider;
@@ -56,6 +56,7 @@ fn run(input_paths: Vec<String>, output_path: String, filetype: String) {
             "GeoPackage" => Box::new(GpkgSinkProvider {}),
             "Serde" => Box::new(SerdeSinkProvider {}),
             "Vector Tiles" => Box::new(MVTSinkProvider {}),
+            "Shapefile" => Box::new(ShapefileSinkProvider {}),
             _ => {
                 log::error!("Unknown filetype: {}", filetype);
                 return;

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -1,4 +1,4 @@
-const fileTypeOptions = ['GeoJSON', 'GeoPackage', 'Serde', 'Vector Tiles'];
+const fileTypeOptions = ['GeoJSON', 'GeoPackage', 'Serde', 'Vector Tiles', 'Shapefile'];
 
 const crsOptions = [
 	{ value: 'EPSG:6678', label: 'JGD2011 / Japan Plane Rectangular CS X' },


### PR DESCRIPTION
3行、変更しただけです！

- #214 で作成したShapefile Sinkを、Tauri側で選択できるようにする
- 選択肢の扱い方の整理などは別途検討 #138

<img width="629" alt="image" src="https://github.com/MIERUNE/nusamai/assets/595008/5b7e7515-22b2-43df-a106-3e43bcf204dc">
