### PR TITLE
gltf: JPEG は元データをそのまま埋め込む

### DIFF
--- a/nusamai-gltf/nusamai-gltf-json/src/models/image.rs
+++ b/nusamai-gltf/nusamai-gltf-json/src/models/image.rs
@@ -10,8 +10,6 @@ pub enum MimeType {
     ImageJpeg,
     #[serde(rename = "image/png")]
     ImagePng,
-    #[serde(rename = "image/webp")]
-    ImageWebP,
 }
 
 /// Image data used to create a texture. Image MAY be referenced by an URI (or IRI) or a buffer view index.

--- a/nusamai/Cargo.toml
+++ b/nusamai/Cargo.toml
@@ -12,7 +12,7 @@ nusamai-citygml = { path = "../nusamai-citygml" }
 quick-xml = "0.31.0"
 clap = { version = "4.5.2", features = ["derive", "string"] }
 thiserror = "1.0.57"
-ctrlc = "3.4.2"
+ctrlc = "3.4.4"
 bincode = { version = "2.0.0-rc.3", default-features = false, features = ["std", "serde"] }
 lz4_flex = "0.11.2"
 nusamai-geojson = { path = "../nusamai-geojson" }
@@ -46,7 +46,7 @@ glob = "0.3.1"
 shellexpand = "3.1.0"
 kml = "0.8.5"
 nusamai-kml = { path = "../nusamai-kml" }
-image = { version = "0.24.9", default-features = false, features = ["tiff", "jpeg", "jpeg_rayon", "webp-encoder"] }
+image = { version = "0.25.0-preview.0", default-features = false, features = ["rayon", "tiff", "jpeg", "webp", "png"] }
 flate2 = "1.0.28"
 chrono = "0.4.35"
 

--- a/nusamai/src/sink/cesiumtiles/material.rs
+++ b/nusamai/src/sink/cesiumtiles/material.rs
@@ -3,7 +3,7 @@
 use std::{hash::Hash, path::Path, time::Instant};
 
 use indexmap::IndexSet;
-use nusamai_gltf_json::BufferView;
+use nusamai_gltf_json::{BufferView, MimeType};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -84,7 +84,7 @@ impl Image {
     ) -> std::io::Result<nusamai_gltf_json::Image> {
         if let Ok(path) = self.uri.to_file_path() {
             // NOTE: temporary implementation
-            let content = load_image(&path)?;
+            let (content, mime_type) = load_image(&path)?;
 
             buffer_views.push(BufferView {
                 name: Some("image".to_string()),
@@ -96,7 +96,7 @@ impl Image {
             bin_content.extend(content);
 
             Ok(nusamai_gltf_json::Image {
-                mime_type: Some(nusamai_gltf_json::MimeType::ImageJpeg),
+                mime_type: Some(mime_type),
                 buffer_view: Some(buffer_views.len() as u32 - 1),
                 ..Default::default()
             })
@@ -110,24 +110,26 @@ impl Image {
 }
 
 // NOTE: temporary implementation
-fn load_image(path: &Path) -> std::io::Result<Vec<u8>> {
-    log::info!("Decoding image: {:?}", path);
-
+fn load_image(path: &Path) -> std::io::Result<(Vec<u8>, MimeType)> {
     if let Some(ext) = path.extension() {
         match ext.to_str() {
-            // use `image crate` for TIFF
-            Some("tif" | "tiff" | "png" | "jpg" | "jpeg") => {
+            Some("tif" | "tiff" | "png") => {
+                log::info!("Decoding image: {:?}", path);
                 let t = Instant::now();
                 let image = image::open(path)
                     .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
                 log::debug!("Image decoding took {:?}", t.elapsed());
 
-                let content: Vec<u8> = Vec::new();
-                let mut writer = std::io::Cursor::new(content);
+                let mut writer = std::io::Cursor::new(Vec::new());
+                let encoder = image::codecs::png::PngEncoder::new(&mut writer);
                 image
-                    .write_to(&mut writer, image::ImageOutputFormat::Jpeg(100))
+                    .write_with_encoder(encoder)
                     .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
-                Ok(writer.into_inner())
+                Ok((writer.into_inner(), MimeType::ImagePng))
+            }
+            Some("jpg" | "jpeg") => {
+                log::info!("Embedding a jpeg as is: {:?}", path);
+                Ok((std::fs::read(path)?, MimeType::ImageJpeg))
             }
             _ => {
                 let err = format!("Unsupported image format: {:?}", path);

--- a/nusamai/src/sink/cesiumtiles/mod.rs
+++ b/nusamai/src/sink/cesiumtiles/mod.rs
@@ -405,6 +405,7 @@ fn tile_writing_stage(
 
             let mut file = std::fs::File::create(path_glb)?;
             write_gltf_glb(
+                feedback,
                 &mut BufWriter::new(&mut file),
                 translation,
                 vertices,

--- a/nusamai/src/sink/gltf/mod.rs
+++ b/nusamai/src/sink/gltf/mod.rs
@@ -353,6 +353,7 @@ impl DataSink for GltfSink {
             let num_features = &features.len();
 
             write_gltf_glb(
+                feedback,
                 writer,
                 translation,
                 vertices,


### PR DESCRIPTION
- glTF Sinkにおいて、元のテクスチャ画像がJPEG画像であれば、デコード・再圧縮等せずに、元ファイルの内容をそのまま埋め込む。glTF sink では、テクスチャ画像を加工する必要がないため。
    - 巨大なJPEGの decode/encode には時間がかかるため、これにより処理をだいぶ高速化できる。
- TIFF, PNG はひとまず PNG (lossless) で格納する。
    - 後ほど WebP にするかもしれない。
- 3D Tiles もでひとまず同様にしておく。

その他：

- 画像のデコード・エンコードのループ（時間がかかる）中に、パイプラインをキャンセルできるようにする。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- JPEG画像をそのまま埋め込む機能とPNG画像の処理を追加しました。

- **機能改善**
	- GLTF生成プロセス内のエラー管理とフィードバックメカニズムを強化しました。
	- GLTFファイルの書き込み時にキャンセルフィードバックを確認する機能を追加しました。

- **リファクタリング**
	- エラーハンドリングを改善するために、複数の関数の戻り値を`Result`型に変更しました。
	- 画像のMIMEタイプを正しく設定するための処理を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->