### PR TITLE
マッピングルール: ワイルドカード `*:` 表記による全ネームスペースの指定

### DIFF
--- a/nusamai/src/transformer/transform/attrname.rs
+++ b/nusamai/src/transformer/transform/attrname.rs
@@ -82,26 +82,19 @@ impl Transform for EditFieldNamesTransform {
 
 impl EditFieldNamesTransform {
     fn rename<'a>(&'a self, name: &'a str) -> Option<&str> {
-        let mut new_name = None;
-
         // Lookup and rename: exact match
         if let Some(new_key) = self.exact_rename_map.get(name) {
-            new_name = Some(new_key.as_ref());
-            return new_name;
+            return Some(new_key.as_ref());
         }
 
-        // Remove the namespace prefix, then rename:
-        // General match (consider the string after the namespace prefix)
-        if let Some(pos) = name.find(':') {
+        name.find(':').map(|pos| {
             let key = &name[pos + 1..]; // remove the namespace prefix
-            new_name = if let Some(new_key) = self.general_rename_map.get(key) {
-                Some(new_key.as_ref())
+            if let Some(new_key) = self.general_rename_map.get(key) {
+                new_key.as_ref()
             } else {
-                Some(key)
+                key
             }
-        }
-
-        new_name
+        })
     }
 
     fn edit_tree(&self, value: &mut Value) {


### PR DESCRIPTION
close #251:
#324, #331 の続き

`*:foo` などと表記することで、ネームスペース（= 文字列中で `:` より前にある部分）に関係なく、全てのネームスペースにおいて属性名変更の適用を可能とします。

ルールファイル例:

```json
{
  "rename": {
    "*:class": "分類",
    "luse:class": "土地利用区分"
  }
}
```

## 備考

- 「具体的なネームスペースが表記されているルール」が優先されます
- あくまで `*:` という表記を可能とするものです
  - 実装の容易さと、パフォーマンスを考慮して、このように必要十分にしてあります
  - ですので、 `*foo:bar` のように、部分文字列一致での指定はできません


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - `EditFieldNamesTransform`構造体に、フィールド名をリネームするためのテストケース `test_rename` を追加しました。
    - ユーザーが定義したルールに基づいてフィールド名を変更する機能を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->