### PR TITLE
3dtiles, mvt: 外部ソートの一時ファイル出力先を tempfile のデフォルト値にする

### DIFF
--- a/nusamai/src/sink/cesiumtiles/mod.rs
+++ b/nusamai/src/sink/cesiumtiles/mod.rs
@@ -186,7 +186,6 @@ fn feature_sorting_stage(
         BincodeExternalChunk<_>,
         // TODO: Implement an external sorter by ourselves?
     > = ExternalSorterBuilder::new()
-        .with_tmp_dir(Path::new("./"))
         .with_buffer(MemoryLimitedBufferBuilder::new(200 * 1024 * 1024)) // TODO
         .with_threads_number(8) // TODO
         .build()

--- a/nusamai/src/sink/mvt/mod.rs
+++ b/nusamai/src/sink/mvt/mod.rs
@@ -194,7 +194,6 @@ fn feature_sorting_stage(
         BincodeExternalChunk<_>,
         // TODO: Implement an external sorter by ourselves?
     > = ExternalSorterBuilder::new()
-        .with_tmp_dir(Path::new("./"))
         .with_buffer(MemoryLimitedBufferBuilder::new(200 * 1024 * 1024)) // TODO
         .with_threads_number(8) // TODO
         .build()


### PR DESCRIPTION
現在は、外部ソートの一時ファイルを "./" に出力するようにしている（ext-sort crate のサンプルを参考にした）。

このことが、Mac での GUI版 (.app) ビルドで、MVTと3D Tilesが生成できない問題の原因になっている可能性がある。 つまり .app ビルドでは "./" が意味する場所に書き込めないなど。

この指定を外すことで、 tempfile crate のデフォルトの一時ファイル出力先を ext-sort に使わせる。