### PR TITLE
GUI: 「出力形式」選択肢の順番を変更

### DIFF
--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -60,11 +60,6 @@ const filetypeOptions: Record<string, { label: string; extensions: string[]; eps
 			extensions: ['ply'],
 			epsg: [{ value: 4979, label: 'WGS84' }]
 		},
-		serde: {
-			label: 'Serde',
-			extensions: [''],
-			epsg: [{ value: 4979, label: 'WGS84' }]
-		},
 
 		shapefile: {
 			label: 'Shapefile',

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -2,11 +2,6 @@ type epsgOption = { value: number; label: string };
 
 const filetypeOptions: Record<string, { label: string; extensions: string[]; epsg: epsgOption[] }> =
 	{
-		geojson: {
-			label: 'GeoJSON',
-			extensions: [],
-			epsg: [{ value: 4979, label: 'WGS84' }]
-		},
 		gpkg: {
 			label: 'GeoPackage',
 			extensions: ['gpkg'],
@@ -27,37 +22,32 @@ const filetypeOptions: Record<string, { label: string; extensions: string[]; eps
 				{ value: 10174, label: 'JGD 2011 / 平面直角座標系 XIII' }
 			]
 		},
-		mvt: {
-			label: 'Vector Tiles',
-			extensions: [''],
+		geojson: {
+			label: 'GeoJSON',
+			extensions: [],
 			epsg: [{ value: 4979, label: 'WGS84' }]
 		},
-		czml: {
-			label: 'CZML',
-			extensions: ['json'],
-			epsg: [{ value: 4979, label: 'WGS84' }]
-		},
+
 		cesiumtiles: {
 			label: '3D Tiles',
 			extensions: [''],
 			epsg: [{ value: 4979, label: 'WGS84' }]
 		},
+		mvt: {
+			label: 'Vector Tiles (MVT)',
+			extensions: [''],
+			epsg: [{ value: 4979, label: 'WGS84' }]
+		},
+
+		czml: {
+			label: 'CZML',
+			extensions: ['json'],
+			epsg: [{ value: 4979, label: 'WGS84' }]
+		},
+
 		kml: {
 			label: 'KML',
 			extensions: ['kml'],
-			epsg: [{ value: 4979, label: 'WGS84' }]
-		},
-		shapefile: {
-			label: 'Shapefile',
-			extensions: ['shp'],
-			epsg: [
-				{ value: 4979, label: 'WGS84' }
-				// TODO: more epsg options
-			]
-		},
-		ply: {
-			label: 'PLY',
-			extensions: ['ply'],
 			epsg: [{ value: 4979, label: 'WGS84' }]
 		},
 		gltf: {
@@ -65,10 +55,24 @@ const filetypeOptions: Record<string, { label: string; extensions: string[]; eps
 			extensions: [''],
 			epsg: [{ value: 4979, label: 'WGS84' }]
 		},
+		ply: {
+			label: 'PLY',
+			extensions: ['ply'],
+			epsg: [{ value: 4979, label: 'WGS84' }]
+		},
 		serde: {
 			label: 'Serde',
 			extensions: [''],
 			epsg: [{ value: 4979, label: 'WGS84' }]
+		},
+
+		shapefile: {
+			label: 'Shapefile',
+			extensions: ['shp'],
+			epsg: [
+				{ value: 4979, label: 'WGS84' }
+				// TODO: more epsg options
+			]
 		}
 	};
 

--- a/app/src/routes/SettingSelector.svelte
+++ b/app/src/routes/SettingSelector.svelte
@@ -38,7 +38,7 @@
 	<div class="flex flex-col gap-5 mt-3 ml-2">
 		<div class=" flex flex-col gap-1.5">
 			<label for="filetype-select" class="font-bold">ファイル形式</label>
-			<select bind:value={filetype} name="filetype" id="filetype-select" class="w-36">
+			<select bind:value={filetype} name="filetype" id="filetype-select" class="w-64">
 				{#each Object.entries(filetypeOptions) as [value, item]}
 					<option {value}>{item.label}</option>
 				{/each}


### PR DESCRIPTION
close #381

- 順番を並び替え
  - GeoPackageが、利用してほしい適切な形式であり、また座標参照系のオプションも複数あるため、一番目に置いた
  - GeoPackage, GeoJSONのあとに、タイル系2種類を置いた
  - その他は、ほぼ順不同
  - `Serde` は、なくても良い？
- リネーム: `Vector Tiles` → `Vector Tiles (MVT)`（ユーザーフィードバックを参考に）

## before

<img width="176" alt="image" src="https://github.com/MIERUNE/PLATEAU-GIS-Converter/assets/595008/57164678-5dcd-441b-a62a-040114940873">

## after

<img width="330" alt="image" src="https://github.com/MIERUNE/PLATEAU-GIS-Converter/assets/595008/84fb11d4-d27d-4d91-bca4-6803f648ca9f">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - UI内のセレクト要素の幅を36から64に増やしました。
    - `settings.ts`には、`geojson`、`cesiumtiles`、`mvt`、`czml`、`kml`、`gltf`、`ply`、`shapefile`などのファイル形式オプションが追加され、ラベル、拡張子、EPSG値が調整されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->