### PR TITLE
GUI: 「出力形式」の順番整理、区切りの追加

### DIFF
--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -1,79 +1,110 @@
 type epsgOption = { value: number; label: string };
 
-const filetypeOptions: Record<string, { label: string; extensions: string[]; epsg: epsgOption[] }> =
+type filetypeOption = {
+	sinkId: string;
+	label: string;
+	extensions: string[];
+	epsg: epsgOption[];
+};
+
+export let optionDivider: filetypeOption = {
+	sinkId: 'hr',
+	label: '',
+	extensions: [],
+	epsg: []
+};
+
+const filetypeOptions: filetypeOption[] = [
 	{
-		gpkg: {
-			label: 'GeoPackage',
-			extensions: ['gpkg'],
-			epsg: [
-				{ value: 4979, label: 'WGS84' },
-				{ value: 10162, label: 'JGD 2011 / 平面直角座標系 I' },
-				{ value: 10163, label: 'JGD 2011 / 平面直角座標系 II' },
-				{ value: 10164, label: 'JGD 2011 / 平面直角座標系 III' },
-				{ value: 10165, label: 'JGD 2011 / 平面直角座標系 IV' },
-				{ value: 10166, label: 'JGD 2011 / 平面直角座標系 V' },
-				{ value: 10167, label: 'JGD 2011 / 平面直角座標系 VI' },
-				{ value: 10168, label: 'JGD 2011 / 平面直角座標系 VII' },
-				{ value: 10169, label: 'JGD 2011 / 平面直角座標系 VIII' },
-				{ value: 10170, label: 'JGD 2011 / 平面直角座標系 IX' },
-				{ value: 10171, label: 'JGD 2011 / 平面直角座標系 X' },
-				{ value: 10172, label: 'JGD 2011 / 平面直角座標系 XI' },
-				{ value: 10173, label: 'JGD 2011 / 平面直角座標系 XII' },
-				{ value: 10174, label: 'JGD 2011 / 平面直角座標系 XIII' }
-			]
-		},
-		geojson: {
-			label: 'GeoJSON',
-			extensions: [],
-			epsg: [{ value: 4979, label: 'WGS84' }]
-		},
+		sinkId: 'gpkg',
+		label: 'GeoPackage',
+		extensions: ['gpkg'],
+		epsg: [
+			{ value: 4979, label: 'WGS84' },
+			{ value: 10162, label: 'JGD 2011 / 平面直角座標系 I' },
+			{ value: 10163, label: 'JGD 2011 / 平面直角座標系 II' },
+			{ value: 10164, label: 'JGD 2011 / 平面直角座標系 III' },
+			{ value: 10165, label: 'JGD 2011 / 平面直角座標系 IV' },
+			{ value: 10166, label: 'JGD 2011 / 平面直角座標系 V' },
+			{ value: 10167, label: 'JGD 2011 / 平面直角座標系 VI' },
+			{ value: 10168, label: 'JGD 2011 / 平面直角座標系 VII' },
+			{ value: 10169, label: 'JGD 2011 / 平面直角座標系 VIII' },
+			{ value: 10170, label: 'JGD 2011 / 平面直角座標系 IX' },
+			{ value: 10171, label: 'JGD 2011 / 平面直角座標系 X' },
+			{ value: 10172, label: 'JGD 2011 / 平面直角座標系 XI' },
+			{ value: 10173, label: 'JGD 2011 / 平面直角座標系 XII' },
+			{ value: 10174, label: 'JGD 2011 / 平面直角座標系 XIII' }
+		]
+	},
+	{
+		sinkId: 'geojson',
+		label: 'GeoJSON',
+		extensions: [],
+		epsg: [{ value: 4979, label: 'WGS84' }]
+	},
 
-		cesiumtiles: {
-			label: '3D Tiles',
-			extensions: [''],
-			epsg: [{ value: 4979, label: 'WGS84' }]
-		},
-		mvt: {
-			label: 'Vector Tiles',
-			extensions: [''],
-			epsg: [{ value: 4979, label: 'WGS84' }]
-		},
+	optionDivider,
 
-		czml: {
-			label: 'CZML',
-			extensions: ['json'],
-			epsg: [{ value: 4979, label: 'WGS84' }]
-		},
-		kml: {
-			label: 'KML',
-			extensions: ['kml'],
-			epsg: [{ value: 4979, label: 'WGS84' }]
-		},
+	{
+		sinkId: 'cesiumtiles',
+		label: '3D Tiles',
+		extensions: [''],
+		epsg: [{ value: 4979, label: 'WGS84' }]
+	},
+	{
+		sinkId: 'mvt',
+		label: 'Vector Tiles',
+		extensions: [''],
+		epsg: [{ value: 4979, label: 'WGS84' }]
+	},
 
-		ply: {
-			label: 'PLY',
-			extensions: ['ply'],
-			epsg: [{ value: 4979, label: 'WGS84' }]
-		},
-		gltf: {
-			label: 'glTF',
-			extensions: [''],
-			epsg: [{ value: 4979, label: 'WGS84' }]
-		},
-		serde: {
-			label: 'Serde',
-			extensions: [''],
-			epsg: [{ value: 4979, label: 'WGS84' }]
-		},
+	optionDivider,
 
-		shapefile: {
-			label: 'Shapefile',
-			extensions: ['shp'],
-			epsg: [
-				{ value: 4979, label: 'WGS84' }
-				// TODO: more epsg options
-			]
-		}
-	};
+	{
+		sinkId: 'czml',
+		label: 'CZML',
+		extensions: ['json'],
+		epsg: [{ value: 4979, label: 'WGS84' }]
+	},
+	{
+		sinkId: 'kml',
+		label: 'KML',
+		extensions: ['kml'],
+		epsg: [{ value: 4979, label: 'WGS84' }]
+	},
+
+	optionDivider,
+
+	{
+		sinkId: 'ply',
+		label: 'PLY',
+		extensions: ['ply'],
+		epsg: [{ value: 4979, label: 'WGS84' }]
+	},
+	{
+		sinkId: 'gltf',
+		label: 'glTF',
+		extensions: [''],
+		epsg: [{ value: 4979, label: 'WGS84' }]
+	},
+	{
+		sinkId: 'serde',
+		label: 'Serde',
+		extensions: [''],
+		epsg: [{ value: 4979, label: 'WGS84' }]
+	},
+
+	optionDivider,
+
+	{
+		sinkId: 'shapefile',
+		label: 'Shapefile',
+		extensions: ['shp'],
+		epsg: [
+			{ value: 4979, label: 'WGS84' }
+			// TODO: more epsg options
+		]
+	}
+];
 
 export { filetypeOptions };

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -2,11 +2,6 @@ type epsgOption = { value: number; label: string };
 
 const filetypeOptions: Record<string, { label: string; extensions: string[]; epsg: epsgOption[] }> =
 	{
-		geojson: {
-			label: 'GeoJSON',
-			extensions: [],
-			epsg: [{ value: 4979, label: 'WGS84' }]
-		},
 		gpkg: {
 			label: 'GeoPackage',
 			extensions: ['gpkg'],
@@ -27,19 +22,26 @@ const filetypeOptions: Record<string, { label: string; extensions: string[]; eps
 				{ value: 10174, label: 'JGD 2011 / 平面直角座標系 XIII' }
 			]
 		},
+		geojson: {
+			label: 'GeoJSON',
+			extensions: [],
+			epsg: [{ value: 4979, label: 'WGS84' }]
+		},
+
+		cesiumtiles: {
+			label: '3D Tiles',
+			extensions: [''],
+			epsg: [{ value: 4979, label: 'WGS84' }]
+		},
 		mvt: {
 			label: 'Vector Tiles',
 			extensions: [''],
 			epsg: [{ value: 4979, label: 'WGS84' }]
 		},
+
 		czml: {
 			label: 'CZML',
 			extensions: ['json'],
-			epsg: [{ value: 4979, label: 'WGS84' }]
-		},
-		cesiumtiles: {
-			label: '3D Tiles',
-			extensions: [''],
 			epsg: [{ value: 4979, label: 'WGS84' }]
 		},
 		kml: {
@@ -47,14 +49,7 @@ const filetypeOptions: Record<string, { label: string; extensions: string[]; eps
 			extensions: ['kml'],
 			epsg: [{ value: 4979, label: 'WGS84' }]
 		},
-		shapefile: {
-			label: 'Shapefile',
-			extensions: ['shp'],
-			epsg: [
-				{ value: 4979, label: 'WGS84' }
-				// TODO: more epsg options
-			]
-		},
+
 		ply: {
 			label: 'PLY',
 			extensions: ['ply'],
@@ -69,6 +64,15 @@ const filetypeOptions: Record<string, { label: string; extensions: string[]; eps
 			label: 'Serde',
 			extensions: [''],
 			epsg: [{ value: 4979, label: 'WGS84' }]
+		},
+
+		shapefile: {
+			label: 'Shapefile',
+			extensions: ['shp'],
+			epsg: [
+				{ value: 4979, label: 'WGS84' }
+				// TODO: more epsg options
+			]
 		}
 	};
 

--- a/app/src/routes/SettingSelector.svelte
+++ b/app/src/routes/SettingSelector.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import { dialog } from '@tauri-apps/api';
 	import Icon from '@iconify/svelte';
-	import { filetypeOptions } from '$lib/settings';
+	import { filetypeOptions, optionDivider } from '$lib/settings';
 
 	export let filetype: string;
 	export let epsg: number = 4979;
 	export let rulesPath: string;
 
-	$: epsgOptions = filetypeOptions[filetype]?.epsg || [];
+	$: epsgOptions = filetypeOptions[0]?.epsg || [];
 	$: disableEpsgOptions = epsgOptions.length < 2;
 
 	async function openRulesPathDialog() {
@@ -39,8 +39,12 @@
 		<div class=" flex flex-col gap-1.5">
 			<label for="filetype-select" class="font-bold">ファイル形式</label>
 			<select bind:value={filetype} name="filetype" id="filetype-select" class="w-36">
-				{#each Object.entries(filetypeOptions) as [value, item]}
-					<option {value}>{item.label}</option>
+				{#each filetypeOptions as option}
+					{#if option === optionDivider}
+						<hr />
+					{:else}
+						<option value={option.sinkId}>{option.label}</option>
+					{/if}
 				{/each}
 			</select>
 		</div>


### PR DESCRIPTION
## Before

<img width="309" alt="image" src="https://github.com/MIERUNE/PLATEAU-GIS-Converter/assets/595008/6243c62f-d8c1-49c5-a939-e96623ff0d74">

## After

<img width="355" alt="image" src="https://github.com/MIERUNE/PLATEAU-GIS-Converter/assets/595008/52825f48-5b36-425e-9b0b-0c0285f15634">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ファイルタイプ選択のオプションが改善され、より詳細な設定が可能になりました。各ファイルタイプに`sinkId`が追加され、オプションが`optionDivider`で区切られて整理されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->