### PR TITLE
GUI, doc: `BRIDGE` → `PLATEAU`, `PLATEAU-GIS-Converter` → `PLATEAU GIS Converter` へリネーム

### DIFF
--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -63,7 +63,7 @@
 		},
 		"windows": [
 			{
-				"title": "BRIDGE 都市デジタルツイン・GISコンバータ",
+				"title": "PLATEAU 都市デジタルツイン・GISコンバータ",
 				"fullscreen": false,
 				"resizable": true,
 				"height": 800,

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -55,7 +55,7 @@
 <div class="grid place-items-center h-screen">
 	<div class="max-w-2xl flex flex-col gap-12">
 		<div class="flex items-center gap-1.5">
-			<h1 class="font-bold text-2xl">BRIDGE 都市デジタルツイン・GISコンバータ</h1>
+			<h1 class="font-bold text-2xl">PLATEAU 都市デジタルツイン・GISコンバータ</h1>
 			<a href="/about" class="hover:text-accent1">
 				<Icon class="text-2xl mt-0.5" icon="mingcute:information-line" />
 			</a>

--- a/app/src/routes/about/+page.svelte
+++ b/app/src/routes/about/+page.svelte
@@ -4,7 +4,7 @@
 
 <div class="grid place-items-center h-screen">
 	<div class="max-w-md flex flex-col gap-9">
-		<h1 class="font-semibold text-lg">BRIDGE 都市デジタルツイン・GISコンバータ</h1>
+		<h1 class="font-semibold text-lg">PLATEAU 都市デジタルツイン・GISコンバータ</h1>
 
 		<p>国土交通省によるPLATEAUデータを、各種ファイル形式へ変換するためのツールです。</p>
 		<p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-# PLATEAU 都市デジタルツイン・GISコンバータ（PLATEAU-GIS-Converter）
+# PLATEAU 都市デジタルツイン・GISコンバータ（PLATEAU GIS Converter）
 
-PLATEAU-GIS-ConverterはCityGML形式の3D都市モデルを標準的なGISデータに変換するオーサリングツールです。本ツールでは3D都市モデルを以下の形式に変換することが可能です。
+PLATEAU GIS ConverterはCityGML形式の3D都市モデルを標準的なGISデータに変換するオーサリングツールです。本ツールでは3D都市モデルを以下の形式に変換することが可能です。
 
 - GeoJSON
 - Shapefile

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# BRIDGE 都市デジタルツイン・GISコンバータ（PLATEAU-GIS-Converter）
+# PLATEAU 都市デジタルツイン・GISコンバータ（PLATEAU-GIS-Converter）
 
 PLATEAU-GIS-ConverterはCityGML形式の3D都市モデルを標準的なGISデータに変換するオーサリングツールです。本ツールでは3D都市モデルを以下の形式に変換することが可能です。
 


### PR DESCRIPTION
タイトルに `BRIDGE` と表記されているものを、代わりに `PLATEAU` としました。

ユーザーフィードバックでも指摘があったように「BRIDGE」という文言は、一般利用者にはわからないものであるため、この変更が良いのではないかと考えます。

@nokonoko1203 
こちら、妥当なのか判断いただき、OKならapproveしていただければと思います！

- [x] GUI
  - [x] `BRIDGE` を `PLATEAU` へリネーム: タイトルバー、ページ内タイトル
- [x] ドキュメント
  - [x] `BRIDGE` を `PLATEAU` へリネーム
  - [x] `PLATEAU-GIS-Converter` を `PLATEAU GIS Converter` へリネーム（#370で、アプリ名をハイフン区切りではなく空白文字区切りにしたことへ合わせる）

## GUI: before

<img width="752" alt="image" src="https://github.com/MIERUNE/PLATEAU-GIS-Converter/assets/595008/c0605909-3d46-40f4-a948-fbb76d7c0700">


## GUI: after

<img width="752" alt="image" src="https://github.com/MIERUNE/PLATEAU-GIS-Converter/assets/595008/b581c806-e4eb-4ac1-bb75-d909b39c2bb4">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ツールの焦点の変更を反映して、"BRIDGE 都市デジタルツイン・GISコンバータ"から"PLATEAU 都市デジタルツイン・GISコンバータ"へタイトルを更新しました。
- **ドキュメント**
	- ツールの名前を"BRIDGE 都市デジタルツイン・GISコンバータ"から"PLATEAU 都市デジタルツイン・GISコンバータ"へ変更し、CityGML 3D都市モデルを標準GISデータフォーマット（GeoJSONやShapefileなど）に変換する目的はそのままにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->