### PR TITLE
Feedback機構を少し改善

### DIFF
--- a/nusamai-citygml/src/object.rs
+++ b/nusamai-citygml/src/object.rs
@@ -113,10 +113,10 @@ impl Value {
                         .iter()
                         .map(|(k, v)| (k.into(), v.to_attribute_json())),
                 );
-                m.insert("type".into(), cls.typename.clone().into());
                 if let Some(id) = cls.stereotype.id() {
                     m.insert("id".into(), serde_json::Value::String(id.into()));
                 }
+                m.insert("type".into(), cls.typename.clone().into());
                 serde_json::Value::Object(m)
             }
         }

--- a/nusamai/src/main.rs
+++ b/nusamai/src/main.rs
@@ -231,7 +231,13 @@ fn run(
         // log watcher
         scope.spawn(move || {
             for msg in watcher {
-                log::info!("Feedback message from the pipeline {:?}", msg);
+                let msg_source = format!("{:?}", msg.source_component);
+                match msg.error {
+                    Some(error) => {
+                        log::error!("An error occured in the pipeline: {error:?}");
+                    }
+                    None => log::info!("[{msg_source}]: {}", msg.message),
+                }
             }
         });
     });

--- a/nusamai/src/main.rs
+++ b/nusamai/src/main.rs
@@ -234,9 +234,11 @@ fn run(
                 let msg_source = format!("{:?}", msg.source_component);
                 match msg.error {
                     Some(error) => {
-                        log::error!("An error occured in the pipeline: {error:?}");
+                        log::log!(msg.level, "[{msg_source}]: {}: {error:?}", msg.message);
                     }
-                    None => log::info!("[{msg_source}]: {}", msg.message),
+                    None => {
+                        log::log!(msg.level, "[{msg_source}]: {}", msg.message);
+                    }
                 }
             }
         });

