### PR TITLE
GUI: エラー発生時にアラートダイアログ表示

### DIFF
--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ nusamai-plateau = { path = "../../nusamai-plateau" }
 nusamai-citygml = {path = "../../nusamai-citygml" }
 log = "0.4.20"
 pretty_env_logger = "0.5.0"
+thiserror = "1.0.57"
 
 
 [features]

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -24,15 +24,21 @@
 		}
 
 		isRunning = true;
-		await invoke('run', {
-			inputPaths,
-			outputPath,
-			filetype,
-			epsg,
-			rulesPath
-		});
+
+		try {
+			await invoke('run', {
+				inputPaths,
+				outputPath,
+				filetype,
+				epsg,
+				rulesPath
+			});
+			alert(`変換が完了しました。\n'${outputPath}' に出力しました。`);
+		} catch (error) {
+			alert(`エラーが発生しました。\n\n${error}`);
+		}
+
 		isRunning = false;
-		alert(`'${outputPath}' に出力しました。`);
 	}
 </script>
 


### PR DESCRIPTION
close #336 

## 現在

バックエンドでエラーが発生しても、フロントエンド側は関知せず、「出力しました」アラートダイアログを出してしまう。


## 変更

- バックエンドの関数がResultを返す
- それを受け取ったフロントエンドが、エラーの場合はアラート表示する

<img width="372" alt="image" src="https://github.com/MIERUNE/PLATEAU-GIS-Converter/assets/595008/ff0734b1-8487-4904-aee5-8dead0f83777">

参考: [Calling Rust from the frontend | Tauri Apps](https://tauri.app/v1/guides/features/command/#error-handling)

## 備考

パニックしたらどうしようもない。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - `thiserror::Error` を追加し、エラーハンドリングを強化しました。
    - カスタム `Error` 列挙型を定義しました。
    - `run` 関数が `Result<(), Error>` を返すように変更されました。
    - `run` 関数内のエラーハンドリングが特定のエラーを返すように更新されました。
    - `Error` に `serde::Serialize` を実装し、シリアル化を可能にしました。
    - `run` 関数内のエラーロギングとエラーの返却が調整されました。
    - `run` 関数の最後に `Ok(())` の返却が追加されました。
- **改善点**
    - `invoke('run')` の呼び出しを try-catch ブロックで囲むように機能を更新しました。変換プロセス中の成功とエラーに対してアラートを介したエラーハンドリングが導入されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->