### PR TITLE
GUI: キャンセル可能にする & 変換ログを表示する（いずれも初期的実装）

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -27,6 +27,7 @@
 				"prettier-plugin-svelte": "^3.1.2",
 				"svelte": "^4.2.10",
 				"svelte-check": "^3.6.4",
+				"svelte-virtual-scroll-list": "^1.3.0",
 				"tailwindcss": "^3.4.1",
 				"tslib": "^2.6.2",
 				"typescript": "^5.3.3",
@@ -4518,6 +4519,15 @@
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/svelte-virtual-scroll-list": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/svelte-virtual-scroll-list/-/svelte-virtual-scroll-list-1.3.0.tgz",
+			"integrity": "sha512-rkU993mMsTboFRlygExhYeLJwysaFxyzfTsAfOtDklGIyd0wB31eZtYSAHAcz/WaZCEwjn+GKXfx5jM1xUv3GQ==",
+			"dev": true,
+			"peerDependencies": {
+				"svelte": ">=3.5.0"
 			}
 		},
 		"node_modules/tailwindcss": {

--- a/app/package.json
+++ b/app/package.json
@@ -29,6 +29,7 @@
 		"prettier-plugin-svelte": "^3.1.2",
 		"svelte": "^4.2.10",
 		"svelte-check": "^3.6.4",
+		"svelte-virtual-scroll-list": "^1.3.0",
 		"tailwindcss": "^3.4.1",
 		"tslib": "^2.6.2",
 		"typescript": "^5.3.3",

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -63,11 +63,13 @@
 		},
 		"windows": [
 			{
-				"title": "PLATEAU 都市デジタルツイン・GISコンバータ",
+				"title": "PLATEAU 都市デジタルツイン GISコンバータ",
 				"fullscreen": false,
 				"resizable": true,
 				"height": 800,
-				"width": 640
+				"width": 640,
+				"minHeight": 600,
+				"minWidth": 500
 			}
 		]
 	}

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -32,24 +32,29 @@
 		isRunning = true;
 
 		try {
-			await invoke('run', {
+			await invoke('run_conversion', {
 				inputPaths,
 				outputPath,
 				filetype,
 				epsg,
 				rulesPath
 			});
+			isRunning = false;
 			await message(`変換が完了しました。\n'${outputPath}' に出力しました。`, { type: 'info' });
-		} catch (error) {
-			await message(`エラーが発生しました。\n\n${error}`, { type: 'error' });
+		} catch (error: any) {
+			if (error.type != 'Canceled') {
+				await message(`エラーが発生しました。\n\n${error.type}: ${error.message}`, {
+					title: '変換エラー',
+					type: 'error'
+				});
+			}
+			isRunning = false;
 		}
-
-		isRunning = false;
 	}
 </script>
 
 {#if isRunning}
-	<div class="grid place-items-center absolute w-screen h-screen z-20 bg-black/60">
+	<div class="absolute inset-0 bg-black/70 backdrop-blur-[2px] z-20">
 		<LoadingAnimation />
 	</div>
 {/if}
@@ -57,7 +62,7 @@
 <div class="grid place-items-center h-screen">
 	<div class="max-w-2xl flex flex-col gap-12">
 		<div class="flex items-center gap-1.5">
-			<h1 class="font-bold text-2xl">PLATEAU 都市デジタルツイン・GISコンバータ</h1>
+			<h1 class="font-bold text-2xl">PLATEAU 都市デジタルツイン GISコンバータ</h1>
 			<a href="/about" class="hover:text-accent1">
 				<Icon class="text-2xl mt-0.5" icon="mingcute:information-line" />
 			</a>

--- a/app/src/routes/LoadingAnimation.svelte
+++ b/app/src/routes/LoadingAnimation.svelte
@@ -1,10 +1,102 @@
-<div class="loader flex flex-col gap-3">
-	<p class="text-white font-semibold text-2xl">変換中 ...</p>
+<script lang="ts">
+	import Icon from '@iconify/svelte';
+	import { invoke } from '@tauri-apps/api/tauri';
+	import { listen } from '@tauri-apps/api/event';
+	import { onMount } from 'svelte';
+	import VirtualScroll from 'svelte-virtual-scroll-list';
 
-	<div class="loader ball-pulse flex">
+	async function cancelConversion() {
+		await invoke('cancel_conversion');
+	}
+
+	let items: Array<{
+		id: number;
+		message: string;
+		level: string;
+		error_message?: string;
+		source: string;
+	}> = [];
+
+	let logView: VirtualScroll;
+
+	// Setup log monitor
+	onMount(() => {
+		let promise = listen<{
+			message: string;
+			level: string;
+			error_message?: string;
+			source: string;
+		}>('conversion-log', (event) => {
+			items.push({
+				id: items.length,
+				...event.payload
+			});
+			items = items;
+			logView.scrollToBottom();
+		});
+
+		return () => {
+			promise.then((unlisten) => {
+				unlisten();
+			});
+		};
+	});
+</script>
+
+<div class="flex flex-col gap-4 p-12 place-items-center">
+	<p class="text-white text-center font-semibold text-2xl">変換中 &hellip;</p>
+	<div class="loader ball-pulse flex justify-center">
 		<div />
 		<div />
 		<div />
+	</div>
+
+	<div
+		class="my-5 w-full h-96 max-h-96 bg-slate-900/70 text-slate-300 text-xs font-mono p-1 rounded"
+	>
+		<div class="w-full h-full">
+			<VirtualScroll bind:this={logView} data={items} key="id" let:data>
+				<div>
+					{#if data.level === 'ERROR'}
+						<span
+							class="inline-flex items-center rounded-md bg-red-400/10 px-1 py-0.5 text-xs font-medium text-red-400 ring-1 ring-inset ring-red-400/20"
+							>ERROR</span
+						>
+					{:else if data.level === 'WARN'}
+						<span
+							class="inline-flex items-center rounded-md bg-yellow-400/10 px-1 py-0.5 text-xs font-medium text-yellow-500 ring-1 ring-inset ring-yellow-400/20"
+							>WARN</span
+						>
+					{:else if data.level === 'INFO'}
+						<span
+							class="inline-flex items-center rounded-md bg-blue-400/10 px-1 py-0.5 text-xs font-medium text-blue-400 ring-1 ring-inset ring-blue-400/30"
+							>INFO</span
+						>
+					{/if}
+
+					<span
+						class="inline-flex items-center rounded-md bg-gray-400/10 px-2 py-1 text-xs font-medium text-gray-400 ring-1 ring-inset ring-gray-400/20"
+						>{data.source}</span
+					>
+
+					{data.message}
+
+					{#if data.error_message}
+						<span class="text-red-600">{data.error_message}</span>
+					{/if}
+				</div>
+			</VirtualScroll>
+		</div>
+	</div>
+
+	<div>
+		<button
+			on:click={cancelConversion}
+			class="bg-red-300 flex items-center font-bold py-1.5 pl-3 pr-5 rounded-full gap-1 shawdow-2xl hover:bg-red-400"
+		>
+			<Icon class="text-lg" icon="ic:baseline-cancel" />
+			キャンセル
+		</button>
 	</div>
 </div>
 

--- a/nusamai/src/pipeline/feedback.rs
+++ b/nusamai/src/pipeline/feedback.rs
@@ -35,6 +35,17 @@ pub enum SourceComponent {
     Pipeline,
 }
 
+impl std::fmt::Display for SourceComponent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SourceComponent::Source => write!(f, "source"),
+            SourceComponent::Transformer => write!(f, "transformer"),
+            SourceComponent::Sink => write!(f, "sink"),
+            SourceComponent::Pipeline => write!(f, "pipeline"),
+        }
+    }
+}
+
 impl Feedback {
     /// Checks if the pipeline is requested to be canceled
     #[inline]
@@ -98,7 +109,7 @@ impl Feedback {
 
     /// Send a warning log
     #[inline]
-    pub fn warning(&self, message: String) {
+    pub fn warn(&self, message: String) {
         self.send_message(message, log::Level::Warn)
     }
 
@@ -111,13 +122,20 @@ impl Feedback {
     /// Report a fatal error and cancel the pipeline
     #[inline]
     pub fn fatal_error(&self, error: PipelineError) {
-        self.cancel();
-        let _ = self.sender.send(Message {
-            message: "Fatal error".to_string(),
-            level: log::Level::Error,
-            source_component: self.source_component,
-            error: Some(error),
-        });
+        match error {
+            PipelineError::Canceled => {
+                // do nothing
+            }
+            _ => {
+                self.cancel();
+                let _ = self.sender.send(Message {
+                    message: "Fatal error".to_string(),
+                    level: log::Level::Error,
+                    source_component: self.source_component,
+                    error: Some(error),
+                });
+            }
+        }
     }
 }
 

--- a/nusamai/src/pipeline/mod.rs
+++ b/nusamai/src/pipeline/mod.rs
@@ -28,10 +28,10 @@ pub enum PipelineError {
     #[error("I/O error: {0}")]
     IoError(#[from] std::io::Error),
 
-    #[error("{0}")]
+    #[error("CityGML parsing error: {0}")]
     ParseError(#[from] nusamai_citygml::ParseError),
 
-    #[error("canceled")]
+    #[error("Conversion canceled")]
     Canceled,
 
     #[error("{0}")]

--- a/nusamai/src/source/citygml.rs
+++ b/nusamai/src/source/citygml.rs
@@ -57,7 +57,7 @@ impl DataSource for CityGmlSource {
         self.filenames.par_iter().try_for_each(|filename| {
             feedback.ensure_not_canceled()?;
 
-            log::info!("Parsing CityGML file: {:?} ...", filename);
+            feedback.info(format!("Parsing CityGML file: {:?} ...", filename));
             let file = std::fs::File::open(filename)?;
             let reader = std::io::BufReader::with_capacity(1024 * 1024, file);
             let mut xml_reader = quick_xml::NsReader::from_reader(reader);


### PR DESCRIPTION
変換中の画面に、(1) キャンセルボタンと (2) 変換ログの表示、を設けて、いずれも最低限機能するようにする。

Close #267, Close #460

注意：

- log crate によるシステムログは受信しない。Feedback 機構から得た変換ログのみ受信する。

![Untitled](https://github.com/MIERUNE/PLATEAU-GIS-Converter/assets/5351911/b31f61df-e889-4e3b-b1da-f6c91ef6477c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - `nusamai::pipeline`から`feedback`のインポートを追加しました。
    - `ConversionTasksState`構造体を追加しました。
    - `LogMessage`構造体と`Error`列挙型の実装を追加しました。
    - `run`関数を`run_conversion`に変更し、追加のパラメータとキャンセルロジックを追加しました。
    - タスクのキャンセルに使用する`cancel_conversion`関数を追加しました。

- **バグ修正**
    - エラータイプを確認してからエラーメッセージを表示するようにエラー処理を変更しました。

- **リファクタ**
    - `PipelineError`列挙型のエラーメッセージをセマンティックに調整しました。
    - `ParseError`と`Canceled`のエラーメッセージを洗練しました。

- **スタイル**
    - ローディングアニメーションと見出しテキストのスタイリングクラスを調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->