### PR TITLE
リリース時の LTO のレベルを lto="thin" に変える

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Set optimization options
         run: |
           echo '[profile.release]' >> Cargo.toml
-          echo 'lto = true' >> Cargo.toml
+          echo 'lto = "thin"' >> Cargo.toml
           echo 'panic = "abort"' >> Cargo.toml
 
       - name: Build the app

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["MIERUNE Inc. <info@mierune.co.jp>"]
 
 [profile.release-lto]
 inherits = "release"
-lto = "fat"
+lto = "thin"
 panic = "abort"
 
 [profile.dev.package.zune-image]


### PR DESCRIPTION
CIでリリースビルドする際の LTO (link time optimization) のレベルを true ("fat") から "thin" に変えてみる。

CI での lto="fat" の負荷が高すぎてビルド時間が長大になるため。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- リリースワークフローの最適化設定で、`lto` オプションを `true` から `"thin"` に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->