### PR TITLE
LTO: lto = fat に戻す

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,12 @@ version = "0.0.0-alpha.0"
 authors = ["MIERUNE Inc. <info@mierune.co.jp>"]
 
 [profile.dev.package."*"]
-opt-level = 2
+opt-level = 3
+
+[profile.release]
+strip = "debuginfo"
 
 [profile.release-lto]
 inherits = "release"
-lto = "thin"
+codegen-units = 8
+lto = "fat"

--- a/nusamai-citygml/macros/src/derive.rs
+++ b/nusamai-citygml/macros/src/derive.rs
@@ -376,10 +376,11 @@ fn generate_citygml_impl_for_struct(
 
     Ok(quote! {
         impl #impl_generics ::nusamai_citygml::CityGmlElement for #struct_ident #ty_generics #where_clause {
+            #[inline(never)]
             fn parse<R: std::io::BufRead>(&mut self, st: &mut ::nusamai_citygml::SubTreeReader<R>) -> Result<(), ::nusamai_citygml::ParseError> {
                 #attr_parsing
 
-                st.parse_children(|st| {
+                st.parse_children(move |st| {
                     let path = st.current_path();
                     let hash = (path.iter().skip(#HASH_CHAR_SKIP).take(#HASH_CHAR_TAKE).fold(5381u32, |a, c| a.wrapping_mul(33) ^ *c as u32) & #HASH_MASK) as u8;
                     match (hash, path) {
@@ -389,7 +390,8 @@ fn generate_citygml_impl_for_struct(
                 })
             }
 
-            fn into_object(self) -> Option<::nusamai_citygml::object::Value> {
+            #[inline(never)]
+    fn into_object(self) -> Option<::nusamai_citygml::object::Value> {
                 #into_object_impl
             }
 
@@ -506,6 +508,7 @@ fn generate_citygml_impl_for_enum(
 
     Ok(quote! {
         impl #impl_generics ::nusamai_citygml::CityGmlElement for #struct_name #ty_generics #where_clause {
+            #[inline(never)]
             fn parse<R: ::std::io::BufRead>(&mut self, st: &mut ::nusamai_citygml::SubTreeReader<R>) -> Result<(), ::nusamai_citygml::ParseError> {
                 st.parse_children(|st| {
                     let path = st.current_path();
@@ -517,7 +520,8 @@ fn generate_citygml_impl_for_enum(
                 })
             }
 
-            fn into_object(self) -> Option<::nusamai_citygml::object::Value> {
+            #[inline(never)]
+    fn into_object(self) -> Option<::nusamai_citygml::object::Value> {
                 match self {
                     #(#into_object_arms,)*
                     _ => None,

--- a/nusamai-citygml/macros/src/type_attrs.rs
+++ b/nusamai-citygml/macros/src/type_attrs.rs
@@ -54,7 +54,7 @@ pub(crate) fn citygml_type(
 
     quote! {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(tag = "type"))]
-        #[derive(Default, Debug, ::nusamai_citygml::CityGmlElement)]
+        #[derive(Default, ::nusamai_citygml::CityGmlElement)]
         #input
     }
     .into()

--- a/nusamai-citygml/src/appearance.rs
+++ b/nusamai-citygml/src/appearance.rs
@@ -23,6 +23,7 @@ impl CityGmlElement for TextureAssociation {
         Ok(())
     }
 
+    #[inline(never)]
     fn into_object(self) -> Option<crate::object::Value> {
         None
     }

--- a/nusamai-citygml/src/attribute.rs
+++ b/nusamai-citygml/src/attribute.rs
@@ -5,14 +5,12 @@ pub trait CityGmlAttribute: Sized {
 }
 
 impl CityGmlAttribute for String {
-    #[inline]
     fn parse_attribute_value(value: &str, _st: &mut ParseContext) -> Result<Self, ParseError> {
         Ok(value.to_string())
     }
 }
 
 impl<T: CityGmlAttribute> CityGmlAttribute for Option<T> {
-    #[inline]
     fn parse_attribute_value(value: &str, st: &mut ParseContext) -> Result<Self, ParseError> {
         Ok(Some(<T as CityGmlAttribute>::parse_attribute_value(
             value, st,

--- a/nusamai-citygml/src/parser.rs
+++ b/nusamai-citygml/src/parser.rs
@@ -111,7 +111,6 @@ impl<'a> Default for ParseContext<'a> {
 }
 
 impl<'a> CityGmlReader<'a> {
-    #[inline]
     pub fn new(context: ParseContext<'a>) -> Self {
         Self {
             state: InternalState::new(context),
@@ -320,6 +319,7 @@ impl<'b, R: BufRead> SubTreeReader<'_, 'b, R> {
     }
 
     /// Expect a geometric attribute of CityGML
+    #[inline(never)]
     pub fn parse_geometric_attr(
         &mut self,
         geomref: &mut GeometryRefs,

--- a/nusamai-citygml/src/values.rs
+++ b/nusamai-citygml/src/values.rs
@@ -19,12 +19,13 @@ pub type LODType = u64; // TODO?
 pub type Double01 = f64; // TODO?
 
 impl CityGmlElement for String {
-    #[inline]
+    #[inline(never)]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         self.push_str(st.parse_text()?);
         Ok(())
     }
 
+    #[inline(never)]
     fn into_object(self) -> Option<Value> {
         Some(Value::String(self))
     }
@@ -62,7 +63,7 @@ impl Default for Uri {
 }
 
 impl CityGmlElement for Uri {
-    #[inline]
+    #[inline(never)]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         let text = st.parse_text()?.to_string();
         let base_url = st.context().source_url();
@@ -72,6 +73,7 @@ impl CityGmlElement for Uri {
         Ok(())
     }
 
+    #[inline(never)]
     fn into_object(self) -> Option<Value> {
         Some(Value::String(self.0.to_string()))
     }
@@ -101,7 +103,7 @@ impl Code {
 }
 
 impl CityGmlElement for Code {
-    #[inline]
+    #[inline(never)]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         let code_space = st.find_codespace_attr();
         let code = st.parse_text()?.to_string();
@@ -131,6 +133,7 @@ impl CityGmlElement for Code {
         Ok(())
     }
 
+    #[inline(never)]
     fn into_object(self) -> Option<Value> {
         Some(Value::Code(self))
     }
@@ -141,7 +144,7 @@ impl CityGmlElement for Code {
 }
 
 impl CityGmlElement for i64 {
-    #[inline]
+    #[inline(never)]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         let text = st.parse_text()?;
         match text.parse() {
@@ -156,6 +159,7 @@ impl CityGmlElement for i64 {
         }
     }
 
+    #[inline(never)]
     fn into_object(self) -> Option<Value> {
         Some(Value::Integer(self))
     }
@@ -166,7 +170,7 @@ impl CityGmlElement for i64 {
 }
 
 impl CityGmlElement for u64 {
-    #[inline]
+    #[inline(never)]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         let text = st.parse_text()?;
         match text.parse() {
@@ -181,6 +185,7 @@ impl CityGmlElement for u64 {
         }
     }
 
+    #[inline(never)]
     fn into_object(self) -> Option<Value> {
         Some(Value::NonNegativeInteger(self))
     }
@@ -191,7 +196,7 @@ impl CityGmlElement for u64 {
 }
 
 impl CityGmlElement for f64 {
-    #[inline]
+    #[inline(never)]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         let text = st.parse_text()?;
         match text.parse() {
@@ -206,6 +211,7 @@ impl CityGmlElement for f64 {
         }
     }
 
+    #[inline(never)]
     fn into_object(self) -> Option<Value> {
         Some(Value::Double(self))
     }
@@ -216,7 +222,7 @@ impl CityGmlElement for f64 {
 }
 
 impl CityGmlElement for bool {
-    #[inline]
+    #[inline(never)]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         let text = st.parse_text()?.trim();
         match text {
@@ -235,6 +241,7 @@ impl CityGmlElement for bool {
         }
     }
 
+    #[inline(never)]
     fn into_object(self) -> Option<Value> {
         Some(Value::Boolean(self))
     }
@@ -260,7 +267,7 @@ impl Measure {
 }
 
 impl CityGmlElement for Measure {
-    #[inline]
+    #[inline(never)]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         let text = st.parse_text()?;
         match text.parse() {
@@ -275,6 +282,7 @@ impl CityGmlElement for Measure {
         }
     }
 
+    #[inline(never)]
     fn into_object(self) -> Option<Value> {
         Some(Value::Measure(self))
     }
@@ -285,7 +293,7 @@ impl CityGmlElement for Measure {
 }
 
 impl CityGmlElement for Date {
-    #[inline]
+    #[inline(never)]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         let text = st.parse_text()?;
         match Date::parse_from_str(text, "%Y-%m-%d") {
@@ -300,6 +308,7 @@ impl CityGmlElement for Date {
         }
     }
 
+    #[inline(never)]
     fn into_object(self) -> Option<Value> {
         Some(Value::Date(self))
     }
@@ -317,12 +326,13 @@ pub struct Point {
 pub type Vector = Point;
 
 impl CityGmlElement for Point {
-    #[inline]
+    #[inline(never)]
     fn parse<R: BufRead>(&mut self, _st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         // TODO
         todo!();
     }
 
+    #[inline(never)]
     fn into_object(self) -> Option<Value> {
         Some(Value::Point(self))
     }
@@ -347,7 +357,7 @@ impl LocalId {
 }
 
 impl CityGmlElement for LocalId {
-    #[inline]
+    #[inline(never)]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         let s = st.parse_text()?;
         if let Some(id) = s.strip_prefix('#') {
@@ -362,6 +372,7 @@ impl CityGmlElement for LocalId {
         }
     }
 
+    #[inline(never)]
     fn into_object(self) -> Option<Value> {
         Some(Value::NonNegativeInteger(self.0 as u64))
     }
@@ -372,7 +383,6 @@ impl CityGmlElement for LocalId {
 }
 
 impl CityGmlAttribute for LocalId {
-    #[inline]
     fn parse_attribute_value(value: &str, st: &mut ParseContext) -> Result<Self, ParseError> {
         let s = value;
         if let Some(id) = s.strip_prefix('#') {
@@ -415,6 +425,7 @@ impl std::hash::Hash for Color {
 }
 
 impl CityGmlElement for Color {
+    #[inline(never)]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         let text = st.parse_text()?;
         let r: Result<Vec<_>, _> = text
@@ -435,6 +446,7 @@ impl CityGmlElement for Color {
         Ok(())
     }
 
+    #[inline(never)]
     fn into_object(self) -> Option<Value> {
         Some(Value::Array(vec![
             Value::Double(self.r),
@@ -477,6 +489,7 @@ impl ColorPlusOpacity {
 }
 
 impl CityGmlElement for ColorPlusOpacity {
+    #[inline(never)]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         let text = st.parse_text()?;
         let r: Result<Vec<_>, _> = text
@@ -500,6 +513,7 @@ impl CityGmlElement for ColorPlusOpacity {
         Ok(())
     }
 
+    #[inline(never)]
     fn into_object(self) -> Option<Value> {
         Some(Value::Array(vec![
             Value::Double(self.r),
@@ -519,8 +533,8 @@ impl CityGmlElement for ColorPlusOpacity {
     }
 }
 
-impl<T: CityGmlElement + Default + std::fmt::Debug> CityGmlElement for Option<T> {
-    #[inline]
+impl<T: CityGmlElement + Default> CityGmlElement for Option<T> {
+    #[inline(never)]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         if self.is_some() {
             return Err(ParseError::SchemaViolation(format!(
@@ -534,6 +548,7 @@ impl<T: CityGmlElement + Default + std::fmt::Debug> CityGmlElement for Option<T>
         Ok(())
     }
 
+    #[inline(never)]
     fn into_object(self) -> Option<Value> {
         match self {
             Some(v) => v.into_object(),
@@ -549,7 +564,7 @@ impl<T: CityGmlElement + Default + std::fmt::Debug> CityGmlElement for Option<T>
 }
 
 impl<T: CityGmlElement + Default> CityGmlElement for Vec<T> {
-    #[inline]
+    #[inline(never)]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         let mut v: T = Default::default();
         <T as CityGmlElement>::parse(&mut v, st)?;
@@ -557,6 +572,7 @@ impl<T: CityGmlElement + Default> CityGmlElement for Vec<T> {
         Ok(())
     }
 
+    #[inline(never)]
     fn into_object(self) -> Option<Value> {
         if self.is_empty() {
             None
@@ -576,12 +592,13 @@ impl<T: CityGmlElement + Default> CityGmlElement for Vec<T> {
 }
 
 impl<T: CityGmlElement + Default> CityGmlElement for Box<T> {
-    #[inline]
+    #[inline(never)]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         <T as CityGmlElement>::parse(self, st)?;
         Ok(())
     }
 
+    #[inline(never)]
     fn into_object(self) -> Option<Value> {
         (*self).into_object()
     }
@@ -604,6 +621,7 @@ pub struct GenericAttribute {
 }
 
 impl CityGmlElement for GenericAttribute {
+    #[inline(never)]
     fn parse<R: BufRead>(&mut self, st: &mut SubTreeReader<R>) -> Result<(), ParseError> {
         match st.current_path() {
             b"gen:stringAttribute" | b"gen:StringAttribute" => {
@@ -632,6 +650,7 @@ impl CityGmlElement for GenericAttribute {
         Ok(())
     }
 
+    #[inline(never)]
     fn into_object(self) -> Option<Value> {
         let mut map = object::Map::default();
         map.extend(


### PR DESCRIPTION
出力バイナリの肥大化の抑制と高速化のため、 `LTO = "fat"` に戻します。  #359 で `LTO = "thin"` にしていた。

バイナリ全体および `.text` 部のサイズ比較：

- `LTO = "thin"` (20.1 MB)

    ```
    ❯ cargo bloat --package nusamai --bin nusamai --profile release-lto --crates
        Analyzing target/release-lto/nusamai
    
     File  .text     Size Crate
    27.6%  39.3%   5.5MiB nusamai_plateau
    12.4%  17.6%   2.5MiB nusamai
     9.3%  13.2%   1.9MiB std
     7.3%  10.3%   1.5MiB [Unknown]
     1.4%   2.0% 285.7KiB regex_automata
    [...]
     2.7%   3.8% 545.6KiB And 89 more crates. Use -n N to show more.
    70.2% 100.0%  14.1MiB .text section size, the file size is 20.1MiB
    ```

- `LTO = "fat"` (16.3 MB)
    
    ```
    ❯ cargo bloat --package nusamai --bin nusamai --profile release-lto --crates
        Analyzing target/release-lto/nusamai
    
     File  .text     Size Crate
    30.2%  40.0%   4.9MiB nusamai_plateau
    14.9%  19.8%   2.4MiB nusamai
     8.1%  10.7%   1.3MiB [Unknown]
     8.0%  10.6%   1.3MiB std
     1.7%   2.2% 282.1KiB regex_automata
    [...]
     2.8%   3.7% 468.6KiB And 81 more crates. Use -n N to show more.
    75.4% 100.0%  12.3MiB .text section size, the file size is 16.3MiB
    ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタ**
	- 一部の関数において、パフォーマンス最適化のためインライン展開の設定を調整しました。
- **スタイル**
	- 特定の機能からデバッグトレイトの自動導出を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->