### PR TITLE
GUI: 出力形式が切り替えられたとき、必要に応じて出力先CRSをリセットする

### DIFF
--- a/app/src/routes/SettingSelector.svelte
+++ b/app/src/routes/SettingSelector.svelte
@@ -10,6 +10,13 @@
 	$: epsgOptions = filetypeOptions[filetype]?.epsg || [];
 	$: disableEpsgOptions = epsgOptions.length < 2;
 
+	$: {
+		// Reset the target CRS if the selected filetype does not support the current CRS
+		if (!filetypeOptions[filetype]?.epsg.some((item) => item.value === epsg)) {
+			epsg = filetypeOptions[filetype]?.epsg[0].value || 4979;
+		}
+	}
+
 	async function openRulesPathDialog() {
 		const res = await dialog.open({
 			filters: [


### PR DESCRIPTION
出力形式が切り変えられたときに、その形式が現在指定中のCRSに対応していない場合は、CRSをその形式のデフォルト値にリセットします。 Close: #487 

https://github.com/MIERUNE/plateau-gis-converter/assets/5351911/2e4c0b61-2456-41e5-b5e6-f5ae6a256200


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 選択されたファイルタイプが現在のCRSをサポートしていない場合、ターゲットCRSをリセットする機能が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->