### PR TITLE
CI: ターゲット aarch64-apple-darwin を追加する

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Rust setup
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2


### PR DESCRIPTION
Universal Binary 対応 (#502) の不備を修正。rustup でターゲット aarch64-apple-darwin を追加する。

参考: https://github.com/tauri-apps/tauri-action/blob/dev/.github/workflows/test-action.yml