### PR TITLE
CI: リリースビルド時のオプションでビルドプロファイルを切り替える

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,17 +36,12 @@ jobs:
         run: npm install
         working-directory: ./app
 
-      - name: Set optimization options
-        run: |
-          echo '[profile.release]' >> Cargo.toml
-          echo 'lto = "fat"' >> Cargo.toml
-          echo 'panic = "abort"' >> Cargo.toml
-
       - name: Build the app
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          args: "--profile release-lto"
           tagName: ${{ github.event.release.tag_name }}
           releaseName: "PLATEAU GIS Converter v__VERSION__"
           releaseDraft: true


### PR DESCRIPTION
CI リリース時に release profile を書き換えるハックではなく、 `--profile release-lto` オプションを付けてビルドするようにします。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **パフォーマンス向上**
	- ビルドプロセスにおいて、最適化オプションの設定を削除し、より効率的なリリースビルドのために`--profile release-lto`オプションを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->