### PR TITLE
Shapefile: gml_idを親のジオメトリに格納するように修正

### DIFF
--- a/nusamai-gpkg/src/handler.rs
+++ b/nusamai-gpkg/src/handler.rs
@@ -404,7 +404,7 @@ mod tests {
             columns,
             vec![
                 ("fid".into(), "INTEGER".into(), 1),
-                ("id".into(), "STRING".into(), 1),
+                ("id".into(), "TEXT".into(), 1),
                 ("geometry".into(), "BLOB".into(), 1),
                 ("attr1".into(), "TEXT".into(), 0),
                 ("attr2".into(), "INTEGER".into(), 0),

--- a/nusamai-gpkg/src/handler.rs
+++ b/nusamai-gpkg/src/handler.rs
@@ -193,7 +193,7 @@ impl<'c> GpkgTransaction<'c> {
             query_string.push_str(", id TEXT NOT NULL");
             query_string.push_str(", geometry BLOB NOT NULL");
         } else {
-            query_string.push_str("fid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL");
+            query_string.push_str("id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL");
         }
         table_info.columns.iter().for_each(|column| {
             query_string.push_str(&format!(", \"{}\" {}", column.name, column.data_type));

--- a/nusamai-gpkg/src/handler.rs
+++ b/nusamai-gpkg/src/handler.rs
@@ -189,10 +189,11 @@ impl<'c> GpkgTransaction<'c> {
         // Create the table
         let mut query_string = format!("CREATE TABLE \"{}\" (", table_info.name);
         if table_info.has_geometry {
-            query_string.push_str("id STRING NOT NULL PRIMARY KEY");
+            query_string.push_str("fid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL");
+            query_string.push_str(", id TEXT NOT NULL");
             query_string.push_str(", geometry BLOB NOT NULL");
         } else {
-            query_string.push_str("id INTEGER NOT NULL PRIMARY KEY");
+            query_string.push_str("fid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL");
         }
         table_info.columns.iter().for_each(|column| {
             query_string.push_str(&format!(", \"{}\" {}", column.name, column.data_type));
@@ -402,6 +403,7 @@ mod tests {
         assert_eq!(
             columns,
             vec![
+                ("fid".into(), "INTEGER".into(), 1),
                 ("id".into(), "STRING".into(), 1),
                 ("geometry".into(), "BLOB".into(), 1),
                 ("attr1".into(), "TEXT".into(), 0),
@@ -475,7 +477,7 @@ mod tests {
             columns,
             vec![
                 // No geometry column
-                ("id".into(), "INTEGER".into(), 1),
+                ("fid".into(), "INTEGER".into(), 1),
                 ("attr1".into(), "TEXT".into(), 0),
             ]
         );
@@ -610,7 +612,7 @@ mod tests {
 
         assert_eq!(rows.len(), 1);
         let row = rows.first().unwrap();
-        assert_eq!(row.get::<i64, &str>("id"), 1);
+        assert_eq!(row.get::<i64, &str>("fid"), 1);
         assert_eq!(row.get::<String, &str>("attr1"), "value1");
         assert_eq!(row.get::<i64, &str>("attr2"), 2);
         assert_eq!(row.get::<f64, &str>("attr3"), 3.33);

--- a/nusamai-gpkg/src/handler.rs
+++ b/nusamai-gpkg/src/handler.rs
@@ -189,11 +189,10 @@ impl<'c> GpkgTransaction<'c> {
         // Create the table
         let mut query_string = format!("CREATE TABLE \"{}\" (", table_info.name);
         if table_info.has_geometry {
-            query_string.push_str("fid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL");
-            query_string.push_str(", id TEXT NOT NULL");
+            query_string.push_str("id STRING NOT NULL PRIMARY KEY");
             query_string.push_str(", geometry BLOB NOT NULL");
         } else {
-            query_string.push_str("fid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL");
+            query_string.push_str("id INTEGER NOT NULL PRIMARY KEY");
         }
         table_info.columns.iter().for_each(|column| {
             query_string.push_str(&format!(", \"{}\" {}", column.name, column.data_type));
@@ -403,7 +402,6 @@ mod tests {
         assert_eq!(
             columns,
             vec![
-                ("fid".into(), "INTEGER".into(), 1),
                 ("id".into(), "STRING".into(), 1),
                 ("geometry".into(), "BLOB".into(), 1),
                 ("attr1".into(), "TEXT".into(), 0),
@@ -477,7 +475,7 @@ mod tests {
             columns,
             vec![
                 // No geometry column
-                ("fid".into(), "INTEGER".into(), 1),
+                ("id".into(), "INTEGER".into(), 1),
                 ("attr1".into(), "TEXT".into(), 0),
             ]
         );
@@ -612,7 +610,7 @@ mod tests {
 
         assert_eq!(rows.len(), 1);
         let row = rows.first().unwrap();
-        assert_eq!(row.get::<i64, &str>("fid"), 1);
+        assert_eq!(row.get::<i64, &str>("id"), 1);
         assert_eq!(row.get::<String, &str>("attr1"), "value1");
         assert_eq!(row.get::<i64, &str>("attr2"), 2);
         assert_eq!(row.get::<f64, &str>("attr3"), 3.33);

--- a/nusamai-gpkg/src/handler.rs
+++ b/nusamai-gpkg/src/handler.rs
@@ -404,7 +404,7 @@ mod tests {
             columns,
             vec![
                 ("fid".into(), "INTEGER".into(), 1),
-                ("id".into(), "TEXT".into(), 1),
+                ("id".into(), "STRING".into(), 1),
                 ("geometry".into(), "BLOB".into(), 1),
                 ("attr1".into(), "TEXT".into(), 0),
                 ("attr2".into(), "INTEGER".into(), 0),

--- a/nusamai-gpkg/src/handler.rs
+++ b/nusamai-gpkg/src/handler.rs
@@ -193,7 +193,7 @@ impl<'c> GpkgTransaction<'c> {
             query_string.push_str(", id TEXT NOT NULL");
             query_string.push_str(", geometry BLOB NOT NULL");
         } else {
-            query_string.push_str("id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL");
+            query_string.push_str("fid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL");
         }
         table_info.columns.iter().for_each(|column| {
             query_string.push_str(&format!(", \"{}\" {}", column.name, column.data_type));

--- a/nusamai/src/sink/shapefile/mod.rs
+++ b/nusamai/src/sink/shapefile/mod.rs
@@ -302,7 +302,10 @@ mod tests {
         };
 
         let (shapes, attributes) = entity_to_shape(obj);
-        assert_eq!(attributes.len(), 0);
+        assert_eq!(
+            attributes.get("id").unwrap(),
+            &Value::String("dummy".into())
+        );
 
         if let shapefile::Shape::PolygonZ(polygon) = &shapes {
             assert_eq!(polygon.rings().len(), 1);

--- a/nusamai/src/sink/shapefile/mod.rs
+++ b/nusamai/src/sink/shapefile/mod.rs
@@ -302,7 +302,11 @@ mod tests {
         };
 
         let (shapes, attributes) = entity_to_shape(obj);
-        assert_eq!(attributes.len(), 0);
+        assert_eq!(attributes.len(), 1);
+        assert_eq!(
+            attributes.get("id").unwrap(),
+            &Value::String("dummy".into())
+        );
 
         if let shapefile::Shape::PolygonZ(polygon) = &shapes {
             assert_eq!(polygon.rings().len(), 1);

--- a/nusamai/src/sink/shapefile/mod.rs
+++ b/nusamai/src/sink/shapefile/mod.rs
@@ -302,11 +302,7 @@ mod tests {
         };
 
         let (shapes, attributes) = entity_to_shape(obj);
-        assert_eq!(attributes.len(), 1);
-        assert_eq!(
-            attributes.get("id").unwrap(),
-            &Value::String("dummy".into())
-        );
+        assert_eq!(attributes.len(), 0);
 
         if let shapefile::Shape::PolygonZ(polygon) = &shapes {
             assert_eq!(polygon.rings().len(), 1);


### PR DESCRIPTION
close #426
rootの地物にidを格納するように修正しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - 属性内に特定のデータが格納されている場所を示すコメントを追加しました。
    - エンティティの根底にあるパターンマッチングを更新し、`obj`に`mut`を使用するように変更しました。
    - `ObjectStereotype::Feature`のパターンマッチングを更新し、`id`と`geometries`を分解するようにしました。
    - `obj.attributes`に`id`属性の挿入を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->