### PR TITLE
Update earcut-rs to v0.3.0

### DIFF
--- a/nusamai-gltf/Cargo.toml
+++ b/nusamai-gltf/Cargo.toml
@@ -11,7 +11,7 @@ clap = { version = "4.5.4", features = ["derive"] }
 nusamai-geometry = { path = "../nusamai-geometry" }
 quick-xml = "0.31.0"
 thiserror = "1.0.58"
-earcut-rs = { git = "https://github.com/MIERUNE/earcut-rs.git", tag = "v0.2.0" }
+earcut-rs = { git = "https://github.com/MIERUNE/earcut-rs.git", tag = "v0.3.0" }
 indexmap = "2.2.6"
 byteorder = "1.5.0"
 serde_json = "1.0.115"

--- a/nusamai/Cargo.toml
+++ b/nusamai/Cargo.toml
@@ -41,7 +41,7 @@ bytesize = "1.3.0"
 ahash = "0.8.11"
 nusamai-shapefile = { path = "../nusamai-shapefile" }
 shapefile = "0.6.0"
-earcut-rs = { git = "https://github.com/MIERUNE/earcut-rs.git", tag = "v0.2.0" }
+earcut-rs = { git = "https://github.com/MIERUNE/earcut-rs.git", tag = "v0.3.0" }
 glob = "0.3.1"
 shellexpand = "3.1.0"
 kml = "0.8.5"

--- a/nusamai/src/sink/gltf/mod.rs
+++ b/nusamai/src/sink/gltf/mod.rs
@@ -286,7 +286,7 @@ impl DataSink for GltfSink {
                 let mut earcutter: Earcut<f64> = Earcut::new();
                 let mut buf3d: Vec<[f64; 3]> = Vec::new();
                 let mut buf2d: Vec<[f64; 2]> = Vec::new(); // 2d-projected [x, y]
-                let mut index_buf: Vec<[u32; 3]> = Vec::new();
+                let mut index_buf: Vec<u32> = Vec::new();
 
                 let mut vertices: IndexSet<[u32; 9], RandomState> = IndexSet::default(); // [x, y, z, nx, ny, nz, u, v, feature_id]
                 let mut primitives: Primitives = Default::default();
@@ -363,29 +363,29 @@ impl DataSink for GltfSink {
 
                             if project3d_to_2d(&buf3d, num_outer, &mut buf2d) {
                                 // earcut
-                                earcutter.earcut(&buf2d, poly.hole_indices(), &mut index_buf);
+                                earcutter.earcut(
+                                    buf2d.iter().flatten().copied(),
+                                    poly.hole_indices(),
+                                    &mut index_buf,
+                                );
 
                                 // collect triangles
-                                primitive
-                                    .indices
-                                    .extend(index_buf.iter().flat_map(|indices| {
-                                        indices.map(|idx| {
-                                            let [x, y, z, u, v] = poly.raw_coords()[idx as usize];
-                                            let vbits = [
-                                                (x as f32).to_bits(),
-                                                (y as f32).to_bits(),
-                                                (z as f32).to_bits(),
-                                                (nx as f32).to_bits(),
-                                                (ny as f32).to_bits(),
-                                                (nz as f32).to_bits(),
-                                                (u as f32).to_bits(),
-                                                (v as f32).to_bits(),
-                                                (feature_id as f32).to_bits(), // UNSIGNED_INT can't be used for vertex attribute
-                                            ];
-                                            let (index, _) = vertices.insert_full(vbits);
-                                            index as u32
-                                        })
-                                    }));
+                                primitive.indices.extend(index_buf.iter().map(|&idx| {
+                                    let [x, y, z, u, v] = poly.raw_coords()[idx as usize];
+                                    let vbits = [
+                                        (x as f32).to_bits(),
+                                        (y as f32).to_bits(),
+                                        (z as f32).to_bits(),
+                                        (nx as f32).to_bits(),
+                                        (ny as f32).to_bits(),
+                                        (nz as f32).to_bits(),
+                                        (u as f32).to_bits(),
+                                        (v as f32).to_bits(),
+                                        (feature_id as f32).to_bits(), // UNSIGNED_INT can't be used for vertex attribute
+                                    ];
+                                    let (index, _) = vertices.insert_full(vbits);
+                                    index as u32
+                                }));
                             }
                         }
                     }

--- a/nusamai/src/sink/ply/mod.rs
+++ b/nusamai/src/sink/ply/mod.rs
@@ -111,7 +111,7 @@ impl DataSink for StanfordPlySink {
                         let mut earcutter = Earcut::new();
                         let mut buf3d: Vec<[f64; 3]> = Vec::new();
                         let mut buf2d: Vec<[f64; 2]> = Vec::new();
-                        let mut triangles_buf: Vec<[u32; 3]> = Vec::new();
+                        let mut index_buf: Vec<u32> = Vec::new();
                         let mut triangles = Vec::new();
 
                         geometries.iter().for_each(|entry| match entry.ty {
@@ -140,17 +140,13 @@ impl DataSink for StanfordPlySink {
                                     if project3d_to_2d(&buf3d, num_outer, &mut buf2d) {
                                         // earcut
                                         earcutter.earcut(
-                                            &buf2d,
+                                            buf2d.iter().flatten().cloned(),
                                             poly.hole_indices(),
-                                            &mut triangles_buf,
+                                            &mut index_buf,
                                         );
-                                        triangles.extend(triangles_buf.iter().flat_map(|idx| {
-                                            [
-                                                buf3d[idx[0] as usize],
-                                                buf3d[idx[1] as usize],
-                                                buf3d[idx[2] as usize],
-                                            ]
-                                        }));
+                                        triangles.extend(
+                                            index_buf.iter().map(|&idx| buf3d[idx as usize]),
+                                        );
                                     }
                                 }
                             }


### PR DESCRIPTION
https://github.com/MIERUNE/earcut-rs/pull/7 の変更に追従する


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタ**
	- 3DタイルとGLTFの出力処理で、インデックスバッファの型を改善しました。これにより、データの処理がより効率的になります。
	- PLY形式の出力処理も同様に改善され、よりシンプルで効率的なデータ処理を実現しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->