--- a/nusamai/src/pipeline/runner.rs
+++ b/nusamai/src/pipeline/runner.rs
@@ -80,7 +80,7 @@ fn spawn_sink_thread(
     upstream: Receiver,
     feedback: Feedback,
 ) -> std::thread::JoinHandle<()> {
-    spawn_thread("pipeline-transformer".to_string(), move || {
+    spawn_thread("pipeline-sink".to_string(), move || {
         log::info!("Sink thread started.");
         let num_threads = std::thread::available_parallelism()
             .map(|v| v.get() * 3)

--- a/nusamai/src/pipeline/runner.rs
+++ b/nusamai/src/pipeline/runner.rs
@@ -43,7 +43,7 @@ fn spawn_source_thread(
             .unwrap();
         pool.install(move || {
             if let Err(error) = source.run(sender, &feedback) {
-                feedback.report_fatal_error(error);
+                feedback.fatal_error(error);
             }
         });
         log::info!("Source thread finished.");
@@ -66,7 +66,7 @@ fn spawn_transformer_thread(
             .unwrap();
         pool.install(move || {
             if let Err(error) = transformer.run(upstream, sender, &feedback) {
-                feedback.report_fatal_error(error);
+                feedback.fatal_error(error);
             }
         });
         log::info!("Transformer thread finished.");
@@ -92,7 +92,7 @@ fn spawn_sink_thread(
             .unwrap();
         pool.install(move || {
             if let Err(error) = sink.run(upstream, &feedback, &schema) {
-                feedback.report_fatal_error(error);
+                feedback.fatal_error(error);
             }
         });
         log::info!("Sink thread finished.");
@@ -134,18 +134,18 @@ pub fn run(
     // Start the pipeline
     let (source_thread_handle, source_receiver) = spawn_source_thread(
         source,
-        feedback.component_span(super::FeedbackSourceComponent::Source),
+        feedback.component_span(super::SourceComponent::Source),
     );
     let (transformer_thread_handle, transformer_receiver) = spawn_transformer_thread(
         transformer,
         source_receiver,
-        feedback.component_span(super::FeedbackSourceComponent::Transformer),
+        feedback.component_span(super::SourceComponent::Transformer),
     );
     let sink_thread_handle = spawn_sink_thread(
         sink,
         schema,
         transformer_receiver,
-        feedback.component_span(super::FeedbackSourceComponent::Sink),
+        feedback.component_span(super::SourceComponent::Sink),
     );
 
     let handle = PipelineHandle {

--- a/nusamai/src/sink/cesiumtiles/mod.rs
+++ b/nusamai/src/sink/cesiumtiles/mod.rs
@@ -121,7 +121,7 @@ impl DataSink for CesiumTilesSink {
                         min_zoom,
                         max_zoom,
                     ) {
-                        feedback.report_fatal_error(error);
+                        feedback.fatal_error(error);
                     }
                 });
             }
@@ -132,7 +132,7 @@ impl DataSink for CesiumTilesSink {
                     if let Err(error) =
                         feature_sorting_stage(feedback, receiver_sliced, sender_sorted)
                     {
-                        feedback.report_fatal_error(error);
+                        feedback.fatal_error(error);
                     }
                 });
             }
@@ -154,7 +154,7 @@ impl DataSink for CesiumTilesSink {
                             tile_id_conv,
                             schema,
                         ) {
-                            feedback.report_fatal_error(error);
+                            feedback.fatal_error(error);
                         }
                     })
                 });

--- a/nusamai/src/sink/cesiumtiles/tiling/scheme.rs
+++ b/nusamai/src/sink/cesiumtiles/tiling/scheme.rs
@@ -1,7 +1,8 @@
+//! Our tiling scheme for the 3D Tiles
+
 use std::ops::Range;
 
-/// Our tiling scheme for the 3D Tiles
-
+// Get the position of the most significant bit
 fn msb(d: u32) -> u32 {
     u32::BITS - d.leading_zeros()
 }

--- a/nusamai/src/sink/czml/mod.rs
+++ b/nusamai/src/sink/czml/mod.rs
@@ -119,11 +119,11 @@ impl DataSink for CzmlSink {
 
         match ra {
             Ok(_) | Err(PipelineError::Canceled) => {}
-            Err(error) => feedback.report_fatal_error(error),
+            Err(error) => feedback.fatal_error(error),
         }
         match rb {
             Ok(_) | Err(PipelineError::Canceled) => {}
-            Err(error) => feedback.report_fatal_error(error),
+            Err(error) => feedback.fatal_error(error),
         }
 
         Ok(())

--- a/nusamai/src/sink/geojson/mod.rs
+++ b/nusamai/src/sink/geojson/mod.rs
@@ -145,11 +145,11 @@ impl DataSink for GeoJsonSink {
 
         match ra {
             Ok(_) | Err(PipelineError::Canceled) => {}
-            Err(error) => feedback.report_fatal_error(error),
+            Err(error) => feedback.fatal_error(error),
         }
         match rb {
             Ok(_) | Err(PipelineError::Canceled) => {}
-            Err(error) => feedback.report_fatal_error(error),
+            Err(error) => feedback.fatal_error(error),
         }
 
         Ok(())

--- a/nusamai/src/sink/kml/mod.rs
+++ b/nusamai/src/sink/kml/mod.rs
@@ -200,11 +200,11 @@ impl DataSink for KmlSink {
 
         match ra {
             Ok(_) | Err(PipelineError::Canceled) => {}
-            Err(error) => feedback.report_fatal_error(error),
+            Err(error) => feedback.fatal_error(error),
         }
         match rb {
             Ok(_) | Err(PipelineError::Canceled) => {}
-            Err(error) => feedback.report_fatal_error(error),
+            Err(error) => feedback.fatal_error(error),
         }
 
         Ok(())

--- a/nusamai/src/sink/mvt/mod.rs
+++ b/nusamai/src/sink/mvt/mod.rs
@@ -151,7 +151,7 @@ impl DataSink for MvtSink {
                         sender_sliced,
                         &self.mvt_options,
                     ) {
-                        feedback.report_fatal_error(error);
+                        feedback.fatal_error(error);
                     }
                 });
             }
@@ -176,7 +176,7 @@ impl DataSink for MvtSink {
                         if let Err(error) =
                             tile_writing_stage(output_path, feedback, receiver_sorted, tile_id_conv)
                         {
-                            feedback.report_fatal_error(error);
+                            feedback.fatal_error(error);
                         }
                     })
                 });

--- a/nusamai/src/sink/noop/mod.rs
+++ b/nusamai/src/sink/noop/mod.rs
@@ -70,7 +70,7 @@ impl DataSink for NoopSink {
             self.num_features += 1;
             self.num_vertices += parcel.entity.geometry_store.read().unwrap().vertices.len();
 
-            log::info!("feature: {:?}", parcel.entity.root);
+            // log::info!("feature: {:?}", parcel.entity.root);
         }
 
         feedback.ensure_not_canceled()?;

--- a/nusamai/src/sink/ply/mod.rs
+++ b/nusamai/src/sink/ply/mod.rs
@@ -230,11 +230,11 @@ impl DataSink for StanfordPlySink {
 
         match ra {
             Ok(_) | Err(PipelineError::Canceled) => {}
-            Err(error) => feedback.report_fatal_error(error),
+            Err(error) => feedback.fatal_error(error),
         }
         match rb {
             Ok(_) | Err(PipelineError::Canceled) => {}
-            Err(error) => feedback.report_fatal_error(error),
+            Err(error) => feedback.fatal_error(error),
         }
         Ok(())
     }

--- a/nusamai/src/sink/serde/mod.rs
+++ b/nusamai/src/sink/serde/mod.rs
@@ -108,11 +108,11 @@ impl DataSink for SerdeSink {
         );
         match ra {
             Ok(_) | Err(PipelineError::Canceled) => {}
-            Err(error) => feedback.report_fatal_error(error),
+            Err(error) => feedback.fatal_error(error),
         }
         match rb {
             Ok(_) | Err(PipelineError::Canceled) => {}
-            Err(error) => feedback.report_fatal_error(error),
+            Err(error) => feedback.fatal_error(error),
         }
         Ok(())
     }

