### PR TITLE
gltf(propertyTables): idを2重に書き込んでいた箇所を修正

### DIFF
--- a/nusamai/src/sink/cesiumtiles/metadata/mod.rs
+++ b/nusamai/src/sink/cesiumtiles/metadata/mod.rs
@@ -174,7 +174,7 @@ impl Class {
 
             // Fill in the default values for the properties that don't occur in the input
             for (key, prop) in &mut self.properties {
-                if obj.attributes.contains_key(key) {
+                if obj.attributes.contains_key(key) | obj.stereotype.id().is_some() {
                     continue;
                 }
 

--- a/nusamai/src/sink/cesiumtiles/metadata/mod.rs
+++ b/nusamai/src/sink/cesiumtiles/metadata/mod.rs
@@ -174,7 +174,7 @@ impl Class {
 
             // Fill in the default values for the properties that don't occur in the input
             for (key, prop) in &mut self.properties {
-                if obj.attributes.contains_key(key) | obj.stereotype.id().is_some() {
+                if obj.attributes.contains_key(key) || obj.stereotype.id().is_some() {
                     continue;
                 }
 

--- a/nusamai/src/sink/gltf/metadata/mod.rs
+++ b/nusamai/src/sink/gltf/metadata/mod.rs
@@ -174,7 +174,7 @@ impl Class {
 
             // Fill in the default values for the properties that don't occur in the input
             for (key, prop) in &mut self.properties {
-                if obj.attributes.contains_key(key) {
+                if obj.attributes.contains_key(key) | obj.stereotype.id().is_some() {
                     continue;
                 }
 

--- a/nusamai/src/sink/gltf/metadata/mod.rs
+++ b/nusamai/src/sink/gltf/metadata/mod.rs
@@ -174,7 +174,7 @@ impl Class {
 
             // Fill in the default values for the properties that don't occur in the input
             for (key, prop) in &mut self.properties {
-                if obj.attributes.contains_key(key) | obj.stereotype.id().is_some() {
+                if obj.attributes.contains_key(key) || obj.stereotype.id().is_some() {
                     continue;
                 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 特定のキーの存在と、オブジェクトのステレオタイプIDのチェック条件を改善しました。これにより、より正確なメタデータの処理が可能になります。
  - プロパティを繰り返し確認する際の条件に、ステレオタイプ属性のIDの存在チェックを追加しました。これにより、より柔軟なデータ検証が行えるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->