### PR TITLE
Fix: glTF Sink で interior rings を正しく扱うようにする

### DIFF
--- a/nusamai/src/sink/cesiumtiles/material.rs
+++ b/nusamai/src/sink/cesiumtiles/material.rs
@@ -115,7 +115,7 @@ impl Image {
 // NOTE: temporary implementation
 fn load_image(feedback: &Feedback, path: &Path) -> std::io::Result<(Vec<u8>, MimeType)> {
     if let Some(ext) = path.extension() {
-        match ext.to_str() {
+        match ext.to_ascii_lowercase().to_str() {
             Some("tif" | "tiff" | "png") => {
                 feedback.info(format!("Decoding image: {:?}", path));
                 let t = Instant::now();

--- a/nusamai/src/sink/cesiumtiles/slice.rs
+++ b/nusamai/src/sink/cesiumtiles/slice.rs
@@ -174,17 +174,21 @@ pub fn slice_to_tiles<E>(
                                         polygon_material_ids: Default::default(),
                                         materials: Default::default(), // set later
                                     });
-                            poly.rings()
-                                .zip_eq(poly_uv.rings())
-                                .for_each(|(ring, uv_ring)| {
+                            poly.rings().zip_eq(poly_uv.rings()).enumerate().for_each(
+                                |(ri, (ring, uv_ring))| {
                                     ring.iter_closed().zip_eq(uv_ring.iter_closed()).for_each(
                                         |(c, uv)| {
                                             ring_buffer.push([c[0], c[1], c[2], uv[0], uv[1]]);
                                         },
                                     );
-                                    sliced_feature.polygons.add_exterior(ring_buffer.drain(..));
-                                    sliced_feature.polygon_material_ids.push(mat_idx as u32);
-                                });
+                                    if ri == 0 {
+                                        sliced_feature.polygons.add_exterior(ring_buffer.drain(..));
+                                        sliced_feature.polygon_material_ids.push(mat_idx as u32);
+                                    } else {
+                                        sliced_feature.polygons.add_interior(ring_buffer.drain(..));
+                                    }
+                                },
+                            );
                         }
                     }
                 }

--- a/nusamai/src/sink/gltf/material.rs
+++ b/nusamai/src/sink/gltf/material.rs
@@ -114,7 +114,7 @@ impl Image {
 // NOTE: temporary implementation
 fn load_image(feedback: &Feedback, path: &Path) -> std::io::Result<(Vec<u8>, MimeType)> {
     if let Some(ext) = path.extension() {
-        match ext.to_str() {
+        match ext.to_ascii_lowercase().to_str() {
             Some("tif" | "tiff" | "png") => {
                 feedback.info(format!("Decoding image: {:?}", path));
                 let t = Instant::now();


### PR DESCRIPTION
- glTF Sink は Polygon の Interior rings を考慮しない（暫定の？）実装になっていた。修正する。 Close #489
- 同時に、大文字拡張子 (e.g. ".JPG") のテクスチャ画像でエラーになる問題も修正する。 Close #490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- サポートされている画像フォーマットを拡張子に基づいて識別するロジックを改善し、拡張子を小文字に変換してから比較します。

- **機能改善**
	- 多角形のリングを処理するロジックを更新し、リングのインデックスに基づいて外側と内側のリングを区別し、その位置に応じて異なる方法で扱います。
	- 多角形とそれに関連するUV座標の取り扱いをリファクタリングし、多角形リングとUVリングを同時に反復処理し、座標とUV値でリングバッファを満たします。この反復処理中に境界ボリュームの境界を更新するロジックを調整します。外側と内側のリングを区別する方法を変更して、多角形を機能に追加します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->