--- a/nusamai/src/sink/shapefile/mod.rs
+++ b/nusamai/src/sink/shapefile/mod.rs
@@ -114,14 +114,14 @@ impl DataSink for ShapefileSink {
 
         match ra {
             Ok(_) | Err(PipelineError::Canceled) => {}
-            Err(error) => feedback.report_fatal_error(error),
+            Err(error) => feedback.fatal_error(error),
         }
         match rb {
             Ok(_) => {}
             Err(shapefile::Error::IoError(error)) => {
-                feedback.report_fatal_error(PipelineError::IoError(error))
+                feedback.fatal_error(PipelineError::IoError(error))
             }
-            Err(error) => feedback.report_fatal_error(PipelineError::Other(error.to_string())),
+            Err(error) => feedback.fatal_error(PipelineError::Other(error.to_string())),
         }
 
         Ok(())

--- a/nusamai/tests/pipeline.rs
+++ b/nusamai/tests/pipeline.rs
@@ -1,8 +1,8 @@
 use std::sync::Once;
 
 use nusamai::parameters::Parameters;
-use nusamai::pipeline::{self, FeedbackSourceComponent, Parcel, Receiver};
-use nusamai::pipeline::{Feedback, FeedbackMessage, Result, Sender};
+use nusamai::pipeline::{self, Parcel, Receiver};
+use nusamai::pipeline::{Feedback, Result, Sender};
 use nusamai::sink::{DataRequirements, DataSink, DataSinkProvider, SinkInfo};
 use nusamai::source::{DataSource, DataSourceProvider, SourceInfo};
 use nusamai::transformer::Transformer;
@@ -52,11 +52,7 @@ impl DataSource for DummySource {
                     appearance_store: Default::default(),
                 },
             };
-            feedback.feedback_raw(FeedbackMessage {
-                message: format!("generating: {:?}", obj),
-                source_component: FeedbackSourceComponent::Source,
-                error: None,
-            });
+            feedback.info(format!("generating: {:?}", obj));
             if sink.send(obj).is_err() {
                 break;
             }
@@ -108,11 +104,7 @@ impl DataSink for DummySink {
             std::thread::sleep(std::time::Duration::from_millis(
                 (5.0 + random::<f32>() * 20.0) as u64,
             ));
-            feedback.feedback_raw(FeedbackMessage {
-                message: format!("dummy sink received: {:?}", parcel),
-                source_component: FeedbackSourceComponent::Sink,
-                error: None,
-            })
+            feedback.info(format!("dummy sink received: {:?}", parcel))
         }
 
         Ok(())

--- a/nusamai/tests/pipeline.rs
+++ b/nusamai/tests/pipeline.rs
@@ -1,7 +1,7 @@
 use std::sync::Once;
 
 use nusamai::parameters::Parameters;
-use nusamai::pipeline::{self, Parcel, Receiver};
+use nusamai::pipeline::{self, FeedbackSourceComponent, Parcel, Receiver};
 use nusamai::pipeline::{Feedback, FeedbackMessage, Result, Sender};
 use nusamai::sink::{DataRequirements, DataSink, DataSinkProvider, SinkInfo};
 use nusamai::source::{DataSource, DataSourceProvider, SourceInfo};
@@ -54,7 +54,8 @@ impl DataSource for DummySource {
             };
             feedback.feedback_raw(FeedbackMessage {
                 message: format!("generating: {:?}", obj),
-                ..Default::default()
+                source_component: FeedbackSourceComponent::Source,
+                error: None,
             });
             if sink.send(obj).is_err() {
                 break;
@@ -109,7 +110,8 @@ impl DataSink for DummySink {
             ));
             feedback.feedback_raw(FeedbackMessage {
                 message: format!("dummy sink received: {:?}", parcel),
-                ..Default::default()
+                source_component: FeedbackSourceComponent::Sink,
+                error: None,
             })
         }
 


### PR DESCRIPTION
rel: #433 

変換パイプラインのFeedback機構を少し改善：

- 子スレッド内で起きたエラーを（システムログだけでなく）エラーとして報告できるようにする（GUIでダイアログを表示できるようにする準備）。
- メッセージがパイプラインのどの要素 (Source, Transformer, SInk, etc.) から送信されたかを把握できるようにする。
- 子スレッド内での panic がパイプラインのどの要素 (Source, Transformer, SInk, etc.) で起きたか分かるようにする。
- など

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - 3D Tiles用のタイリングスキームを導入し、最も重要なビットの位置を計算する機能を追加しました。

- **リファクタリング**
    - スレッドのスポーン処理を扱うための汎用`spawn_thread`関数を追加しました。
    - `PipelineHandle`内のスレッド処理を個別に結合し、パニック時にエラーをログに記録するようにリファクタリングしました。

- **バグ修正**
    - 複数のセクションで、`CesiumTilesSink`実装内の`feedback.report_fatal_error(error)`を`feedback.fatal_error(error)`に置換しました。

- **テスト**
    - `DummySource`と`DummySink`実装内の`FeedbackMessage`の使用を削除し、データ処理中にフィードバックメッセージを提供するために`info`メソッド呼び出しに置き換えました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->