### PR TITLE
GUI: 出力EPSGの指定

### DIFF
--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -51,7 +51,13 @@ fn select_sink_provider(filetype: &str) -> Box<dyn DataSinkProvider> {
 }
 
 #[tauri::command]
-fn run(input_paths: Vec<String>, output_path: String, filetype: String, rules_path: String) {
+fn run(
+    input_paths: Vec<String>,
+    output_path: String,
+    filetype: String,
+    epsg: u16,
+    rules_path: String,
+) {
     let sinkopt: Vec<(String, String)> = vec![("@output".into(), output_path)];
 
     log::info!("Running pipeline with input: {:?}", input_paths);
@@ -73,7 +79,8 @@ fn run(input_paths: Vec<String>, output_path: String, filetype: String, rules_pa
         sink_provider.create(&sink_params)
     };
 
-    let requirements = sink.make_requirements();
+    let mut requirements = sink.make_requirements();
+    requirements.set_output_epsg(epsg);
 
     let source = {
         let source_provider: Box<dyn DataSourceProvider> = Box::new(CityGmlSourceProvider {

--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -103,14 +103,14 @@ fn run(
         use nusamai_citygml::CityGmlElement;
 
         let mapping_rules = if rules_path.is_empty() {
+            None
+        } else {
             // FIXME: error handling
             let file_contents =
                 std::fs::read_to_string(rules_path).expect("Error reading rules file");
             let mapping_rules: MappingRules =
                 serde_json::from_str(&file_contents).expect("Error parsing rules file");
             Some(mapping_rules)
-        } else {
-            None
         };
 
         let request = {

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -1,74 +1,75 @@
-type CrsOption = { value: number; label: string };
+type epsgOption = { value: number; label: string };
 
-const filetypeOptions: Record<string, { label: string; extensions: string[]; crs: CrsOption[] }> = {
-	geojson: {
-		label: 'GeoJSON',
-		extensions: [],
-		crs: [{ value: 4979, label: 'WGS84' }]
-	},
-	gpkg: {
-		label: 'GeoPackage',
-		extensions: ['gpkg'],
-		crs: [
-			{ value: 4979, label: 'WGS84' },
-			{ value: 10162, label: 'JGD 2011 / 平面直角座標系 I' },
-			{ value: 10163, label: 'JGD 2011 / 平面直角座標系 II' },
-			{ value: 10164, label: 'JGD 2011 / 平面直角座標系 III' },
-			{ value: 10165, label: 'JGD 2011 / 平面直角座標系 IV' },
-			{ value: 10166, label: 'JGD 2011 / 平面直角座標系 V' },
-			{ value: 10167, label: 'JGD 2011 / 平面直角座標系 VI' },
-			{ value: 10168, label: 'JGD 2011 / 平面直角座標系 VII' },
-			{ value: 10169, label: 'JGD 2011 / 平面直角座標系 VIII' },
-			{ value: 10170, label: 'JGD 2011 / 平面直角座標系 IX' },
-			{ value: 10171, label: 'JGD 2011 / 平面直角座標系 X' },
-			{ value: 10172, label: 'JGD 2011 / 平面直角座標系 XI' },
-			{ value: 10173, label: 'JGD 2011 / 平面直角座標系 XII' },
-			{ value: 10174, label: 'JGD 2011 / 平面直角座標系 XIII' }
-		]
-	},
-	mvt: {
-		label: 'Vector Tiles',
-		extensions: [''],
-		crs: [{ value: 4979, label: 'WGS84' }]
-	},
-	czml: {
-		label: 'CZML',
-		extensions: ['json'],
-		crs: [{ value: 4979, label: 'WGS84' }]
-	},
-	cesiumtiles: {
-		label: '3D Tiles',
-		extensions: [''],
-		crs: [{ value: 4979, label: 'WGS84' }]
-	},
-	kml: {
-		label: 'KML',
-		extensions: ['kml'],
-		crs: [{ value: 4979, label: 'WGS84' }]
-	},
-	shapefile: {
-		label: 'Shapefile',
-		extensions: ['shp'],
-		crs: [
-			{ value: 4979, label: 'WGS84' }
-			// TODO: more CRS options
-		]
-	},
-	ply: {
-		label: 'PLY',
-		extensions: ['ply'],
-		crs: [{ value: 4979, label: 'WGS84' }]
-	},
-	gltf: {
-		label: 'glTF',
-		extensions: [''],
-		crs: [{ value: 4979, label: 'WGS84' }]
-	},
-	serde: {
-		label: 'Serde',
-		extensions: [''],
-		crs: [{ value: 4979, label: 'WGS84' }]
-	}
-};
+const filetypeOptions: Record<string, { label: string; extensions: string[]; epsg: epsgOption[] }> =
+	{
+		geojson: {
+			label: 'GeoJSON',
+			extensions: [],
+			epsg: [{ value: 4979, label: 'WGS84' }]
+		},
+		gpkg: {
+			label: 'GeoPackage',
+			extensions: ['gpkg'],
+			epsg: [
+				{ value: 4979, label: 'WGS84' },
+				{ value: 10162, label: 'JGD 2011 / 平面直角座標系 I' },
+				{ value: 10163, label: 'JGD 2011 / 平面直角座標系 II' },
+				{ value: 10164, label: 'JGD 2011 / 平面直角座標系 III' },
+				{ value: 10165, label: 'JGD 2011 / 平面直角座標系 IV' },
+				{ value: 10166, label: 'JGD 2011 / 平面直角座標系 V' },
+				{ value: 10167, label: 'JGD 2011 / 平面直角座標系 VI' },
+				{ value: 10168, label: 'JGD 2011 / 平面直角座標系 VII' },
+				{ value: 10169, label: 'JGD 2011 / 平面直角座標系 VIII' },
+				{ value: 10170, label: 'JGD 2011 / 平面直角座標系 IX' },
+				{ value: 10171, label: 'JGD 2011 / 平面直角座標系 X' },
+				{ value: 10172, label: 'JGD 2011 / 平面直角座標系 XI' },
+				{ value: 10173, label: 'JGD 2011 / 平面直角座標系 XII' },
+				{ value: 10174, label: 'JGD 2011 / 平面直角座標系 XIII' }
+			]
+		},
+		mvt: {
+			label: 'Vector Tiles',
+			extensions: [''],
+			epsg: [{ value: 4979, label: 'WGS84' }]
+		},
+		czml: {
+			label: 'CZML',
+			extensions: ['json'],
+			epsg: [{ value: 4979, label: 'WGS84' }]
+		},
+		cesiumtiles: {
+			label: '3D Tiles',
+			extensions: [''],
+			epsg: [{ value: 4979, label: 'WGS84' }]
+		},
+		kml: {
+			label: 'KML',
+			extensions: ['kml'],
+			epsg: [{ value: 4979, label: 'WGS84' }]
+		},
+		shapefile: {
+			label: 'Shapefile',
+			extensions: ['shp'],
+			epsg: [
+				{ value: 4979, label: 'WGS84' }
+				// TODO: more epsg options
+			]
+		},
+		ply: {
+			label: 'PLY',
+			extensions: ['ply'],
+			epsg: [{ value: 4979, label: 'WGS84' }]
+		},
+		gltf: {
+			label: 'glTF',
+			extensions: [''],
+			epsg: [{ value: 4979, label: 'WGS84' }]
+		},
+		serde: {
+			label: 'Serde',
+			extensions: [''],
+			epsg: [{ value: 4979, label: 'WGS84' }]
+		}
+	};
 
 export { filetypeOptions };

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -1,50 +1,74 @@
-const filetypeOptions: Record<string, { label: string; extensions: string[] }> = {
+type CrsOption = { value: number; label: string };
+
+const filetypeOptions: Record<string, { label: string; extensions: string[]; crs: CrsOption[] }> = {
 	geojson: {
 		label: 'GeoJSON',
-		extensions: []
+		extensions: [],
+		crs: [{ value: 4979, label: 'WGS84' }]
 	},
 	gpkg: {
 		label: 'GeoPackage',
-		extensions: ['gpkg']
+		extensions: ['gpkg'],
+		crs: [
+			{ value: 4979, label: 'WGS84' },
+			{ value: 10162, label: 'JGD 2011 / 平面直角座標系 I' },
+			{ value: 10163, label: 'JGD 2011 / 平面直角座標系 II' },
+			{ value: 10164, label: 'JGD 2011 / 平面直角座標系 III' },
+			{ value: 10165, label: 'JGD 2011 / 平面直角座標系 IV' },
+			{ value: 10166, label: 'JGD 2011 / 平面直角座標系 V' },
+			{ value: 10167, label: 'JGD 2011 / 平面直角座標系 VI' },
+			{ value: 10168, label: 'JGD 2011 / 平面直角座標系 VII' },
+			{ value: 10169, label: 'JGD 2011 / 平面直角座標系 VIII' },
+			{ value: 10170, label: 'JGD 2011 / 平面直角座標系 IX' },
+			{ value: 10171, label: 'JGD 2011 / 平面直角座標系 X' },
+			{ value: 10172, label: 'JGD 2011 / 平面直角座標系 XI' },
+			{ value: 10173, label: 'JGD 2011 / 平面直角座標系 XII' },
+			{ value: 10174, label: 'JGD 2011 / 平面直角座標系 XIII' }
+		]
 	},
 	mvt: {
 		label: 'Vector Tiles',
-		extensions: ['']
+		extensions: [''],
+		crs: [{ value: 4979, label: 'WGS84' }]
 	},
 	czml: {
 		label: 'CZML',
-		extensions: ['json']
+		extensions: ['json'],
+		crs: [{ value: 4979, label: 'WGS84' }]
 	},
 	cesiumtiles: {
 		label: '3D Tiles',
-		extensions: ['']
+		extensions: [''],
+		crs: [{ value: 4979, label: 'WGS84' }]
 	},
 	kml: {
 		label: 'KML',
-		extensions: ['kml']
+		extensions: ['kml'],
+		crs: [{ value: 4979, label: 'WGS84' }]
 	},
 	shapefile: {
 		label: 'Shapefile',
-		extensions: ['shp']
+		extensions: ['shp'],
+		crs: [
+			{ value: 4979, label: 'WGS84' }
+			// TODO: more CRS options
+		]
 	},
 	ply: {
 		label: 'PLY',
-		extensions: ['ply']
+		extensions: ['ply'],
+		crs: [{ value: 4979, label: 'WGS84' }]
 	},
 	gltf: {
 		label: 'glTF',
-		extensions: ['']
+		extensions: [''],
+		crs: [{ value: 4979, label: 'WGS84' }]
 	},
 	serde: {
 		label: 'Serde',
-		extensions: ['']
+		extensions: [''],
+		crs: [{ value: 4979, label: 'WGS84' }]
 	}
 };
 
-const crsOptions = [
-	{ value: 'EPSG:6678', label: 'JGD2011 / Japan Plane Rectangular CS X' },
-	{ value: 'EPSG:4326', label: 'WGS 84' },
-	{ value: 'EPSG:3857', label: 'Web Mercator' }
-];
-
-export { crsOptions, filetypeOptions };
+export { filetypeOptions };

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -7,7 +7,7 @@
 	import LoadingAnimation from './LoadingAnimation.svelte';
 
 	let inputPaths: string[] = [];
-	let selectedFiletype: string;
+	let filetype: string;
 	let selectedEpsg: number;
 	let rulesPath = '';
 	let outputPath = '';
@@ -27,8 +27,7 @@
 		await invoke('run', {
 			inputPaths,
 			outputPath,
-			selectedFiletype,
-			selectedEpsg,
+			filetype,
 			rulesPath
 		});
 		isRunning = false;
@@ -53,9 +52,9 @@
 
 		<InputSelector bind:inputPaths />
 
-		<SettingSelector bind:selectedFiletype bind:selectedEpsg bind:rulesPath />
+		<SettingSelector bind:filetype bind:selectedEpsg bind:rulesPath />
 
-		<OutputSelector {selectedFiletype} bind:outputPath />
+		<OutputSelector {filetype} bind:outputPath />
 
 		<div class="flex justify-end">
 			<button

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -8,7 +8,7 @@
 
 	let inputPaths: string[] = [];
 	let selectedFiletype: string;
-	let selectedCrs: number;
+	let selectedEpsg: number;
 	let rulesPath = '';
 	let outputPath = '';
 	let isRunning = false;
@@ -28,7 +28,7 @@
 			inputPaths,
 			outputPath,
 			selectedFiletype,
-			selectedCrs,
+			selectedEpsg,
 			rulesPath
 		});
 		isRunning = false;
@@ -53,7 +53,7 @@
 
 		<InputSelector bind:inputPaths />
 
-		<SettingSelector bind:selectedFiletype bind:selectedCrs bind:rulesPath />
+		<SettingSelector bind:selectedFiletype bind:selectedEpsg bind:rulesPath />
 
 		<OutputSelector {selectedFiletype} bind:outputPath />
 

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -28,6 +28,7 @@
 			inputPaths,
 			outputPath,
 			filetype,
+			selectedCrs,
 			rulesPath
 		});
 		isRunning = false;

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -8,7 +8,7 @@
 
 	let inputPaths: string[] = [];
 	let filetype: string;
-	let selectedEpsg: number;
+	let epsg: number;
 	let rulesPath = '';
 	let outputPath = '';
 	let isRunning = false;
@@ -28,6 +28,7 @@
 			inputPaths,
 			outputPath,
 			filetype,
+			epsg,
 			rulesPath
 		});
 		isRunning = false;
@@ -52,7 +53,7 @@
 
 		<InputSelector bind:inputPaths />
 
-		<SettingSelector bind:filetype bind:selectedEpsg bind:rulesPath />
+		<SettingSelector bind:filetype bind:epsg bind:rulesPath />
 
 		<OutputSelector {filetype} bind:outputPath />
 

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -7,7 +7,7 @@
 	import LoadingAnimation from './LoadingAnimation.svelte';
 
 	let inputPaths: string[] = [];
-	let filetype: string;
+	let selectedFiletype: string;
 	let selectedCrs: number;
 	let rulesPath = '';
 	let outputPath = '';
@@ -27,12 +27,12 @@
 		await invoke('run', {
 			inputPaths,
 			outputPath,
-			filetype,
+			selectedFiletype,
 			selectedCrs,
 			rulesPath
 		});
 		isRunning = false;
-		alert(`${filetype}形式で '${outputPath}' に出力しました。`);
+		alert(`'${outputPath}' に出力しました。`);
 	}
 </script>
 
@@ -53,9 +53,9 @@
 
 		<InputSelector bind:inputPaths />
 
-		<SettingSelector bind:filetype bind:selectedCrs bind:rulesPath />
+		<SettingSelector bind:selectedFiletype bind:selectedCrs bind:rulesPath />
 
-		<OutputSelector {filetype} bind:outputPath />
+		<OutputSelector {selectedFiletype} bind:outputPath />
 
 		<div class="flex justify-end">
 			<button

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -8,6 +8,7 @@
 
 	let inputPaths: string[] = [];
 	let filetype: string;
+	let selectedCrs: number;
 	let rulesPath = '';
 	let outputPath = '';
 	let isRunning = false;
@@ -51,7 +52,7 @@
 
 		<InputSelector bind:inputPaths />
 
-		<SettingSelector bind:filetype bind:rulesPath />
+		<SettingSelector bind:filetype bind:selectedCrs bind:rulesPath />
 
 		<OutputSelector {filetype} bind:outputPath />
 

--- a/app/src/routes/OutputSelector.svelte
+++ b/app/src/routes/OutputSelector.svelte
@@ -4,7 +4,7 @@
 	import { abbreviatePath } from '$lib/utils';
 	import { filetypeOptions } from '$lib/settings';
 
-	export let selectedFiletype: string;
+	export let filetype: string;
 	export let outputPath: string;
 
 	async function openOutputDialog() {
@@ -12,7 +12,7 @@
 			filters: [
 				{
 					name: 'Output format',
-					extensions: filetypeOptions[selectedFiletype].extensions
+					extensions: filetypeOptions[filetype].extensions
 				}
 			]
 		});

