### PR TITLE
Fix(plateau): uro まわりの属性の多重度をいくつか修正

### DIFF
--- a/nusamai-citygml/macros/src/type_attrs.rs
+++ b/nusamai-citygml/macros/src/type_attrs.rs
@@ -130,7 +130,7 @@ fn modify(ty: &Stereotype, args: &FeatureArgs, input: &mut DeriveInput) -> Resul
                             fields,
                             quote! {
                                 #[citygml(geom = #geom_prefix)]
-                                pub geometries: ::nusamai_citygml::GeometryRef
+                                pub geometries: ::nusamai_citygml::GeometryRefs
                             },
                         );
                         pos += 1;

--- a/nusamai-citygml/src/geometry.rs
+++ b/nusamai-citygml/src/geometry.rs
@@ -32,7 +32,7 @@ pub enum GeometryType {
 
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub struct GeometryRefEntry {
+pub struct GeometryRef {
     #[serde(rename = "type")]
     pub ty: GeometryType,
     pub lod: u8,
@@ -40,7 +40,7 @@ pub struct GeometryRefEntry {
     pub len: u32,
 }
 
-pub type GeometryRef = Vec<GeometryRefEntry>;
+pub type GeometryRefs = Vec<GeometryRef>;
 
 /// Geometries in a single city object and all its children.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -52,11 +52,11 @@ pub struct GeometryStore {
     /// Shared vertex buffer for all geometries
     pub vertices: Vec<[f64; 3]>,
 
-    /// All polygons, referenced by `GeometryRef`
+    /// All polygons, referenced by `GeometryRefs`
     pub multipolygon: MultiPolygon<'static, 1, u32>,
-    /// All line-strings, referenced by `GeometryRef`
+    /// All line-strings, referenced by `GeometryRefs`
     pub multilinestring: MultiLineString<'static, 1, u32>,
-    /// All points, referenced by `GeometryRef`
+    /// All points, referenced by `GeometryRefs`
     pub multipoint: MultiPoint<'static, 1, u32>,
 
     /// Ring ids of the all polygons

--- a/nusamai-citygml/src/object.rs
+++ b/nusamai-citygml/src/object.rs
@@ -2,7 +2,7 @@
 
 use std::borrow::Cow;
 
-use crate::geometry::GeometryRef;
+use crate::geometry::GeometryRefs;
 use crate::values::{Code, Date, Point, URI};
 use crate::Measure;
 use serde::{Deserialize, Serialize};
@@ -19,8 +19,13 @@ pub struct Object {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum ObjectStereotype {
-    Feature { id: String, geometries: GeometryRef },
-    Object { id: String },
+    Feature {
+        id: String,
+        geometries: GeometryRefs,
+    },
+    Object {
+        id: String,
+    },
     Data,
 }
 

--- a/nusamai-citygml/src/parser.rs
+++ b/nusamai-citygml/src/parser.rs
@@ -11,8 +11,7 @@ use url::Url;
 use crate::appearance::{TexCoordList, TextureAssociation};
 use crate::codelist::{self, CodeResolver};
 use crate::geometry::{
-    GeometryCollector, GeometryParseType, GeometryRef, GeometryRefEntry, GeometryStore,
-    GeometryType,
+    GeometryCollector, GeometryParseType, GeometryRef, GeometryRefs, GeometryStore, GeometryType,
 };
 use crate::namespace::{wellknown_prefix_from_nsres, APP_2_NS, GML31_NS};
 use crate::{CityGmlAttribute, LocalId, SurfaceSpan};
@@ -323,7 +322,7 @@ impl<'b, R: BufRead> SubTreeReader<'_, 'b, R> {
     /// Expect a geometric attribute of CityGML
     pub fn parse_geometric_attr(
         &mut self,
-        geomref: &mut GeometryRef,
+        geomref: &mut GeometryRefs,
         lod: u8,
         geomtype: GeometryParseType,
     ) -> Result<(), ParseError> {
@@ -353,7 +352,7 @@ impl<'b, R: BufRead> SubTreeReader<'_, 'b, R> {
 
     fn parse_multi_surface_prop(
         &mut self,
-        geomrefs: &mut GeometryRef,
+        geomrefs: &mut GeometryRefs,
         lod: u8,
     ) -> Result<(), ParseError> {
         let mut surface_id = None;
@@ -388,7 +387,7 @@ impl<'b, R: BufRead> SubTreeReader<'_, 'b, R> {
 
                     let poly_end = self.state.geometry_collector.multipolygon.len();
                     if poly_end - poly_begin > 0 {
-                        geomrefs.push(GeometryRefEntry {
+                        geomrefs.push(GeometryRef {
                             ty: geomtype,
                             lod,
                             pos: poly_begin as u32,
@@ -423,14 +422,14 @@ impl<'b, R: BufRead> SubTreeReader<'_, 'b, R> {
 
     fn parse_surface_prop(
         &mut self,
-        geomrefs: &mut GeometryRef,
+        geomrefs: &mut GeometryRefs,
         lod: u8,
     ) -> Result<(), ParseError> {
         let poly_begin = self.state.geometry_collector.multipolygon.len();
         self.parse_surface()?;
         let poly_end = self.state.geometry_collector.multipolygon.len();
         if poly_end - poly_begin > 0 {
-            geomrefs.push(GeometryRefEntry {
+            geomrefs.push(GeometryRef {
                 ty: GeometryType::Surface,
                 lod,
                 pos: poly_begin as u32,
@@ -440,7 +439,7 @@ impl<'b, R: BufRead> SubTreeReader<'_, 'b, R> {
         Ok(())
     }
 
-    fn parse_solid_prop(&mut self, geomrefs: &mut GeometryRef, lod: u8) -> Result<(), ParseError> {
+    fn parse_solid_prop(&mut self, geomrefs: &mut GeometryRefs, lod: u8) -> Result<(), ParseError> {
         let poly_begin = self.state.geometry_collector.multipolygon.len();
 
         if expect_start(self.reader, &mut self.state.buf1, GML31_NS, b"Solid")? {
@@ -450,7 +449,7 @@ impl<'b, R: BufRead> SubTreeReader<'_, 'b, R> {
 
         let poly_end = self.state.geometry_collector.multipolygon.len();
         if poly_end - poly_begin > 0 {
-            geomrefs.push(GeometryRefEntry {
+            geomrefs.push(GeometryRef {
                 ty: GeometryType::Solid,
                 lod,
                 pos: poly_begin as u32,
@@ -462,7 +461,7 @@ impl<'b, R: BufRead> SubTreeReader<'_, 'b, R> {
 
     fn parse_geometry_prop(
         &mut self,
-        geomrefs: &mut GeometryRef,
+        geomrefs: &mut GeometryRefs,
         lod: u8,
     ) -> Result<(), ParseError> {
         let mut surface_id = None;
@@ -525,7 +524,7 @@ impl<'b, R: BufRead> SubTreeReader<'_, 'b, R> {
 
                     let poly_end = self.state.geometry_collector.multipolygon.len();
                     if poly_end - poly_begin > 0 {
-                        geomrefs.push(GeometryRefEntry {
+                        geomrefs.push(GeometryRef {
                             ty: geomtype,
                             lod,
                             pos: poly_begin as u32,
@@ -560,7 +559,7 @@ impl<'b, R: BufRead> SubTreeReader<'_, 'b, R> {
 
     fn parse_triangulated_prop(
         &mut self,
-        geomrefs: &mut GeometryRef,
+        geomrefs: &mut GeometryRefs,
         lod: u8,
     ) -> Result<(), ParseError> {
         let poly_begin = self.state.geometry_collector.multipolygon.len();
@@ -595,7 +594,7 @@ impl<'b, R: BufRead> SubTreeReader<'_, 'b, R> {
 
         let poly_end = self.state.geometry_collector.multipolygon.len();
         if poly_end - poly_begin > 0 {
-            geomrefs.push(GeometryRefEntry {
+            geomrefs.push(GeometryRef {
                 ty: GeometryType::Triangle,
                 lod,
                 pos: poly_begin as u32,

--- a/nusamai-plateau/src/models/bridge.rs
+++ b/nusamai-plateau/src/models/bridge.rs
@@ -44,7 +44,7 @@ pub struct Bridge {
     pub address: Vec<Address>,
 
     #[citygml(path = b"uro:bridBaseAttribute/uro:ConstructionBaseAttribute")]
-    pub brid_base_attribute: Vec<uro::ConstructionBaseAttribute>,
+    pub brid_base_attribute: Option<uro::ConstructionBaseAttribute>,
 
     #[citygml(path = b"uro:bridDataQualityAttribute/uro:ConstructionDataQualityAttribute")]
     pub brid_data_quality_attribute: Option<uro::ConstructionDataQualityAttribute>,
@@ -65,13 +65,13 @@ pub struct Bridge {
     pub brid_facility_type_attribute: Vec<uro::FacilityTypeAttribute>,
 
     #[citygml(path = b"uro:bridFunctionalAttribute/uro:BridgeFunctionalAttribute")]
-    pub brid_functional_attribute: Vec<uro::BridgeFunctionalAttribute>,
+    pub brid_functional_attribute: Option<uro::BridgeFunctionalAttribute>,
 
     #[citygml(path = b"uro:bridRiskAssessmentAttribute/uro:ConstructionRiskAssessmentAttribute")]
-    pub brid_risk_assessment_attribute: Vec<uro::ConstructionRiskAssessmentAttribute>,
+    pub brid_risk_assessment_attribute: Option<uro::ConstructionRiskAssessmentAttribute>,
 
     #[citygml(path = b"uro:bridStructureAttribute/uro:BridgeStructureAttribute")]
-    pub brid_structure_attribute: Vec<uro::BridgeStructureAttribute>,
+    pub brid_structure_attribute: Option<uro::BridgeStructureAttribute>,
 }
 
 #[citygml_feature(name = "brid:BridgePart")]
@@ -116,7 +116,7 @@ pub struct BridgePart {
     pub address: Vec<Address>,
 
     #[citygml(path = b"uro:bridBaseAttribute/uro:ConstructionBaseAttribute")]
-    pub brid_base_attribute: Vec<uro::ConstructionBaseAttribute>,
+    pub brid_base_attribute: Option<uro::ConstructionBaseAttribute>,
 
     #[citygml(path = b"uro:bridDataQualityAttribute/uro:ConstructionDataQualityAttribute")]
     pub brid_data_quality_attribute: Option<uro::ConstructionDataQualityAttribute>,
@@ -137,13 +137,13 @@ pub struct BridgePart {
     pub brid_facility_type_attribute: Vec<uro::FacilityTypeAttribute>,
 
     #[citygml(path = b"uro:bridFunctionalAttribute/uro:BridgeFunctionalAttribute")]
-    pub brid_functional_attribute: Vec<uro::BridgeFunctionalAttribute>,
+    pub brid_functional_attribute: Option<uro::BridgeFunctionalAttribute>,
 
     #[citygml(path = b"uro:bridRiskAssessmentAttribute/uro:ConstructionRiskAssessmentAttribute")]
-    pub brid_risk_assessment_attribute: Vec<uro::ConstructionRiskAssessmentAttribute>,
+    pub brid_risk_assessment_attribute: Option<uro::ConstructionRiskAssessmentAttribute>,
 
     #[citygml(path = b"uro:bridStructureAttribute/uro:BridgeStructureAttribute")]
-    pub brid_structure_attribute: Vec<uro::BridgeStructureAttribute>,
+    pub brid_structure_attribute: Option<uro::BridgeStructureAttribute>,
 }
 
 #[citygml_feature(name = "brid:BridgeConstructionElement")]

--- a/nusamai-plateau/src/models/building.rs
+++ b/nusamai-plateau/src/models/building.rs
@@ -83,7 +83,7 @@ pub struct Building {
     pub building_disaster_risk_attribute: Vec<uro::BuildingDisasterRiskAttributeProperty>, // -> uro:BuildingDisasterRiskAttribute
 
     #[citygml(path = b"uro:buildingIDAttribute/uro:BuildingIDAttribute")]
-    pub building_id_attribute: Vec<uro::BuildingIDAttribute>,
+    pub building_id_attribute: Option<uro::BuildingIDAttribute>,
 
     #[citygml(path = b"uro:ifcBuildingAttribute")]
     pub ifc_building_attribute: Vec<uro::IfcAttributeProperty>, // -> uro:IfcAttribute
@@ -176,7 +176,7 @@ pub struct BuildingPart {
     pub building_disaster_risk_attribute: Vec<uro::BuildingDisasterRiskAttributeProperty>, // -> uro:BuildingDisasterRiskAttribute
 
     #[citygml(path = b"uro:buildingIDAttribute/uro:BuildingIDAttribute")]
-    pub building_id_attribute: Vec<uro::BuildingIDAttribute>,
+    pub building_id_attribute: Option<uro::BuildingIDAttribute>,
 
     #[citygml(path = b"uro:ifcBuildingAttribute")]
     pub ifc_building_attribute: Vec<uro::IfcAttributeProperty>, // -> uro:IfcAttribute

--- a/nusamai-plateau/src/models/iur/uro/dm.rs
+++ b/nusamai-plateau/src/models/iur/uro/dm.rs
@@ -47,7 +47,7 @@ pub struct DmAnnotation {
 #[citygml_data(name = "uro:DmGeometricAttribute")]
 pub struct DmGeometricAttribute {
     #[citygml(geom = b"uro")]
-    pub geometries: nusamai_citygml::GeometryRef,
+    pub geometries: nusamai_citygml::GeometryRefs,
 
     #[citygml(path = b"uro:dmCode", required)]
     pub dm_code: Option<Code>,

--- a/nusamai-plateau/src/models/iur/uro/transportation.rs
+++ b/nusamai-plateau/src/models/iur/uro/transportation.rs
@@ -110,7 +110,7 @@ pub struct RoadType {
 #[citygml_data(name = "uro:RailwayTrackAttribute")]
 pub struct RailwayTrackAttribute {
     #[citygml(geom = b"uro")]
-    geometries: nusamai_citygml::GeometryRef,
+    geometries: nusamai_citygml::GeometryRefs,
 
     #[citygml(path = b"uro:routeName")]
     pub route_name: Option<String>,

--- a/nusamai-plateau/src/models/landuse.rs
+++ b/nusamai-plateau/src/models/landuse.rs
@@ -16,7 +16,7 @@ pub struct LandUse {
     pub ifc_land_use_attribute: Vec<uro::IfcAttributeProperty>, // -> uro:IfcAttribute
 
     #[citygml(path = b"uro:landUseDetailAttribute/uro:LandUseDetailAttribute")]
-    pub land_use_detail_attribute: Vec<uro::LandUseDetailAttribute>,
+    pub land_use_detail_attribute: Option<uro::LandUseDetailAttribute>,
 
     #[citygml(path = b"uro:luseDataQualityAttribute/uro:LandUseDataQualityAttribute")]
     pub luse_data_quality_attribute: Option<uro::LandUseDataQualityAttribute>,

--- a/nusamai-plateau/src/models/transportation.rs
+++ b/nusamai-plateau/src/models/transportation.rs
@@ -38,10 +38,10 @@ pub struct Road {
     pub road_status: Vec<uro::RoadType>,
 
     #[citygml(path = b"uro:roadStructureAttribute/uro:RoadStructureAttribute")]
-    pub road_structure_attribute: Vec<uro::RoadStructureAttribute>,
+    pub road_structure_attribute: Option<uro::RoadStructureAttribute>,
 
     #[citygml(path = b"uro:trafficVolumeAttribute/uro:TrafficVolumeAttribute")]
-    pub traffic_volume_attribute: Vec<uro::TrafficVolumeAttribute>,
+    pub traffic_volume_attribute: Option<uro::TrafficVolumeAttribute>,
 }
 
 #[citygml_feature(name = "tran:Railway")]
@@ -77,7 +77,7 @@ pub struct Railway {
     pub tran_facility_type_attribute: Vec<uro::FacilityTypeAttribute>,
 
     #[citygml(path = b"uro:railwayRouteAttribute/uro:RailwayRouteAttribute")]
-    pub railway_route_attribute: Vec<uro::RailwayRouteAttribute>,
+    pub railway_route_attribute: Option<uro::RailwayRouteAttribute>,
 }
 
 #[citygml_feature(name = "tran:Track")]
@@ -113,7 +113,7 @@ pub struct Track {
     pub tran_facility_type_attribute: Vec<uro::FacilityTypeAttribute>,
 
     #[citygml(path = b"uro:trackAttribute/uro:TrackAttribute")]
-    pub track_attribute: Vec<uro::TrackAttribute>,
+    pub track_attribute: Option<uro::TrackAttribute>,
 }
 
 #[citygml_feature(name = "tran:Square")]
@@ -149,7 +149,7 @@ pub struct Square {
     pub tran_facility_type_attribute: Vec<uro::FacilityTypeAttribute>,
 
     #[citygml(path = b"uro:squareUrbanPlanAttribute")]
-    pub square_urban_plan_attribute: Vec<uro::SquareUrbanPlanAttributeProperty>, // -> uro:SquareUrbanPlanAttribute
+    pub square_urban_plan_attribute: Option<uro::SquareUrbanPlanAttributeProperty>, // -> uro:SquareUrbanPlanAttribute
 }
 
 /// uro:Waterway (PLATEAU, CityGML 2.x)
@@ -211,7 +211,7 @@ pub struct TrafficArea {
     pub railway_track_attribute: Vec<uro::RailwayTrackAttribute>,
 
     #[citygml(path = b"uro:trafficAreaStructureAttribute/uro:TrafficAreaStructureAttribute")]
-    pub traffic_area_structure_attribute: Vec<uro::TrafficAreaStructureAttribute>,
+    pub traffic_area_structure_attribute: Option<uro::TrafficAreaStructureAttribute>,
 }
 
 #[citygml_feature(name = "tran:AuxiliaryTrafficArea")]

--- a/nusamai-plateau/src/models/tunnel.rs
+++ b/nusamai-plateau/src/models/tunnel.rs
@@ -34,7 +34,7 @@ pub struct Tunnel {
     pub consists_of_tunnel_part: Vec<TunnelPart>,
 
     #[citygml(path = b"uro:tunBaseAttribute/uro:ConstructionBaseAttribute")]
-    pub tun_base_attribute: Vec<uro::ConstructionBaseAttribute>,
+    pub tun_base_attribute: Option<uro::ConstructionBaseAttribute>,
 
     #[citygml(path = b"uro:tunDataQualityAttribute/uro:ConstructionDataQualityAttribute")]
     pub tun_data_quality_attribute: Option<uro::ConstructionDataQualityAttribute>,
@@ -55,13 +55,13 @@ pub struct Tunnel {
     pub tun_facility_type_attribute: Vec<uro::FacilityTypeAttribute>,
 
     #[citygml(path = b"uro:tunFunctionalAttribute/uro:TunnelFunctionalAttribute")]
-    pub tun_functional_attribute: Vec<uro::TunnelFunctionalAttribute>,
+    pub tun_functional_attribute: Option<uro::TunnelFunctionalAttribute>,
 
     #[citygml(path = b"uro:tunRiskAssessmentAttribute/uro:ConstructionRiskAssessmentAttribute")]
-    pub tun_risk_assessment_attribute: Vec<uro::ConstructionRiskAssessmentAttribute>,
+    pub tun_risk_assessment_attribute: Option<uro::ConstructionRiskAssessmentAttribute>,
 
     #[citygml(path = b"uro:tunStructureAttribute/uro:TunnelStructureAttribute")]
-    pub tun_structure_attribute: Vec<uro::TunnelStructureAttribute>,
+    pub tun_structure_attribute: Option<uro::TunnelStructureAttribute>,
 }
 
 #[citygml_feature(name = "tun:TunnelPart")]
@@ -97,7 +97,7 @@ pub struct TunnelPart {
     pub consists_of_tunnel_part: Vec<TunnelPart>,
 
     #[citygml(path = b"uro:tunBaseAttribute/uro:ConstructionBaseAttribute")]
-    pub tun_base_attribute: Vec<uro::ConstructionBaseAttribute>,
+    pub tun_base_attribute: Option<uro::ConstructionBaseAttribute>,
 
     #[citygml(path = b"uro:tunDataQualityAttribute/uro:ConstructionDataQualityAttribute")]
     pub tun_data_quality_attribute: Option<uro::ConstructionDataQualityAttribute>,
@@ -118,13 +118,13 @@ pub struct TunnelPart {
     pub tun_facility_type_attribute: Vec<uro::FacilityTypeAttribute>,
 
     #[citygml(path = b"uro:tunFunctionalAttribute/uro:TunnelFunctionalAttribute")]
-    pub tun_functional_attribute: Vec<uro::TunnelFunctionalAttribute>,
+    pub tun_functional_attribute: Option<uro::TunnelFunctionalAttribute>,
 
     #[citygml(path = b"uro:tunRiskAssessmentAttribute/uro:ConstructionRiskAssessmentAttribute")]
-    pub tun_risk_assessment_attribute: Vec<uro::ConstructionRiskAssessmentAttribute>,
+    pub tun_risk_assessment_attribute: Option<uro::ConstructionRiskAssessmentAttribute>,
 
     #[citygml(path = b"uro:tunStructureAttribute/uro:TunnelStructureAttribute")]
-    pub tun_structure_attribute: Vec<uro::TunnelStructureAttribute>,
+    pub tun_structure_attribute: Option<uro::TunnelStructureAttribute>,
 }
 
 #[citygml_feature(name = "tun:HollowSpace")]

--- a/nusamai-plateau/src/models/waterbody.rs
+++ b/nusamai-plateau/src/models/waterbody.rs
@@ -19,7 +19,7 @@ pub struct WaterBody {
     pub flooding_risk_attribute: Vec<uro::WaterBodyFloodingRiskAttributeProperty>, // -> uro:WaterBodyFloodingRiskAttribute
 
     #[citygml(path = b"uro:waterBodyDetailAttribute/uro:WaterBodyDetailAttribute")]
-    pub water_body_detail_attribute: Vec<uro::WaterBodyDetailAttribute>,
+    pub water_body_detail_attribute: Option<uro::WaterBodyDetailAttribute>,
 
     #[citygml(path = b"uro:wtrDmAttribute")]
     pub wtr_dm_attribute: Vec<uro::DmAttributeProperty>, // -> uro:DmAttribute

--- a/nusamai-plateau/tests/load_examples.rs
+++ b/nusamai-plateau/tests/load_examples.rs
@@ -65,9 +65,11 @@ fn load_bridge_example() {
             vec![Code::new("横断歩道橋".to_string(), "07".to_string())]
         );
         assert_eq!(bridge.year_of_construction, Some("1968".to_string()));
-        assert_eq!(bridge.brid_risk_assessment_attribute.len(), 1);
         assert_eq!(
-            bridge.brid_risk_assessment_attribute[0]
+            bridge
+                .brid_risk_assessment_attribute
+                .as_ref()
+                .unwrap()
                 .risk_type
                 .as_ref()
                 .unwrap()
@@ -91,9 +93,11 @@ fn load_bridge_example() {
                 "08".to_string()
             )]
         );
-        assert_eq!(bridge.brid_structure_attribute.len(), 1);
         assert_eq!(
-            bridge.brid_structure_attribute[0]
+            bridge
+                .brid_structure_attribute
+                .as_ref()
+                .unwrap()
                 .length
                 .as_ref()
                 .unwrap()
@@ -184,11 +188,15 @@ fn load_landuse_example() {
     };
 
     assert_eq!(
-        landuse.land_use_detail_attribute[0].prefecture,
+        landuse
+            .land_use_detail_attribute
+            .as_ref()
+            .unwrap()
+            .prefecture,
         Some(Code::new("静岡県".into(), "22".into()))
     );
     assert_eq!(
-        landuse.land_use_detail_attribute[0].city,
+        landuse.land_use_detail_attribute.as_ref().unwrap().city,
         Some(Code::new("静岡県沼津市".into(), "22203".into()))
     );
 }
@@ -321,12 +329,12 @@ fn load_road_example() {
         vec![Code::new("歩道部の段差".into(), "2000".into())]
     );
     assert_eq!(
-        road.road_structure_attribute.first().unwrap().width,
+        road.road_structure_attribute.as_ref().unwrap().width,
         Some(Measure::new(22.0)),
     );
     assert_eq!(
         road.traffic_volume_attribute
-            .first()
+            .as_ref()
             .unwrap()
             .weekday12hour_traffic_volume,
         Some(8170),
@@ -380,7 +388,7 @@ fn load_track_example() {
         vec![Code::new("島".into(), "3000".into())]
     );
     assert_eq!(
-        track.track_attribute.first().unwrap().admin_type,
+        track.track_attribute.as_ref().unwrap().admin_type,
         Some(Code::new("市区町村".into(), "3".into()))
     );
 }
@@ -638,7 +646,6 @@ fn load_urf_kuiki_example() {
     assert_eq!(
         acf.function,
         vec![Code::new("市街化区域".to_string(), "22".to_string(),)]
-
     );
 
     assert_eq!(
@@ -650,7 +657,6 @@ fn load_urf_kuiki_example() {
         acf.valid_from_type,
         Some(Code::new("変更".to_string(), "3".to_string()))
     );
-
 }
 
 #[test]
@@ -664,7 +670,6 @@ fn load_urf_rinko_example() {
     assert_eq!(
         pz.function,
         vec![Code::new("臨港地区".to_string(), "30".to_string(),)]
-
     );
 
     assert_eq!(
@@ -676,7 +681,6 @@ fn load_urf_rinko_example() {
         pz.valid_from_type,
         Some(Code::new("変更".to_string(), "3".to_string()))
     );
-
 }
 
 #[test]
@@ -690,7 +694,6 @@ fn load_urf_yoto_example() {
     assert_eq!(
         ud.function,
         vec![Code::new("工業専用地域".to_string(), "13".to_string(),)]
-
     );
 
     assert_eq!(
@@ -715,7 +718,6 @@ fn load_urf_boka_example() {
     assert_eq!(
         fpd.function,
         vec![Code::new("準防火地域".to_string(), "25".to_string(),)]
-
     );
 
     assert_eq!(
@@ -727,7 +729,6 @@ fn load_urf_boka_example() {
         fpd.valid_from_type,
         Some(Code::new("変更".to_string(), "3".to_string()))
     );
-
 }
 #[test]
 fn load_urf_seisan_example() {
@@ -740,7 +741,6 @@ fn load_urf_seisan_example() {
     assert_eq!(
         pgz.function,
         vec![Code::new("生産緑地地区".to_string(), "38".to_string(),)]
-
     );
 
     assert_eq!(
@@ -752,22 +752,22 @@ fn load_urf_seisan_example() {
         pgz.valid_from_type,
         Some(Code::new("変更".to_string(), "3".to_string()))
     );
-
 }
-
 
 #[test]
 fn load_urf_tokuryoku_example() {
-    let cityobjs = load_cityobjs("./tests/data/kawasaki-shi/udx/urf/533923_urf_6668_tokuryoku_op.gml");
+    let cityobjs =
+        load_cityobjs("./tests/data/kawasaki-shi/udx/urf/533923_urf_6668_tokuryoku_op.gml");
     assert_eq!(cityobjs.len(), 7);
-    let TopLevelCityObject::SpecialGreenSpaceConservationDistrict(sgcd) = &cityobjs.first().unwrap().cityobj else {
+    let TopLevelCityObject::SpecialGreenSpaceConservationDistrict(sgcd) =
+        &cityobjs.first().unwrap().cityobj
+    else {
         panic!("Not a SpecialGreenSpaceConservationDistrict");
     };
 
     assert_eq!(
         sgcd.function,
         vec![Code::new("特別緑地保存地区".to_string(), "35".to_string(),)]
-
     );
 
     assert_eq!(
@@ -779,20 +779,19 @@ fn load_urf_tokuryoku_example() {
         sgcd.valid_from_type,
         Some(Code::new("変更".to_string(), "3".to_string()))
     );
-
 }
 #[test]
 fn load_urf_chusha_example() {
     let cityobjs = load_cityobjs("./tests/data/kawasaki-shi/udx/urf/533925_urf_6668_chusha_op.gml");
     assert_eq!(cityobjs.len(), 1);
-    let TopLevelCityObject::ParkingPlaceDevelopmentZone(ppdz) = &cityobjs.first().unwrap().cityobj else {
+    let TopLevelCityObject::ParkingPlaceDevelopmentZone(ppdz) = &cityobjs.first().unwrap().cityobj
+    else {
         panic!("Not a ParkingPlaceDevelopmentZone");
     };
 
     assert_eq!(
         ppdz.function,
         vec![Code::new("駐車場整備地区".to_string(), "29".to_string(),)]
-
     );
 
     assert_eq!(
@@ -804,12 +803,12 @@ fn load_urf_chusha_example() {
         ppdz.valid_from_type,
         Some(Code::new("決定".to_string(), "1".to_string()))
     );
-
 }
 
 #[test]
 fn load_urf_tokuyoto_example() {
-    let cityobjs = load_cityobjs("./tests/data/kawasaki-shi/udx/urf/533925_urf_6668_tokuyoto_op.gml");
+    let cityobjs =
+        load_cityobjs("./tests/data/kawasaki-shi/udx/urf/533925_urf_6668_tokuyoto_op.gml");
     assert_eq!(cityobjs.len(), 4);
     let TopLevelCityObject::SpecialUseDistrict(sud) = &cityobjs.first().unwrap().cityobj else {
         panic!("Not a SpecialUseDistrict");
@@ -818,7 +817,6 @@ fn load_urf_tokuyoto_example() {
     assert_eq!(
         sud.function,
         vec![Code::new("特別用途地区".to_string(), "14".to_string(),)]
-
     );
 
     assert_eq!(
@@ -830,7 +828,6 @@ fn load_urf_tokuyoto_example() {
         sud.valid_from_type,
         Some(Code::new("変更".to_string(), "3".to_string()))
     );
-
 }
 
 #[test]
@@ -844,7 +841,6 @@ fn load_urf_toshikeikaku_example() {
     assert_eq!(
         upa.function,
         vec![Code::new("都市計画区域".to_string(), "21".to_string(),)]
-
     );
 
     assert_eq!(
@@ -856,7 +852,6 @@ fn load_urf_toshikeikaku_example() {
         upa.valid_from_type,
         Some(Code::new("変更".to_string(), "3".to_string()))
     );
-
 }
 
 #[test]
@@ -870,7 +865,6 @@ fn load_urf_huchi_example() {
     assert_eq!(
         sd.function,
         vec![Code::new("風致地区".to_string(), "28".to_string(),)]
-
     );
 
     assert_eq!(
@@ -882,12 +876,12 @@ fn load_urf_huchi_example() {
         sd.city,
         Some(Code::new("宮城県仙台市".to_string(), "04100".to_string()))
     );
-
 }
 
 #[test]
 fn load_urf_kodoriyou_example() {
-    let cityobjs = load_cityobjs("./tests/data/sendai-shi/udx/urf/574027_urf_6668_kodoriyou_op.gml");
+    let cityobjs =
+        load_cityobjs("./tests/data/sendai-shi/udx/urf/574027_urf_6668_kodoriyou_op.gml");
     assert_eq!(cityobjs.len(), 3);
     let TopLevelCityObject::HighLevelUseDistrict(hlud) = &cityobjs.first().unwrap().cityobj else {
         panic!("Not a HighLevelUseDistrict");
@@ -896,7 +890,6 @@ fn load_urf_kodoriyou_example() {
     assert_eq!(
         hlud.function,
         vec![Code::new("高度利用地区".to_string(), "19".to_string(),)]
-
     );
 
     assert_eq!(
@@ -909,10 +902,7 @@ fn load_urf_kodoriyou_example() {
         Some(Code::new("変更".to_string(), "3".to_string()))
     );
 
-    assert_eq!(
-        hlud.custodian,
-        Some("仙台市".to_string())
-    );
+    assert_eq!(hlud.custodian, Some("仙台市".to_string()));
 
     assert_eq!(
         hlud.prefecture,
@@ -923,9 +913,7 @@ fn load_urf_kodoriyou_example() {
         hlud.city,
         Some(Code::new("宮城県仙台市".to_string(), "04100".to_string()))
     );
-
 }
-
 
 #[test]
 fn load_urf_keikan_example() {
@@ -938,7 +926,6 @@ fn load_urf_keikan_example() {
     assert_eq!(
         lz.function,
         vec![Code::new("景観地区".to_string(), "27".to_string(),)]
-
     );
 
     assert_eq!(
@@ -951,10 +938,7 @@ fn load_urf_keikan_example() {
         Some(Code::new("変更".to_string(), "3".to_string()))
     );
 
-    assert_eq!(
-        lz.custodian,
-        Some("仙台市".to_string())
-    );
+    assert_eq!(lz.custodian, Some("仙台市".to_string()));
 
     assert_eq!(
         lz.prefecture,
@@ -965,21 +949,21 @@ fn load_urf_keikan_example() {
         lz.city,
         Some(Code::new("宮城県仙台市".to_string(), "04100".to_string()))
     );
-
 }
 
 #[test]
 fn load_urf_tosisai_example() {
     let cityobjs = load_cityobjs("./tests/data/sendai-shi/udx/urf/574036_urf_6668_tosisai_op.gml");
     assert_eq!(cityobjs.len(), 1);
-    let TopLevelCityObject::SpecialUrbanRenaissanceDistrict(surd) = &cityobjs.first().unwrap().cityobj else {
+    let TopLevelCityObject::SpecialUrbanRenaissanceDistrict(surd) =
+        &cityobjs.first().unwrap().cityobj
+    else {
         panic!("Not a SpecialUrbanRenaissanceDistrict");
     };
 
     assert_eq!(
         surd.function,
         vec![Code::new("都市再生特別地区".to_string(), "21".to_string(),)]
-
     );
 
     assert_eq!(
@@ -992,10 +976,7 @@ fn load_urf_tosisai_example() {
         Some(Code::new("変更".to_string(), "3".to_string()))
     );
 
-    assert_eq!(
-        surd.custodian,
-        Some("仙台市".to_string())
-    );
+    assert_eq!(surd.custodian, Some("仙台市".to_string()));
 
     assert_eq!(
         surd.prefecture,
@@ -1006,22 +987,20 @@ fn load_urf_tosisai_example() {
         surd.city,
         Some(Code::new("宮城県仙台市".to_string(), "04100".to_string()))
     );
-
 }
-
 
 #[test]
 fn load_urf_sigaidev_example() {
     let cityobjs = load_cityobjs("./tests/data/kofu-shi/udx/urf/533834_urf_6668_sigaidev_op.gml");
     assert_eq!(cityobjs.len(), 27);
-    let TopLevelCityObject::UrbanDevelopmentProject(udp) = &cityobjs.first().unwrap().cityobj else {
+    let TopLevelCityObject::UrbanDevelopmentProject(udp) = &cityobjs.first().unwrap().cityobj
+    else {
         panic!("Not a UrbanDevelopmentProject");
     };
 
     assert_eq!(
         udp.function,
         vec![Code::new("工業地域".to_string(), "12".to_string(),)]
-
     );
 
     assert_eq!(
@@ -1043,5 +1022,4 @@ fn load_urf_sigaidev_example() {
         udp.city,
         Some(Code::new("山梨県甲府市".to_string(), "19201".to_string()))
     );
-
 }

--- a/nusamai/src/sink/czml/mod.rs
+++ b/nusamai/src/sink/czml/mod.rs
@@ -230,7 +230,7 @@ mod tests {
     use std::sync::RwLock;
 
     use super::*;
-    use nusamai_citygml::{object::Object, GeometryRefEntry, Value};
+    use nusamai_citygml::{object::Object, GeometryRef, Value};
     use nusamai_czml::{PositionListProperties, PositionListType};
     use nusamai_geometry::MultiPolygon;
     use nusamai_projection::crs::EPSG_JGD2011_GEOGRAPHIC_3D;
@@ -295,19 +295,19 @@ mod tests {
                 stereotype: nusamai_citygml::object::ObjectStereotype::Feature {
                     id: "dummy".into(),
                     geometries: vec![
-                        GeometryRefEntry {
+                        GeometryRef {
                             ty: GeometryType::Solid,
                             pos: 0,
                             len: 1,
                             lod: 1,
                         },
-                        GeometryRefEntry {
+                        GeometryRef {
                             ty: GeometryType::Solid,
                             pos: 1,
                             len: 1,
                             lod: 1,
                         },
-                        GeometryRefEntry {
+                        GeometryRef {
                             ty: GeometryType::Solid,
                             pos: 2,
                             len: 1,

--- a/nusamai/src/sink/geojson/mod.rs
+++ b/nusamai/src/sink/geojson/mod.rs
@@ -237,7 +237,7 @@ mod tests {
     use std::sync::RwLock;
 
     use super::*;
-    use nusamai_citygml::{object::Object, GeometryRefEntry, Value};
+    use nusamai_citygml::{object::Object, GeometryRef, Value};
     use nusamai_geometry::MultiPolygon;
     use nusamai_projection::crs::EPSG_JGD2011_GEOGRAPHIC_3D;
 
@@ -264,7 +264,7 @@ mod tests {
                 attributes: Default::default(),
                 stereotype: nusamai_citygml::object::ObjectStereotype::Feature {
                     id: "dummy".into(),
-                    geometries: vec![GeometryRefEntry {
+                    geometries: vec![GeometryRef {
                         ty: GeometryType::Solid,
                         pos: 0,
                         len: 1,

--- a/nusamai/src/sink/geojson_transform_exp/transform.rs
+++ b/nusamai/src/sink/geojson_transform_exp/transform.rs
@@ -67,7 +67,7 @@ struct Param {
 //         }
 //
 //         // child_geometry_refの重複を除去する
-//         let child_geometry_refs: Vec<GeometryRefEntry> =
+//         let child_geometry_refs: Vec<GeometryRef> =
 //             child_geometry_refs
 //                 .into_iter()
 //                 .fold(Vec::new(), |mut acc, x| {
@@ -429,7 +429,7 @@ mod tests {
     use super::*;
     use nusamai_citygml::{
         object::{self, Map, ObjectStereotype},
-        Code, GeometryRefEntry, GeometryStore, GeometryType, Value,
+        Code, GeometryRef, GeometryStore, GeometryType, Value,
     };
     use nusamai_plateau::Entity;
 
@@ -494,7 +494,7 @@ mod tests {
             "Code".to_string(),
             Value::Code(Code::new("test".to_string(), "1".to_string())),
         );
-        let geometries_1 = vec![GeometryRefEntry {
+        let geometries_1 = vec![GeometryRef {
             ty: GeometryType::Surface,
             lod: 0,
             pos: 0,

--- a/nusamai/src/sink/gltf_poc/mod.rs
+++ b/nusamai/src/sink/gltf_poc/mod.rs
@@ -555,7 +555,7 @@ mod tests {
     use std::sync::RwLock;
 
     use super::*;
-    use nusamai_citygml::{object::Object, GeometryRefEntry, Value};
+    use nusamai_citygml::{object::Object, GeometryRef, Value};
     use nusamai_geometry::MultiPolygon;
     use nusamai_plateau::Entity;
     use nusamai_projection::crs::EPSG_JGD2011_GEOGRAPHIC_3D;
@@ -622,19 +622,19 @@ mod tests {
                 stereotype: nusamai_citygml::object::ObjectStereotype::Feature {
                     id: "dummy".into(),
                     geometries: vec![
-                        GeometryRefEntry {
+                        GeometryRef {
                             ty: GeometryType::Solid,
                             pos: 0,
                             len: 1,
                             lod: 1,
                         },
-                        GeometryRefEntry {
+                        GeometryRef {
                             ty: GeometryType::Solid,
                             pos: 1,
                             len: 1,
                             lod: 1,
                         },
-                        GeometryRefEntry {
+                        GeometryRef {
                             ty: GeometryType::Solid,
                             pos: 2,
                             len: 1,

--- a/nusamai/src/sink/shapefile/mod.rs
+++ b/nusamai/src/sink/shapefile/mod.rs
@@ -185,7 +185,7 @@ mod tests {
     use std::sync::RwLock;
 
     use super::*;
-    use nusamai_citygml::{object::Object, GeometryRefEntry, Value};
+    use nusamai_citygml::{object::Object, GeometryRef, Value};
     use nusamai_geometry::MultiPolygon;
     use nusamai_plateau::Entity;
     use nusamai_projection::crs::EPSG_JGD2011_GEOGRAPHIC_3D;
@@ -214,7 +214,7 @@ mod tests {
                 attributes: Default::default(),
                 stereotype: nusamai_citygml::object::ObjectStereotype::Feature {
                     id: "dummy".into(),
-                    geometries: vec![GeometryRefEntry {
+                    geometries: vec![GeometryRef {
                         ty: GeometryType::Solid,
                         pos: 0,
                         len: 1,

--- a/nusamai/src/transformer/transform/merge.rs
+++ b/nusamai/src/transformer/transform/merge.rs
@@ -3,13 +3,13 @@ use crate::transformer::Transform;
 use hashbrown::HashSet;
 use nusamai_citygml::object::{Map, Object, ObjectStereotype, Value};
 use nusamai_citygml::schema::{Schema, TypeDef};
-use nusamai_citygml::GeometryRefEntry;
+use nusamai_citygml::GeometryRef;
 use nusamai_plateau::Entity;
 
 /// Collect all attributes and geometries from the descendants and merge them into the root object.
 #[derive(Default, Clone)]
 pub struct FullMergedownTransform {
-    geoms_buf: HashSet<GeometryRefEntry>,
+    geoms_buf: HashSet<GeometryRef>,
     path_buf: String,
 }
 
@@ -51,7 +51,7 @@ impl Transform for FullMergedownTransform {
 
 fn collect_all_attrs_and_geoms(
     new_attrs: &mut Map,
-    new_geoms: &mut HashSet<GeometryRefEntry>,
+    new_geoms: &mut HashSet<GeometryRef>,
     path: &mut String,
     attributes: Map,
     in_child_feature: bool,
@@ -121,7 +121,7 @@ fn collect_all_attrs_and_geoms(
 
 #[derive(Default, Clone)]
 pub struct GeometricMergedownTransform {
-    geoms_buf: HashSet<GeometryRefEntry>,
+    geoms_buf: HashSet<GeometryRef>,
 }
 
 impl Transform for GeometricMergedownTransform {
@@ -141,7 +141,7 @@ impl Transform for GeometricMergedownTransform {
     }
 }
 
-fn collect_all_geoms(new_geoms: &mut HashSet<GeometryRefEntry>, obj: &mut Object) {
+fn collect_all_geoms(new_geoms: &mut HashSet<GeometryRef>, obj: &mut Object) {
     if let ObjectStereotype::Feature { geometries, .. } = &mut obj.stereotype {
         new_geoms.extend(geometries.drain(..));
     }


### PR DESCRIPTION
uro まわりの多重度が誤っているので修正します（XMLスキーマから多重度を判断できないため、自動生成の結果では適切な多重度度になっていなかった）。