### PR TITLE
KML Sink:属性(第一階層)

### DIFF
--- a/nusamai/src/sink/kml/mod.rs
+++ b/nusamai/src/sink/kml/mod.rs
@@ -79,10 +79,10 @@ impl DataSink for KmlSink {
 
                         let polygons = entity_to_kml_polygons(&parcel.entity);
 
-                        let _simple_data_items = property_to_schema_data_entries(
+                        let simple_data_items = property_to_schema_data_entries(
                             &entity_to_properties(&parcel.entity).unwrap_or_default(),
                         );
-                        let _schema_data = Element {
+                        let schema_data = Element {
                             name: "SchemaData".to_string(),
                             attrs: {
                                 let mut attrs = HashMap::new();
@@ -90,7 +90,7 @@ impl DataSink for KmlSink {
                                 attrs
                             },
                             content: None,
-                            children: _simple_data_items
+                            children: simple_data_items
                                 .into_iter()
                                 .map(|simple_data| Element {
                                     name: "SimpleData".to_string(),
@@ -104,7 +104,7 @@ impl DataSink for KmlSink {
                             name: "ExtendedData".to_string(),
                             attrs: HashMap::new(),
                             content: None,
-                            children: vec![_schema_data],
+                            children: vec![schema_data],
                         };
 
                         let geoms = polygons.into_iter().map(Geometry::Polygon).collect();


### PR DESCRIPTION
https://github.com/MIERUNE/nusamai/pull/278
のマージが前提です。

属性をKML地物に付与し、Google Earth上で表示可能なSchemaを付与。

ExtendedDataなので、機械的にも可読である
![スクリーンショット 2024-02-15 12 15 28](https://github.com/MIERUNE/nusamai/assets/83005951/2cd4b12a-b4a1-4f59-9d47-dac7b2adf11d)

<img width="1582" alt="スクリーンショット 2024-02-15 12 12 28" src="https://github.com/MIERUNE/nusamai/assets/83005951/4ab95d92-705c-4642-b247-12992ca83265">

TODO：
- 属性の階層を処理していないので、文字列になっている


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - `KmlPolygon`の`Vec<KmlPolygon>`への変更
    - `polygon_to_kml_polygon_with_mapping`の導入
    - 既存の関数の更新
    - `CityObjects`から`GeoJSON`オブジェクトから`KML`オブジェクトへの切り替え
    - 新しいデータ構造の導入: `Element`, `Geometry`, `Polygon`, `SimpleData`
    - プロパティの処理と`KML`要素の生成ロジックの更新
    - スキーマデータエントリの作成
    - 拡張データの処理
    - `KML`出力の構造の調整
    - `.gitignore`に`data/*`と`*.kml`を追加して、これらのファイルとディレクトリをバージョン管理から除外
    - `.vscode/launch.json`にLLDBを使用してプロジェクト内の異なるコンポーネントとテストをデバッグするための様々な起動構成を設定
    - 実行可能ファイル、ユニットテスト、統合テスト、ライブラリ、およびワークスペース内の複数のパッケージの例をデバッグするための構成のセットアップ

<!-- end of auto-generated comment: release notes by coderabbit.ai -->