--- a/app/src/routes/OutputSelector.svelte
+++ b/app/src/routes/OutputSelector.svelte
@@ -4,7 +4,7 @@
 	import { abbreviatePath } from '$lib/utils';
 	import { filetypeOptions } from '$lib/settings';
 
-	export let filetype: string;
+	export let selectedFiletype: string;
 	export let outputPath: string;
 
 	async function openOutputDialog() {
@@ -12,7 +12,7 @@
 			filters: [
 				{
 					name: 'Output format',
-					extensions: filetypeOptions[filetype].extensions
+					extensions: filetypeOptions[selectedFiletype].extensions
 				}
 			]
 		});

--- a/app/src/routes/SettingSelector.svelte
+++ b/app/src/routes/SettingSelector.svelte
@@ -8,7 +8,7 @@
 	export let rulesPath: string;
 
 	$: epsgOptions = filetypeOptions[filetype]?.epsg || [];
-	$: disableCrsOptions = epsgOptions.length < 2;
+	$: disableEpsgOptions = epsgOptions.length < 2;
 
 	async function openRulesPathDialog() {
 		const res = await dialog.open({
@@ -52,8 +52,8 @@
 				name="epsg"
 				id="epsg-select"
 				class="w-64"
-				disabled={disableCrsOptions}
-				class:opacity-50={disableCrsOptions}
+				disabled={disableEpsgOptions}
+				class:opacity-50={disableEpsgOptions}
 			>
 				{#each epsgOptions as option}
 					<option value={option.value}>{option.label}</option>

--- a/app/src/routes/SettingSelector.svelte
+++ b/app/src/routes/SettingSelector.svelte
@@ -49,7 +49,7 @@
 			<select
 				name="crs"
 				id="crs-select"
-				class="w-36"
+				class="w-64"
 				disabled={disableCrsOptions}
 				class:opacity-50={disableCrsOptions}
 			>

--- a/app/src/routes/SettingSelector.svelte
+++ b/app/src/routes/SettingSelector.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 	import { dialog } from '@tauri-apps/api';
 	import Icon from '@iconify/svelte';
-	import { filetypeOptions, crsOptions } from '$lib/settings';
+	import { filetypeOptions } from '$lib/settings';
 
 	export let filetype: string;
 	export let rulesPath: string;
+
+	$: crsOptions = filetypeOptions[filetype]?.crs || [];
 
 	async function openRulesPathDialog() {
 		const res = await dialog.open({
@@ -41,7 +43,7 @@
 			</select>
 		</div>
 
-		<div class=" flex flex-col gap-1.5 opacity-50">
+		<div class=" flex flex-col gap-1.5">
 			<label for="crs-select" class="font-bold">座標参照系</label>
 			<select name="crs" id="crs-select" class="w-80">
 				{#each crsOptions as crs}

--- a/app/src/routes/SettingSelector.svelte
+++ b/app/src/routes/SettingSelector.svelte
@@ -4,7 +4,7 @@
 	import { filetypeOptions } from '$lib/settings';
 
 	export let selectedFiletype: string = 'gpkg';
-	export let selectedCrs: number = 4979;
+	export let selectedEpsg: number = 4979;
 	export let rulesPath: string;
 
 	$: crsOptions = filetypeOptions[selectedFiletype]?.crs || [];
@@ -48,7 +48,7 @@
 		<div class=" flex flex-col gap-1.5">
 			<label for="crs-select" class="font-bold">座標参照系</label>
 			<select
-				bind:value={selectedCrs}
+				bind:value={selectedEpsg}
 				name="crs"
 				id="crs-select"
 				class="w-64"

--- a/app/src/routes/SettingSelector.svelte
+++ b/app/src/routes/SettingSelector.svelte
@@ -7,8 +7,8 @@
 	export let epsg: number = 4979;
 	export let rulesPath: string;
 
-	$: crsOptions = filetypeOptions[filetype]?.crs || [];
-	$: disableCrsOptions = crsOptions.length < 2;
+	$: epsgOptions = filetypeOptions[filetype]?.epsg || [];
+	$: disableCrsOptions = epsgOptions.length < 2;
 
 	async function openRulesPathDialog() {
 		const res = await dialog.open({
@@ -46,17 +46,17 @@
 		</div>
 
 		<div class=" flex flex-col gap-1.5">
-			<label for="crs-select" class="font-bold">座標参照系</label>
+			<label for="epsg-select" class="font-bold">座標参照系</label>
 			<select
 				bind:value={epsg}
-				name="crs"
-				id="crs-select"
+				name="epsg"
+				id="epsg-select"
 				class="w-64"
 				disabled={disableCrsOptions}
 				class:opacity-50={disableCrsOptions}
 			>
-				{#each crsOptions as crs}
-					<option value={crs.value}>{crs.label}</option>
+				{#each epsgOptions as option}
+					<option value={option.value}>{option.label}</option>
 				{/each}
 			</select>
 		</div>

--- a/app/src/routes/SettingSelector.svelte
+++ b/app/src/routes/SettingSelector.svelte
@@ -3,11 +3,11 @@
 	import Icon from '@iconify/svelte';
 	import { filetypeOptions } from '$lib/settings';
 
-	export let selectedFiletype: string = 'gpkg';
+	export let filetype: string;
 	export let selectedEpsg: number = 4979;
 	export let rulesPath: string;
 
-	$: crsOptions = filetypeOptions[selectedFiletype]?.crs || [];
+	$: crsOptions = filetypeOptions[filetype]?.crs || [];
 	$: disableCrsOptions = crsOptions.length < 2;
 
 	async function openRulesPathDialog() {
@@ -38,7 +38,7 @@
 	<div class="flex flex-col gap-5 mt-3 ml-2">
 		<div class=" flex flex-col gap-1.5">
 			<label for="filetype-select" class="font-bold">ファイル形式</label>
-			<select bind:value={selectedFiletype} name="filetype" id="filetype-select" class="w-36">
+			<select bind:value={filetype} name="filetype" id="filetype-select" class="w-36">
 				{#each Object.entries(filetypeOptions) as [value, item]}
 					<option {value}>{item.label}</option>
 				{/each}

--- a/app/src/routes/SettingSelector.svelte
+++ b/app/src/routes/SettingSelector.svelte
@@ -3,11 +3,11 @@
 	import Icon from '@iconify/svelte';
 	import { filetypeOptions } from '$lib/settings';
 
-	export let filetype: string = 'gpkg';
+	export let selectedFiletype: string = 'gpkg';
 	export let selectedCrs: number = 4979;
 	export let rulesPath: string;
 
-	$: crsOptions = filetypeOptions[filetype]?.crs || [];
+	$: crsOptions = filetypeOptions[selectedFiletype]?.crs || [];
 	$: disableCrsOptions = crsOptions.length < 2;
 
 	async function openRulesPathDialog() {
@@ -38,7 +38,7 @@
 	<div class="flex flex-col gap-5 mt-3 ml-2">
 		<div class=" flex flex-col gap-1.5">
 			<label for="filetype-select" class="font-bold">ファイル形式</label>
-			<select bind:value={filetype} name="filetype" id="filetype-select" class="w-36">
+			<select bind:value={selectedFiletype} name="filetype" id="filetype-select" class="w-36">
 				{#each Object.entries(filetypeOptions) as [value, item]}
 					<option {value}>{item.label}</option>
 				{/each}

--- a/app/src/routes/SettingSelector.svelte
+++ b/app/src/routes/SettingSelector.svelte
@@ -7,6 +7,7 @@
 	export let rulesPath: string;
 
 	$: crsOptions = filetypeOptions[filetype]?.crs || [];
+	$: disableCrsOptions = crsOptions.length < 2;
 
 	async function openRulesPathDialog() {
 		const res = await dialog.open({
@@ -45,7 +46,13 @@
 
 		<div class=" flex flex-col gap-1.5">
 			<label for="crs-select" class="font-bold">座標参照系</label>
-			<select name="crs" id="crs-select" class="w-36">
+			<select
+				name="crs"
+				id="crs-select"
+				class="w-36"
+				disabled={disableCrsOptions}
+				class:opacity-50={disableCrsOptions}
+			>
 				{#each crsOptions as crs}
 					<option value={crs.value}>{crs.label}</option>
 				{/each}

--- a/app/src/routes/SettingSelector.svelte
+++ b/app/src/routes/SettingSelector.svelte
@@ -62,7 +62,7 @@
 		</div>
 
 		<div class=" flex flex-col gap-1.5">
-			<label for="crs-select" class="font-bold">属性マッピングルール</label>
+			<label for="mapping-rule-select" class="font-bold">属性マッピングルール</label>
 			<div class="flex items-center gap-3">
 				<button
 					on:click={openRulesPathDialog}

--- a/app/src/routes/SettingSelector.svelte
+++ b/app/src/routes/SettingSelector.svelte
@@ -3,7 +3,7 @@
 	import Icon from '@iconify/svelte';
 	import { filetypeOptions } from '$lib/settings';
 
-	export let filetype: string;
+	export let filetype: string = 'gpkg';
 	export let selectedCrs: number = 4979;
 	export let rulesPath: string;
 

--- a/app/src/routes/SettingSelector.svelte
+++ b/app/src/routes/SettingSelector.svelte
@@ -46,13 +46,7 @@
 
 		<div class=" flex flex-col gap-1.5">
 			<label for="crs-select" class="font-bold">座標参照系</label>
-			<select
-				name="crs"
-				id="crs-select"
-				class="w-64"
-				disabled={disableCrsOptions}
-				class:opacity-50={disableCrsOptions}
-			>
+			<select name="crs" id="crs-select" class="w-64" class:opacity-60={disableCrsOptions}>
 				{#each crsOptions as crs}
 					<option value={crs.value}>{crs.label}</option>
 				{/each}

--- a/app/src/routes/SettingSelector.svelte
+++ b/app/src/routes/SettingSelector.svelte
@@ -4,6 +4,7 @@
 	import { filetypeOptions } from '$lib/settings';
 
 	export let filetype: string;
+	export let selectedCrs: number = 4979;
 	export let rulesPath: string;
 
 	$: crsOptions = filetypeOptions[filetype]?.crs || [];
@@ -46,7 +47,14 @@
 
 		<div class=" flex flex-col gap-1.5">
 			<label for="crs-select" class="font-bold">座標参照系</label>
-			<select name="crs" id="crs-select" class="w-64" class:opacity-60={disableCrsOptions}>
+			<select
+				bind:value={selectedCrs}
+				name="crs"
+				id="crs-select"
+				class="w-64"
+				disabled={disableCrsOptions}
+				class:opacity-50={disableCrsOptions}
+			>
 				{#each crsOptions as crs}
 					<option value={crs.value}>{crs.label}</option>
 				{/each}

--- a/app/src/routes/SettingSelector.svelte
+++ b/app/src/routes/SettingSelector.svelte
@@ -45,7 +45,7 @@
 
 		<div class=" flex flex-col gap-1.5">
 			<label for="crs-select" class="font-bold">座標参照系</label>
-			<select name="crs" id="crs-select" class="w-80">
+			<select name="crs" id="crs-select" class="w-36">
 				{#each crsOptions as crs}
 					<option value={crs.value}>{crs.label}</option>
 				{/each}

--- a/app/src/routes/SettingSelector.svelte
+++ b/app/src/routes/SettingSelector.svelte
@@ -4,7 +4,7 @@
 	import { filetypeOptions } from '$lib/settings';
 
 	export let filetype: string;
-	export let selectedEpsg: number = 4979;
+	export let epsg: number = 4979;
 	export let rulesPath: string;
 
 	$: crsOptions = filetypeOptions[filetype]?.crs || [];
@@ -48,7 +48,7 @@
 		<div class=" flex flex-col gap-1.5">
 			<label for="crs-select" class="font-bold">座標参照系</label>
 			<select
-				bind:value={selectedEpsg}
+				bind:value={epsg}
 				name="crs"
 				id="crs-select"
 				class="w-64"


### PR DESCRIPTION
#378 （CLIでの例）を踏まえて。

## 例

<img width="636" alt="image" src="https://github.com/MIERUNE/PLATEAU-GIS-Converter/assets/595008/adfc32bd-d657-4a84-bea2-e78cdd411689">


選択肢が一つしかない場合は、透明度を上げて、disabledにしている（クリックできない状態）

<img width="752" alt="image" src="https://github.com/MIERUNE/PLATEAU-GIS-Converter/assets/595008/d7ab6d0f-27bd-4fcd-9207-0e41002b9b10">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
    - ファイル設定選択時に座標参照システム(CRS)オプションを動的に設定可能になりました。
    - ファイル設定選択時の機能が拡張され、新しいCRSオプションが追加されました。
    - EPSG値の処理機能が向上しました。

- **リファクタ**
    - 設定選択コンポーネントの内部ロジックが改善され、CRSオプションの動的な無効化が可能になりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->