### PR TITLE
アプリ名を「PLATEAU GIS Converter」へ変更

### DIFF
--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "app"
 version.workspace = true
-description = "A Tauri App"
+description = "GIS Converter for PLATEAU data"
 authors.workspace = true
 license = ""
 default-run = "app"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
 		"distDir": "../build"
 	},
 	"package": {
-		"productName": "nusamai",
+		"productName": "PLATEAU GIS Converter",
 		"version": "0.1.0"
 	},
 	"tauri": {


### PR DESCRIPTION
- `PLATEAU GIS Converter`
  - 空白文字を含む: 「Google Chrome」などの例に見られるように、問題はなく、ハイフン区切りよりも見た目が良いと考える

## Before

<img width="159" alt="image" src="https://github.com/MIERUNE/PLATEAU-GIS-Converter/assets/595008/0f2aff1f-f3b3-4490-abbb-5fde5757aaa1">

## After

<img width="207" alt="image" src="https://github.com/MIERUNE/PLATEAU-GIS-Converter/assets/595008/5b84fa91-d1a4-4205-afb2-397529f79117">
