### PR TITLE
3dtiles: 頂点属性に _FEATURE_ID_0 を追加

### DIFF
--- a/nusamai/src/sink/cesiumtiles/gltf.rs
+++ b/nusamai/src/sink/cesiumtiles/gltf.rs
@@ -1,17 +1,24 @@
 use std::io::Write;
 
 use super::material;
-use ahash::HashMap;
+use ahash::{HashMap, HashSet};
 use byteorder::{ByteOrder, LittleEndian};
 use indexmap::IndexSet;
+use nusamai_gltf_json::extensions::mesh::ext_mesh_features;
 
-pub type Primitives = HashMap<material::Material, Vec<u32>>;
+#[derive(Default)]
+pub struct PrimitiveInfo {
+    pub indices: Vec<u32>,
+    pub feature_ids: HashSet<u32>,
+}
+
+pub type Primitives = HashMap<material::Material, PrimitiveInfo>;
 
 /// とりいそぎの実装
 pub fn write_gltf_glb<W: Write>(
     writer: W,
     translation: [f64; 3],
-    vertices: impl IntoIterator<Item = [u32; 5]>,
+    vertices: impl IntoIterator<Item = [u32; 6]>,
     primitives: Primitives,
 ) -> std::io::Result<()> {
     use nusamai_gltf_json::*;
@@ -27,10 +34,12 @@ pub fn write_gltf_glb<W: Write>(
         let mut position_max = [f64::MIN; 3];
         let mut position_min = [f64::MAX; 3];
 
+        const VERTEX_BYTE_STRIDE: usize = 4 * 6; // 4-bytes (u32) x 6
+
         let buffer_offset = bin_content.len();
-        let mut buf = [0; 4 * 5];
+        let mut buf = [0; VERTEX_BYTE_STRIDE];
         for v in vertices {
-            let [x, y, z, u, v] = v;
+            let [x, y, z, u, v, feature_id] = v;
             position_min = [
                 f64::min(position_min[0], f32::from_bits(x) as f64),
                 f64::min(position_min[1], f32::from_bits(y) as f64),
@@ -42,7 +51,7 @@ pub fn write_gltf_glb<W: Write>(
                 f64::max(position_max[2], f32::from_bits(z) as f64),
             ];
 
-            LittleEndian::write_u32_into(&[x, y, z, u, v], &mut buf);
+            LittleEndian::write_u32_into(&[x, y, z, u, v, feature_id], &mut buf);
             bin_content.write_all(&buf)?;
             vertices_count += 1;
         }
@@ -50,7 +59,7 @@ pub fn write_gltf_glb<W: Write>(
         gltf_buffer_views.push(BufferView {
             byte_offset: buffer_offset as u32,
             byte_length: (bin_content.len() - buffer_offset) as u32,
-            byte_stride: Some(4 * 5),
+            byte_stride: Some(VERTEX_BYTE_STRIDE as u8),
             target: Some(BufferViewTarget::ArrayBuffer),
             ..Default::default()
         });
@@ -75,6 +84,16 @@ pub fn write_gltf_glb<W: Write>(
             type_: AccessorType::Vec2,
             ..Default::default()
         });
+
+        // accessor (feature_id)
+        gltf_accessors.push(Accessor {
+            buffer_view: Some(gltf_buffer_views.len() as u32 - 1),
+            byte_offset: 4 * 5,
+            component_type: ComponentType::Float,
+            count: vertices_count,
+            type_: AccessorType::Scalar,
+            ..Default::default()
+        });
     }
 
     let mut gltf_primitives = vec![];
@@ -86,7 +105,7 @@ pub fn write_gltf_glb<W: Write>(
         let mut byte_offset = 0;
         for (mat_i, (mat, primitive)) in primitives.iter().enumerate() {
             let mut indices_count = 0;
-            for idx in primitive {
+            for idx in &primitive.indices {
                 bin_content.write_all(&idx.to_le_bytes())?;
                 indices_count += 1;
             }
@@ -101,15 +120,30 @@ pub fn write_gltf_glb<W: Write>(
             });
 
             let mut attributes = vec![("POSITION".to_string(), 0)];
+            // TODO: It will be better for no-texture data to exclude u, v from the vertex buffer
             if mat.base_texture.is_some() {
                 attributes.push(("TEXCOORD_0".to_string(), 1));
             }
+            attributes.push(("_FEATURE_ID_0".to_string(), 2));
 
             gltf_primitives.push(MeshPrimitive {
                 attributes: attributes.into_iter().collect(),
                 indices: Some(gltf_accessors.len() as u32 - 1),
                 material: Some(mat_i as u32), // TODO
                 mode: PrimitiveMode::Triangles,
+                extensions: extensions::mesh::MeshPrimitive {
+                    ext_mesh_features: ext_mesh_features::ExtMeshFeatures {
+                        feature_ids: vec![ext_mesh_features::FeatureId {
+                            attribute: Some(0),
+                            feature_count: primitive.feature_ids.len() as u32,
+                            ..Default::default()
+                        }],
+                        ..Default::default()
+                    }
+                    .into(),
+                    ..Default::default()
+                }
+                .into(),
                 ..Default::default()
             });
 
@@ -171,6 +205,7 @@ pub fn write_gltf_glb<W: Write>(
         accessors: gltf_accessors,
         buffer_views: gltf_buffer_views,
         buffers: gltf_buffers,
+        extensions_used: vec!["EXT_mesh_features".to_string()],
         ..Default::default()
     };
 


### PR DESCRIPTION
`EXT_mesh_features` によって glTF で地物を表現する。

- Vertex attribute として  _FEATURE_ID_0 を追加する。
- 各 mesh primitive の拡張 EXT_mesh_features に適切な情報をセットする。

Closes #305 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- GLTF書き込みプロセスにおいて、`feature_ids`と関連データを扱う追加のロジックが導入されました。
	- 頂点データに`feature_id`フィールドが新たに追加され、より詳細な特徴識別が可能になりました。

- **リファクタ**
	- `PrimitiveInfo`構造体が導入され、インデックスの扱いが改善されました。
	- 頂点のサイズが5から6に変更され、GLTFの書き込み処理が更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->