### PR TITLE
バグ修正: gpkgでマッピングルールが正しく処理されない

### DIFF
--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -96,14 +96,14 @@ fn run(input_paths: Vec<String>, output_path: String, filetype: String, rules_pa
         use nusamai_citygml::CityGmlElement;
 
         let mapping_rules = if rules_path.is_empty() {
+            None
+        } else {
             // FIXME: error handling
             let file_contents =
                 std::fs::read_to_string(rules_path).expect("Error reading rules file");
             let mapping_rules: MappingRules =
                 serde_json::from_str(&file_contents).expect("Error parsing rules file");
             Some(mapping_rules)
-        } else {
-            None
         };
 
         let request = {


### PR DESCRIPTION
## 状況

GUIでのみ発生

- ファイル形式に「GeoPackage」を選ぶ
  - 「属性マッピングルール」を指定しないと、パニックする
  - 「属性マッピングルール」を指定しても、それは適用されない

## 原因

条件が逆になっていた

（ #367 での導入 - 3月1日, 7:54PMにマージ）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタ**
	- `rules_path`が空の場合に`mapping_rules`の初期化を調整し、そのケースで`None`に設定するように変更しました。ルールファイルの内容を扱うロジックを合理化します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->