### PR TITLE
GUI: 「出力形式」を変えたら「出力パス」をクリア

### DIFF
--- a/app/src/routes/OutputSelector.svelte
+++ b/app/src/routes/OutputSelector.svelte
@@ -18,6 +18,13 @@
 		});
 		outputPath = Array.isArray(res) ? res[0] : res;
 	}
+
+	// When filetype changes, reset outputPath
+	$: {
+		if (filetype) {
+			outputPath = '';
+		}
+	}
 </script>
 
 <div>

--- a/app/src/routes/OutputSelector.svelte
+++ b/app/src/routes/OutputSelector.svelte
@@ -21,9 +21,8 @@
 
 	// When filetype changes, reset outputPath
 	$: {
-		if (filetype) {
-			outputPath = '';
-		}
+		filetype;
+		outputPath = '';
 	}
 </script>
 


### PR DESCRIPTION
close #385 

> 連続で違うファイル形式の変換を行う場合、古いパスと拡張子が残るため。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - `filetype` の変更時に `outputPath` をリセットするリアクティブステートメントを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->