### PR TITLE
chore: サンプルファイルの Cesium を v1.115 に更新

### DIFF
--- a/demo/cesium/3dtiles.html
+++ b/demo/cesium/3dtiles.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <title>Cesium</title>
-    <script src="https://cesium.com/downloads/cesiumjs/releases/1.114/Build/Cesium/Cesium.js"></script>
+    <script src="https://cesium.com/downloads/cesiumjs/releases/1.115/Build/Cesium/Cesium.js"></script>
     <link
-      href="https://cesium.com/downloads/cesiumjs/releases/1.114/Build/Cesium/Widgets/widgets.css"
+      href="https://cesium.com/downloads/cesiumjs/releases/1.115/Build/Cesium/Widgets/widgets.css"
       rel="stylesheet"
     />
     <style>

--- a/demo/cesium/czml.html
+++ b/demo/cesium/czml.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <title>Cesium</title>
-    <script src="https://cesium.com/downloads/cesiumjs/releases/1.114/Build/Cesium/Cesium.js"></script>
+    <script src="https://cesium.com/downloads/cesiumjs/releases/1.115/Build/Cesium/Cesium.js"></script>
     <link
-      href="https://cesium.com/downloads/cesiumjs/releases/1.114/Build/Cesium/Widgets/widgets.css"
+      href="https://cesium.com/downloads/cesiumjs/releases/1.115/Build/Cesium/Widgets/widgets.css"
       rel="stylesheet"
     />
     <style>

--- a/demo/cesium/gltf_ext_mesh_features.html
+++ b/demo/cesium/gltf_ext_mesh_features.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <title>Cesium</title>
-    <script src="https://cesium.com/downloads/cesiumjs/releases/1.114/Build/Cesium/Cesium.js"></script>
+    <script src="https://cesium.com/downloads/cesiumjs/releases/1.115/Build/Cesium/Cesium.js"></script>
     <link
-      href="https://cesium.com/downloads/cesiumjs/releases/1.114/Build/Cesium/Widgets/widgets.css"
+      href="https://cesium.com/downloads/cesiumjs/releases/1.115/Build/Cesium/Widgets/widgets.css"
       rel="stylesheet"
     />
     <style>

--- a/demo/cesium/gltf_ext_structural_metadata.html
+++ b/demo/cesium/gltf_ext_structural_metadata.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <title>Cesium</title>
-    <script src="https://cesium.com/downloads/cesiumjs/releases/1.114/Build/Cesium/Cesium.js"></script>
+    <script src="https://cesium.com/downloads/cesiumjs/releases/1.115/Build/Cesium/Cesium.js"></script>
     <link
-      href="https://cesium.com/downloads/cesiumjs/releases/1.114/Build/Cesium/Widgets/widgets.css"
+      href="https://cesium.com/downloads/cesiumjs/releases/1.115/Build/Cesium/Widgets/widgets.css"
       rel="stylesheet"
     />
     <style>

--- a/docs/manual/use_gui.md
+++ b/docs/manual/use_gui.md
@@ -133,9 +133,9 @@ Serving HTTP on :: port 8000 (http://[::]:8000/) ...
  <head>
   <meta charset="UTF-8" />
   <title>Cesium</title>
-  <script src="https://cesium.com/downloads/cesiumjs/releases/1.114/Build/Cesium/Cesium.js"></script>
+  <script src="https://cesium.com/downloads/cesiumjs/releases/1.115/Build/Cesium/Cesium.js"></script>
   <link
-   href="https://cesium.com/downloads/cesiumjs/releases/1.114/Build/Cesium/Widgets/widgets.css"
+   href="https://cesium.com/downloads/cesiumjs/releases/1.115/Build/Cesium/Widgets/widgets.css"
    rel="stylesheet"
   />
   <style>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
	- CesiumJSライブラリのバージョンを1.114から1.115に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->