### PR TITLE
いくつかのunwrap除去（簡単に対応できるもの）

### DIFF
--- a/nusamai/src/main.rs
+++ b/nusamai/src/main.rs
@@ -213,10 +213,9 @@ fn run(
         transform_builder.transform_schema(&mut schema);
 
         if let Some(schema_path) = &args.schema {
-            // TODO: error handling
             let mut file = std::fs::File::create(schema_path).unwrap();
             file.write_all(serde_json::to_string_pretty(&schema).unwrap().as_bytes())
-                .unwrap();
+                .unwrap(); // FIXME: error handling
         }
 
         let transformer = Box::new(MultiThreadTransformer::new(transform_builder));

--- a/nusamai/src/sink/cesiumtiles/material.rs
+++ b/nusamai/src/sink/cesiumtiles/material.rs
@@ -113,9 +113,9 @@ fn load_image(path: &Path) -> std::io::Result<Vec<u8>> {
     log::info!("Decoding image: {:?}", path);
 
     if let Some(ext) = path.extension() {
-        match ext.to_str().unwrap() {
+        match ext.to_str() {
             // use `image crate` for TIFF
-            "tif" | "tiff" | "png" | "jpg" | "jpeg" => {
+            Some("tif" | "tiff" | "png" | "jpg" | "jpeg") => {
                 let t = Instant::now();
                 let image = image::open(path)
                     .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;

--- a/nusamai/src/sink/gltf/gltf_writer.rs
+++ b/nusamai/src/sink/gltf/gltf_writer.rs
@@ -306,9 +306,9 @@ pub fn write_3dtiles(
         ..Default::default()
     };
 
-    let mut tileset_file = File::create(tileset_path).unwrap();
+    let mut tileset_file = File::create(tileset_path)?;
     let tileset_writer = BufWriter::with_capacity(1024 * 1024, &mut tileset_file);
-    serde_json::to_writer_pretty(tileset_writer, &tileset).unwrap();
+    serde_json::to_writer_pretty(tileset_writer, &tileset)?;
 
     Ok(())
 }

--- a/nusamai/src/sink/gltf/material.rs
+++ b/nusamai/src/sink/gltf/material.rs
@@ -113,9 +113,9 @@ fn load_image(path: &Path) -> std::io::Result<Vec<u8>> {
     log::info!("Decoding image: {:?}", path);
 
     if let Some(ext) = path.extension() {
-        match ext.to_str().unwrap() {
+        match ext.to_str() {
             // use `image crate` for TIFF
-            "tif" | "tiff" | "png" | "jpg" | "jpeg" => {
+            Some("tif" | "tiff" | "png" | "jpg" | "jpeg") => {
                 let t = Instant::now();
                 let image = image::open(path)
                     .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;

--- a/nusamai/src/sink/gltf/metadata/mod.rs
+++ b/nusamai/src/sink/gltf/metadata/mod.rs
@@ -46,10 +46,6 @@ pub fn make_metadata(
         let mut properties = property_table.properties.iter().collect::<Vec<_>>();
         properties.sort_by(|a, b| a.1.values.cmp(&b.1.values));
 
-        features
-            .clone()
-            .sort_by(|a, b| a.feature_id.cmp(&b.feature_id));
-
         // we need to write buffers for each column in the same order as in the propertyTable generated from the schema
         // and also need to start from the 0th record of the feature_id
         // todo: whenever they are null, we need to modify them so that they are not written
@@ -89,7 +85,6 @@ pub fn make_metadata(
 
                         // if component_type is Some, write a numeric value to the buffer
                         if let Some(component_type) = component_type {
-                            let component_type = component_type.clone();
                             match component_type {
                                 ClassPropertyComponentType::Int8 => {
                                     buf.write_i8(0).unwrap();
@@ -173,7 +168,7 @@ pub fn make_metadata(
     // Schema
     let schema = Schema {
         id: typename.to_string(),
-        classes: classes.clone(),
+        classes,
         // enums,
         ..Default::default()
     };
@@ -372,7 +367,7 @@ impl ToBytes for Value {
             Value::Integer(i) => i.write_to_bytes(buffer),
             Value::NonNegativeInteger(u) => u.write_to_bytes(buffer),
             Value::Double(d) => d.write_to_bytes(buffer),
-            Value::Boolean(b) => b.write_to_bytes(buffer),
+            Value::Boolean(b) => b.write_to_bytes(buffer), // FIXME: boolean value must be stored as bitstream.
             Value::Measure(m) => m.write_to_bytes(buffer),
             _ => {
                 // todo: implement

--- a/nusamai/src/sink/kml/mod.rs
+++ b/nusamai/src/sink/kml/mod.rs
@@ -181,19 +181,18 @@ impl DataSink for KmlSink {
                     },
                 };
 
-                let mut file = File::create(&self.output_path).unwrap();
+                let mut file = File::create(&self.output_path)?;
                 let mut buf_writer = BufWriter::with_capacity(1024 * 1024, &mut file);
 
-                writeln!(buf_writer, r#"<?xml version="1.0" encoding="UTF-8"?>"#).unwrap();
+                writeln!(buf_writer, r#"<?xml version="1.0" encoding="UTF-8"?>"#)?;
                 writeln!(
                     buf_writer,
                     r#"<kml xmlns="http://www.opengis.net/kml/2.2">"#
-                )
-                .unwrap();
+                )?;
 
                 let mut kml_writer = KmlWriter::from_writer(&mut buf_writer);
                 let _ = kml_writer.write(&kml_doc);
-                writeln!(buf_writer, "</kml>").unwrap();
+                writeln!(buf_writer, "</kml>")?;
 
                 Ok(())
             },

--- a/nusamai/src/sink/shapefile/mod.rs
+++ b/nusamai/src/sink/shapefile/mod.rs
@@ -96,18 +96,19 @@ impl DataSink for ShapefileSink {
                 let mut writer = shapefile::Writer::from_path(&self.output_path, table_builder)?;
 
                 // Write each feature
-                receiver.into_iter().for_each(|shape| match shape {
-                    shapefile::Shape::PolygonZ(polygon) => {
-                        let record = shapefile::dbase::Record::default(); // for attributes
-                        writer.write_shape_and_record(&polygon, &record).unwrap();
+                receiver.into_iter().try_for_each(|shape| {
+                    match shape {
+                        shapefile::Shape::PolygonZ(polygon) => {
+                            let record = shapefile::dbase::Record::default(); // for attributes
+                            writer.write_shape_and_record(&polygon, &record)?;
+                        }
+                        shapefile::Shape::NullShape => {}
+                        _ => {
+                            log::warn!("Unsupported shape type");
+                        }
                     }
-                    shapefile::Shape::NullShape => {}
-                    _ => {
-                        log::warn!("Unsupported shape type");
-                    }
-                });
-
-                Ok::<(), shapefile::Error>(())
+                    Ok(())
+                })
             },
         );
 

--- a/nusamai/src/transformer/transform/attrname.rs
+++ b/nusamai/src/transformer/transform/attrname.rs
@@ -34,7 +34,8 @@ impl EditFieldNamesTransform {
 
     pub fn load_default_map_for_shape(&mut self) {
         const SHAPE_DICT: &str = include_str!("./shp_field_dict.json");
-        let map: HashMap<String, String> = serde_json::from_str(SHAPE_DICT).unwrap();
+        let map: HashMap<String, String> =
+            serde_json::from_str(SHAPE_DICT).expect("should be valid");
         // This applies to field names with any namespace prefix (general match)
         self.general_rename_map.extend(map);
         for value in self.general_rename_map.values() {

--- a/nusamai/src/transformer/transform/flatten.rs
+++ b/nusamai/src/transformer/transform/flatten.rs
@@ -222,7 +222,7 @@ impl FlattenTreeTransform {
                     }
                     out.push(Entity {
                         root: Value::Object(obj),
-                        base_url: url::Url::parse("file:///dummy").unwrap(),
+                        base_url: url::Url::parse("file:///dummy").expect("should be valid"),
                         geometry_store: geom_store.clone(),
                         appearance_store: appearance_store.clone(),
                     });

--- a/nusamai/src/transformer/transform/projection.rs
+++ b/nusamai/src/transformer/transform/projection.rs
@@ -55,6 +55,7 @@ impl Transform for ProjectionTransform {
                     geom_store.vertices.iter_mut().for_each(|v| {
                         let (lng, lat) = (v[1], v[0]);
                         // Change x and y; keep the height
+                        // TODO: error handling
                         (v[0], v[1], _) = proj.project_forward(lng, lat, 0.).unwrap();
                     });
                     geom_store.epsg = self.output_epsg;


### PR DESCRIPTION
簡単にエラーハンドリングできるいくつかの unwrap を除去します。io::Result に対する unwrap など。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
	- エラーハンドリングのアプローチを更新し、`TODO`プレースホルダーから`FIXME`マーカーへと変更しました。
	- ファイル拡張子の比較方法を変更し、エラーハンドリングのメカニズムを改善しました。
	- `Entity`の取り扱いを参照から値へと変更し、パターンマッチングと文字列フォーマットを更新しました。
	- ファイル名のための型名抽出方法を改善し、JSONデータの安全な書き込みを実現しました。
	- `.unwrap()`の使用を`?`に置き換え、エラーハンドリングを強化しました。
	- 画像デコードの条件分岐に影響を与えるファイル拡張子のパターンマッチングを修正しました。
	- 特徴のソート、クローニングの削除、およびコメントの更新を行いました。
	- 不要な`Clone`トレイト実装の削除、変数名の変更、およびリファクタリングを実施しました。
	- エラーハンドリングの簡素化を目的としたコードフローの更新を行いました。
	- エラーハンドリングを可能にするためのメソッドの更新を実施しました。
	- エラーハンドリング時の`unwrap()`の使用を`expect`に置き換えました。

- **リファクタリング**
	- 多数の内部処理の改善により、エラーハンドリングとコードの可読性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->