### PR TITLE
GUI: フォルダにGMLファイルが一つも存在しない場合、処理を開始しない

### DIFF
--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -22,6 +22,12 @@
 			alert('入力フォルダ/ファイルを選択してください');
 			return;
 		}
+
+		if (inputPaths.length === 0) {
+			alert('選択されたフォルダにGMLファイルがありません');
+			return;
+		}
+
 		if (!outputPath) {
 			alert('出力先を選択してください');
 			return;

--- a/app/src/routes/InputSelector.svelte
+++ b/app/src/routes/InputSelector.svelte
@@ -82,7 +82,7 @@
 					{:else}
 						<div class="flex items-center gap-1">
 							<p>
-								<b>{inputFolders.length}</b> フォルダ （計 <b>{inputPaths.length}</b> ファイル）
+								<b>{inputFolders.length}</b> フォルダ （計 <b>{inputPaths.length}</b> GMLファイル）
 							</p>
 							<button class="tooltip hover:text-accent1">
 								<Icon class="text-2xl" icon="material-symbols-light:list-alt-rounded" />


### PR DESCRIPTION
#411 の一部


このように、フォルダを選択しても、中にGMLファイルがゼロ個の場合、

<img width="405" alt="image" src="https://github.com/MIERUNE/PLATEAU-GIS-Converter/assets/595008/cf8b8116-e256-48ad-9de3-4ed63fbbc547">

処理を開始せず、アラートダイアログを出す:

<img width="372" alt="image" src="https://github.com/MIERUNE/PLATEAU-GIS-Converter/assets/595008/841195f5-b7fd-499c-a39a-9b8df487505b">
