### PR TITLE
GUI: 3D Tiles 出力のCRS選択肢にJGD2011を追加する（ジオイド高を加算しない用途）

### DIFF
--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -50,7 +50,10 @@ const filetypeOptions: Record<string, { label: string; extensions: string[]; eps
 		cesiumtiles: {
 			label: '3D Tiles',
 			extensions: [''],
-			epsg: [{ value: 4979, label: 'WGS 84 (EPSG:4979)' }]
+			epsg: [
+				{ value: 4979, label: 'WGS 84 (EPSG:4979) (楕円体高)' },
+				{ value: 6697, label: '特殊: JGD2011 (EPSG:6697) (標高)' }
+			]
 		},
 		mvt: {
 			label: 'Vector Tiles (MVT)',


### PR DESCRIPTION
3D Tilesの出力時に、WGS 84 が求める楕円体高（標高＋ジオイド高）ではなく、標高のままで計算した特殊なタイルセットが欲しいという需要が一部にある。

GUIの出力先CRSとして、WGS84（楕円体高）ではなく、JGD2011 (標高) を選ばせることで、Transformerによるジオイド高の加算を止めることができる。

KML出力で使った方法 (#486) と同様。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- CesiumタイルのためのEPSG値に、対応するラベルを含む追加のオプションを拡張しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->