### PR TITLE
feedback.ensure_canceled()? を随所に仕込む

### DIFF
--- a/nusamai/src/sink/geojson/mod.rs
+++ b/nusamai/src/sink/geojson/mod.rs
@@ -112,6 +112,8 @@ impl DataSink for GeoJsonSink {
                 std::fs::create_dir_all(&self.output_path)?;
                 let _ = categorized_features.iter().try_for_each(
                     |(typename, features)| -> Result<()> {
+                        feedback.ensure_not_canceled()?;
+
                         let mut file_path = self.output_path.clone();
                         let c_name = typename.split_once(':').map(|v| v.1).unwrap_or(typename);
                         file_path.push(&format!("{}.geojson", c_name));
@@ -125,6 +127,8 @@ impl DataSink for GeoJsonSink {
                         // Write each Feature
                         let mut iter = features.iter().peekable();
                         while let Some(feature) = iter.next() {
+                            feedback.ensure_not_canceled()?;
+
                             let bytes = serde_json::to_vec(&feature).unwrap();
                             writer.write_all(&bytes)?;
                             if iter.peek().is_some() {

--- a/nusamai/src/sink/gpkg/mod.rs
+++ b/nusamai/src/sink/gpkg/mod.rs
@@ -240,6 +240,8 @@ impl GpkgSink {
         }
 
         for (table_name, bbox) in table_bboxes {
+            feedback.ensure_not_canceled()?;
+
             tx.update_bbox(&table_name, bbox.to_tuple())
                 .await
                 .map_err(|e| PipelineError::Other(e.to_string()))?;

--- a/nusamai/src/sink/kml/mod.rs
+++ b/nusamai/src/sink/kml/mod.rs
@@ -168,7 +168,7 @@ impl DataSink for KmlSink {
                     // },
                 };
 
-                // let placemarks = receiver.into_iter();
+                // FIXME: streaming write
                 let placemarks = receiver.into_iter().collect::<Vec<_>>();
 
                 let kml_doc = Kml::Document {

--- a/nusamai/src/sink/mvt/mod.rs
+++ b/nusamai/src/sink/mvt/mod.rs
@@ -213,6 +213,8 @@ fn geometry_slicing_stage(
             max_detail,
             buffer_pixels,
             |(z, x, y), mpoly| {
+                feedback.ensure_not_canceled()?;
+
                 let feature = SlicedFeature {
                     geometry: mpoly,
                     properties: parcel.entity.root.clone(),

--- a/nusamai/src/sink/ply/mod.rs
+++ b/nusamai/src/sink/ply/mod.rs
@@ -172,7 +172,11 @@ impl DataSink for StanfordPlySink {
                 let mut mu_y = 0.;
                 let mut mu_z = 0.;
                 let mut all_vertices = Vec::new();
-                for triangles in receiver {
+                for (i, triangles) in receiver.into_iter().enumerate() {
+                    if i % 10000 == 0 {
+                        feedback.ensure_not_canceled()?;
+                    }
+
                     for [x, y, z] in triangles {
                         mu_x += x;
                         mu_y += y;
@@ -198,6 +202,8 @@ impl DataSink for StanfordPlySink {
                         index as u32
                     })
                     .collect();
+
+                feedback.ensure_not_canceled()?;
 
                 // write to file
                 println!("{:?} {:?}", vertices.len(), indices.len());

--- a/nusamai/src/sink/serde/mod.rs
+++ b/nusamai/src/sink/serde/mod.rs
@@ -92,6 +92,8 @@ impl DataSink for SerdeSink {
                 let mut writer =
                     BufWriter::with_capacity(1024 * 1024, File::create(&self.output_path)?);
                 for compressed in receiver {
+                    feedback.ensure_not_canceled()?;
+
                     // size
                     writer.write_all(&(compressed.len() as u32).to_le_bytes())?;
                     // compressed data

--- a/nusamai/src/sink/shapefile/mod.rs
+++ b/nusamai/src/sink/shapefile/mod.rs
@@ -179,8 +179,9 @@ impl DataSink for ShapefileSink {
                                         // - Building (no geometry)
                                         //     - BuildingPart (has geometry)
                                         //     - BuildingPart (has geometry)
-                                        log::warn!(
+                                        feedback.warn(
                                             "Feature without geometry is not supported yet."
+                                                .to_string(),
                                         );
                                     }
                                     shapefile::Shape::NullShape if has_no_geometry => {

--- a/nusamai/src/source/citygml.rs
+++ b/nusamai/src/source/citygml.rs
@@ -147,7 +147,7 @@ fn toplevel_dispatcher<R: BufRead>(
     if parse_appearances {
         for entity in entities {
             if feedback.is_canceled() {
-                break;
+                return Err(ParseError::Canceled);
             }
 
             // merge global appearances into the entity's local appearance store


### PR DESCRIPTION
close #315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタ**
	- 一貫性のために、`CzmlSink`の`entity_to_packet`を`entity_to_packets`に名前変更しました。
	- `GltfSink`でのキャンセルチェックを更新し、より明確なエラー処理を実装しました。
	- `GltfSink`のコード内で使用される特徴のグループ化方法を調整しました。

- **新機能**
	- 各データ変換プロセスにおいて、操作がキャンセルされた場合に適切に処理を中断するチェックを追加しました。

- **バグ修正**
	- `KmlSink`での処理において、ストリーミング書き込みに関する問題を修正するためのコメントを追加しました。

- **改善点**
	- `ShapefileSink`での警告メッセージの表示方法を改善しました。

これらの変更により、データ変換プロセスの安定性と効率が向上し、操作がキャンセルされた場合のハンドリングがより適切になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->