### PR TITLE
gltf: BoundingVolumeの height の更新の誤りを修正

### DIFF
--- a/nusamai/src/sink/gltf/mod.rs
+++ b/nusamai/src/sink/gltf/mod.rs
@@ -80,8 +80,8 @@ impl BoundingVolume {
         self.max_lng = self.max_lng.max(other.max_lng);
         self.min_lat = self.min_lat.min(other.min_lat);
         self.max_lat = self.max_lat.max(other.max_lat);
-        self.min_height = self.min_lng.min(other.min_lng);
-        self.max_height = self.max_lng.max(other.max_lng);
+        self.min_height = self.min_height.min(other.min_height);
+        self.max_height = self.max_height.max(other.max_height);
     }
 }
 


### PR DESCRIPTION
#485 での BoundingVolume の height の更新に誤りがありました。修正します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **バグ修正**
	- `BoundingVolume`実装において、`min_height`と`max_height`の割り当てが修正されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->