### PR TITLE
GUI: 入力ファイル、マッピングファイルの存在確認 / 出力ディレクトリが存在しなければ作成

### DIFF
--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -51,6 +51,8 @@ fn main() {
 enum Error {
     #[error(transparent)]
     Io(#[from] std::io::Error),
+    #[error("Invalid path: {0}")]
+    InvalidPath(String),
     #[error("Invalid setting: {0}")]
     InvalidSetting(String),
 }
@@ -91,6 +93,28 @@ fn run(
     epsg: u16,
     rules_path: String,
 ) -> Result<(), Error> {
+    // Check the existence of the paths
+    for path in input_paths.iter() {
+        if !PathBuf::from_str(path).unwrap().exists() {
+            let msg = format!("Input file does not exist: {}", path);
+            log::error!("{}", msg);
+            return Err(Error::InvalidPath(msg));
+        }
+    }
+    if !PathBuf::from_str(&rules_path).unwrap().exists() {
+        let msg = format!("Mapping rules file does not exist: {}", rules_path);
+        log::error!("{}", msg);
+        return Err(Error::InvalidPath(msg));
+    };
+
+    // If the directory for the output path does not exist, create it
+    let output_path_buf = PathBuf::from_str(&output_path).unwrap();
+    let output_parent_dir = output_path_buf.parent().unwrap();
+    if !output_parent_dir.exists() {
+        std::fs::create_dir_all(output_parent_dir)?;
+        log::info!("Created output directory: {:?}", output_parent_dir);
+    }
+
     let sinkopt: Vec<(String, String)> = vec![("@output".into(), output_path)];
 
     log::info!("Running pipeline with input: {:?}", input_paths);

--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -93,7 +93,7 @@ fn run(
     epsg: u16,
     rules_path: String,
 ) -> Result<(), Error> {
-    // Check the existence of the paths
+    // Check the existence of the input paths
     for path in input_paths.iter() {
         if !PathBuf::from_str(path).unwrap().exists() {
             let msg = format!("Input file does not exist: {}", path);
@@ -101,7 +101,8 @@ fn run(
             return Err(Error::InvalidPath(msg));
         }
     }
-    if !PathBuf::from_str(&rules_path).unwrap().exists() {
+    // Check if the mapping rules file is set, and if it exists
+    if !rules_path.is_empty() && !PathBuf::from_str(&rules_path).unwrap().exists() {
         let msg = format!("Mapping rules file does not exist: {}", rules_path);
         log::error!("{}", msg);
         return Err(Error::InvalidPath(msg));


### PR DESCRIPTION
#411 の一部


- 指定された入力ファイルが、一つでも存在しなければエラー（クラッシュではない）
- 指令されたマッピングルールファイルが、存在しなければエラー（クラッシュではない）
- 指定された出力先のディレクトリが存在しなければ、その親ディレクトリなど含め必要な分を全て作成して、処理を開始

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - `Error` enumに新しい`InvalidPath`バリアントと対応するエラーメッセージフォーマットを追加しました。
    - `run`関数が入力パスとルールパスの存在をチェックし、存在しない場合はエラーをログに記録して`InvalidPath`エラーを返すように更新されました。
    - 出力ディレクトリが存在しない場合に、自動的に作成する機能が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->