### PR TITLE
Fix: CI での release ビルドが失敗する

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,6 @@ authors = ["MIERUNE Inc. <info@mierune.co.jp>"]
 [profile.dev.package."*"]
 opt-level = 3
 
-[profile.release]
-strip = "debuginfo"
-
 [profile.release-lto]
 inherits = "release"
 codegen-units = 8


### PR DESCRIPTION
ちょっとした修正。CI のリリースビルドで `[profile.release]` を動的に足しているために、既存の `[profile.release]` と重複してCIのリリースビルドが失敗する。

エラーメッセージ：

```
Caused by:
  TOML parse error at line 24, column 1
     |
  24 | [profile.release]
     | ^
  invalid table header
  duplicate key `release` in table `profile`
```