### PR TITLE
chore: Update earcut to 0.4

### DIFF
--- a/nusamai-gltf/Cargo.toml
+++ b/nusamai-gltf/Cargo.toml
@@ -11,7 +11,7 @@ clap = { version = "4.5.4", features = ["derive"] }
 nusamai-geometry = { path = "../nusamai-geometry" }
 quick-xml = "0.31.0"
 thiserror = "1.0.58"
-earcut = "0.3"
+earcut = "0.4"
 indexmap = "2.2.6"
 byteorder = "1.5.0"
 serde_json = "1.0.115"

--- a/nusamai/Cargo.toml
+++ b/nusamai/Cargo.toml
@@ -41,7 +41,7 @@ bytesize = "1.3.0"
 ahash = "0.8.11"
 nusamai-shapefile = { path = "../nusamai-shapefile" }
 shapefile = "0.6.0"
-earcut = "0.3"
+earcut = "0.4"
 glob = "0.3.1"
 shellexpand = "3.1.0"
 kml = "0.8.5"

--- a/nusamai/src/sink/cesiumtiles/mod.rs
+++ b/nusamai/src/sink/cesiumtiles/mod.rs
@@ -376,7 +376,7 @@ fn tile_writing_stage(
 
                         if project3d_to_2d(&buf3d, num_outer_points,  &mut buf2d) {
                             // earcut
-                            earcutter.earcut(buf2d.iter().flatten().cloned(), poly.hole_indices(),  &mut index_buf);
+                            earcutter.earcut(buf2d.iter().cloned(), poly.hole_indices(),  &mut index_buf);
 
                             // collect triangles
                             primitive.indices.extend(index_buf.iter().map(|&idx| {

--- a/nusamai/src/sink/gltf/mod.rs
+++ b/nusamai/src/sink/gltf/mod.rs
@@ -364,7 +364,7 @@ impl DataSink for GltfSink {
                             if project3d_to_2d(&buf3d, num_outer, &mut buf2d) {
                                 // earcut
                                 earcutter.earcut(
-                                    buf2d.iter().flatten().copied(),
+                                    buf2d.iter().copied(),
                                     poly.hole_indices(),
                                     &mut index_buf,
                                 );

--- a/nusamai/src/sink/ply/mod.rs
+++ b/nusamai/src/sink/ply/mod.rs
@@ -140,7 +140,7 @@ impl DataSink for StanfordPlySink {
                                     if project3d_to_2d(&buf3d, num_outer, &mut buf2d) {
                                         // earcut
                                         earcutter.earcut(
-                                            buf2d.iter().flatten().cloned(),
+                                            buf2d.iter().cloned(),
                                             poly.hole_indices(),
                                             &mut index_buf,
                                         );


### PR DESCRIPTION
Bump `earcut` to 0.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **依存関係の更新**
	- `earcut` のバージョンを0.3から0.4に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->