### PR TITLE
CI: Mac用リリースを Universal Binary (Apple Silicon & Intel) にする

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,8 +10,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-latest, windows-latest]
-    runs-on: ${{ matrix.platform }}
+        settings:
+          - platform: windows-latest
+            args: '-- --profile release-lto'
+          - platform: macos-latest
+            args: '--target universal-apple-darwin -- --profile release-lto'
+          - platform: ubuntu-latest
+            args: '-- --profile release-lto'
+    runs-on: ${{ matrix.settings.platform }}
 
     steps:
       - name: Checkout repository
@@ -24,6 +30,12 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: "./src-tauri -> target"
+
+      - name: Install dependencies (Ubuntu only)
+        if: matrix.settings.platform == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.0-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
 
       - name: Sync node version and setup cache
         uses: actions/setup-node@v4
@@ -41,7 +53,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: "-- --profile release-lto"  # args for tauri build
+          args: ${{ matrix.settings.args }}  # args for tauri build
           tagName: ${{ github.event.release.tag_name }}
           releaseName: "PLATEAU GIS Converter v__VERSION__"
           releaseDraft: true


### PR DESCRIPTION
GitHub Actions での Mac 用のリリースにおいて、 Universal Binary をビルドするようにする。

（いまはIntel用だけのビルドになってしまっていて、Apple SiliconではRosetta 2での実行になってしまう）

参考: https://github.com/tauri-apps/tauri-action/blob/dev/.github/workflows/test-action.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタ**
	- プラットフォームごとの特定の設定を含むようにプラットフォームマトリックスを再構成し、選択されたプラットフォームに基づいてUbuntuのみの依存関係をインストールするステップを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->