### PR TITLE
test: CLI (nusamai/main.rs) を実行するテスト

### DIFF
--- a/nusamai/Cargo.toml
+++ b/nusamai/Cargo.toml
@@ -53,3 +53,4 @@ tokio = { version = "1.36", features = ["full"] }
 nusamai-geometry = { path = "../nusamai-geometry" }
 byteorder = "1.5.0"
 glob = "0.3.1"
+assert_cmd = "2.0.13"

--- a/nusamai/src/main.rs
+++ b/nusamai/src/main.rs
@@ -187,3 +187,21 @@ fn run(
 
     log::info!("Total processing time: {:?}", total_time.elapsed());
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_run_cmd() {
+        use assert_cmd::Command;
+
+        let mut cmd = Command::cargo_bin("nusamai").unwrap();
+        let assert = cmd
+            .arg("../../nusamai-plateau/tests/data/sendai-shi/udx/urf/574026_urf_6668_huchi_op.gml")
+            .arg("--sink")
+            .arg("noop")
+            .arg("--output")
+            .arg("dummy")
+            .assert();
+        assert.success();
+    }
+}


### PR DESCRIPTION
ふつうのテストでは、CLIコマンドのエントリーポイントである `nusamai/main.rs` が壊れても一切チェックされないので、CLIコマンドを起動するだけのテストを追加します。

[assert_cmd](https://crates.io/crates/assert_cmd)という良く使われてそうな crate を使っています。