### PR TITLE
projection: 平面直角座標系へ変換するためのオブジェクトを一度だけ作成

### DIFF
--- a/nusamai-projection/src/etmerc.rs
+++ b/nusamai-projection/src/etmerc.rs
@@ -9,7 +9,7 @@ const ETMERC_ORDER: usize = 6;
 
 type Coeffs = [f64; ETMERC_ORDER];
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct PoderEngsager {
     /// Merid. quad., scaled to the projection
     pub q_n: f64,
@@ -25,6 +25,7 @@ struct PoderEngsager {
     pub gtu: Coeffs,
 }
 
+#[derive(Debug, Clone)]
 pub struct ExtendedTransverseMercatorProjection {
     q: PoderEngsager,
     /// false longitude (radians)

--- a/nusamai/src/transformer/transform/projection.rs
+++ b/nusamai/src/transformer/transform/projection.rs
@@ -5,14 +5,16 @@ use crate::transformer::Transform;
 use nusamai_citygml::schema::Schema;
 use nusamai_plateau::Entity;
 use nusamai_projection::crs::*;
+use nusamai_projection::etmerc::ExtendedTransverseMercatorProjection;
 use nusamai_projection::jprect::JPRZone;
 use nusamai_projection::vshift::Jgd2011ToWgs84;
 
-/// Coordinate transformation. Currently supports only JGD2011 to WGS 84.
+/// Coordinate transformation
 #[derive(Clone)]
 pub struct ProjectionTransform {
     jgd2wgs: Arc<Jgd2011ToWgs84>,
     output_epsg: EpsgCode,
+    jpr_zone_proj: Option<ExtendedTransverseMercatorProjection>,
 }
 
 impl Transform for ProjectionTransform {
@@ -48,8 +50,7 @@ impl Transform for ProjectionTransform {
                 | EPSG_JGD2011_JPRECT_XII_JGD2011_HEIGHT
                 | EPSG_JGD2011_JPRECT_XIII_JGD2011_HEIGHT => {
                     // To Japan Plane Rectangular CS
-                    let zone = JPRZone::from_epsg(self.output_epsg).unwrap();
-                    let proj = zone.projection();
+                    let proj = self.jpr_zone_proj.as_ref().unwrap();
                     let mut geom_store = entity.geometry_store.write().unwrap();
                     geom_store.vertices.iter_mut().for_each(|v| {
                         let (lng, lat) = (v[1], v[0]);
@@ -101,9 +102,13 @@ impl Transform for ProjectionTransform {
 
 impl ProjectionTransform {
     pub fn new(jgd2wgs: Arc<Jgd2011ToWgs84>, output_epsg: EpsgCode) -> Self {
+        // For Japan Plane Rectangular CS
+        let jpr_zone_proj = JPRZone::from_epsg(output_epsg).map(|zone| zone.projection());
+
         Self {
             jgd2wgs,
             output_epsg,
+            jpr_zone_proj,
         }
     }
 }


### PR DESCRIPTION
https://github.com/MIERUNE/PLATEAU-GIS-Converter/pull/363#discussion_r1507325048 で検討されたことへの対応。

> 可能であれば zone.projection() をキャッシュするといいかなと思います。というのも zone.projection() を呼ぶたび（つまり地物ごとに）に横メルカトル計算用の係数テーブルが算出されることになってしまうので。

愚直にこういう形を一旦作ってみました。もしより良い方策があればご教授ください！

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 日本平面直角座標系の投影に対応するため、`ExtendedTransverseMercatorProjection` 構造体にオプショナルフィールド `jpr_zone_proj` を追加しました。
- **リファクタ**
	- `PoderEngsager` 構造体と `ExtendedTransverseMercatorProjection` 構造体に `Clone` トレイトを実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->