### PR TITLE
必要なときのみアピアランスを読み込む

### DIFF
--- a/nusamai/src/source/mod.rs
+++ b/nusamai/src/source/mod.rs
@@ -23,4 +23,7 @@ pub trait DataSourceProvider {
 
 pub trait DataSource: Send {
     fn run(&mut self, sink: Sender, feedback: &Feedback) -> Result<()>;
+
+    /// Set whether to resolve appearances
+    fn set_appearance_resolution(&mut self, _value: bool);
 }

--- a/nusamai/tests/pipeline.rs
+++ b/nusamai/tests/pipeline.rs
@@ -34,6 +34,10 @@ impl DataSourceProvider for DummySourceProvider {
 pub struct DummySource {}
 
 impl DataSource for DummySource {
+    fn set_appearance_resolution(&mut self, _value: bool) {
+        // do nothing
+    }
+
     fn run(&mut self, sink: Sender, feedback: &Feedback) -> Result<()> {
         for _i in 0..100 {
             feedback.ensure_not_canceled()?;


### PR DESCRIPTION
CityGMLのアピアランスの情報は、それを扱えるファイル形式 -- 現状、3D Tiles (と glTF)  -- のときのみに意味をなす。アピアランスが意味をもつターゲットのときだけアピアランスを読み込むようにして、無駄な処理コストを省けるようにする。

（APIは少しhackyな感じだが、ひとまずはこれで十分だろうという判断）

close: #309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ソースデータからの外観解決の設定を可能にする新しいオプションが追加されました。
	- パイプライン実行前に要件を設定する機能が導入されました。

- **テスト**
	- 外観解決機能のテストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->