### PR TITLE
CI: CODECOV_TOKEN はもう必要ない

### DIFF
--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -39,8 +39,8 @@ jobs:
         run: cargo llvm-cov --package app --lcov --output-path lcov.info --all-features
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        # env:
+        #   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -40,8 +40,8 @@ jobs:
         run: cargo llvm-cov --workspace --exclude app --lcov --output-path lcov.info --all-features
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        # env:
+        #   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: lcov.info
           fail_ci_if_error: false


### PR DESCRIPTION
リポジトリが public になったため、Codecovへの報告にトークンはもう必要ない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Codecovへのカバレッジレポートのアップロードに影響を与える可能性のある、Codecovアクションの`CODECOV_TOKEN`環境変数の割り当てをコメントアウトしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->