### PR TITLE
Add the Web Mercator as a target CRS

### DIFF
--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -7,6 +7,7 @@ const filetypeOptions: Record<string, { label: string; extensions: string[]; eps
 			extensions: ['gpkg'],
 			epsg: [
 				{ value: 4979, label: 'WGS 84 (EPSG:4979)' },
+				{ value: 3857, label: 'Web Mercator (EPSG:3857)' },
 				{ value: 6669, label: 'JGD2011 / 平面直角座標系 I (EPSG:6669)' },
 				{ value: 6670, label: 'JGD2011 / 平面直角座標系 II (EPSG:6670)' },
 				{ value: 6671, label: 'JGD2011 / 平面直角座標系 III (EPSG:6671)' },
@@ -58,7 +59,7 @@ const filetypeOptions: Record<string, { label: string; extensions: string[]; eps
 		mvt: {
 			label: 'Vector Tiles (MVT)',
 			extensions: [''],
-			epsg: [{ value: 4979, label: 'WGS 84 (EPSG:4979)' }]
+			epsg: [{ value: 4979, label: 'WGS 84' }]
 		},
 
 		czml: {
@@ -88,6 +89,7 @@ const filetypeOptions: Record<string, { label: string; extensions: string[]; eps
 			extensions: [''],
 			epsg: [
 				{ value: 4979, label: 'WGS 84 (EPSG:4979)' },
+				{ value: 3857, label: 'Web Mercator (EPSG:3857)' },
 				{ value: 6669, label: 'JGD2011 / 平面直角座標系 I (EPSG:6669)' },
 				{ value: 6670, label: 'JGD2011 / 平面直角座標系 II (EPSG:6670)' },
 				{ value: 6671, label: 'JGD2011 / 平面直角座標系 III (EPSG:6671)' },

--- a/nusamai-gpkg/src/sql/srs.sql
+++ b/nusamai-gpkg/src/sql/srs.sql
@@ -54,6 +54,25 @@ AXIS ["Ellipsoidal height (h)",up,LENGTHUNIT["metre",1,ID["EPSG",9001]]],
 ID ["EPSG",4979]]'
     );
 
+-- Web Mercator (WGS 84 / Pseudo-Mercator)
+-- cf. https://epsg.org/crs_3857/Web_Mercator.html
+INSERT INTO
+    gpkg_spatial_ref_sys (
+        srs_name,
+        srs_id,
+        organization,
+        organization_coordsys_id,
+        definition
+    )
+VALUES
+    (
+        'WGS 84 / Pseudo-Mercator',
+        3857,
+        'EPSG',
+        3857,
+        'PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]'
+    );
+
 -- Japan Plane Rectangular CS + JGD2011 (vertical) height
 -- cf. https://epsg.org/crs_10162/JGD2011-Japan-Plane-Rectangular-CS-I-JGD2011-vertical-height.html, etc.
 INSERT INTO

--- a/nusamai-mvt/src/webmercator.rs
+++ b/nusamai-mvt/src/webmercator.rs
@@ -1,8 +1,11 @@
 //! Web Mercator projection utilities.
 
-use std::f64::consts::FRAC_PI_2;
+use std::f64::consts::{FRAC_PI_2, TAU};
 
-/// Converts geographic coordinate (lng, lat) to Web Mercator coordinate (mx, my).
+const A: f64 = 6378137.;
+const CIRCUMFERENCE: f64 = A * TAU;
+
+/// Converts geographic coordinate (lng, lat) to Web Mercator coordinate (mx, my) normalized.
 ///
 /// The range of (mx, my) is [0.0, 0.0]-[1.0, 1.0] (same as Mapbox/MapLibre API, etc.)
 pub fn lnglat_to_web_mercator(lng: f64, lat: f64) -> (f64, f64) {
@@ -12,7 +15,7 @@ pub fn lnglat_to_web_mercator(lng: f64, lat: f64) -> (f64, f64) {
     (mx, my)
 }
 
-/// Converts Web Mercator coordinate (mx, my) to geographic coordinate (lng, lat).
+/// Converts Web Mercator coordinate (mx, my) normalized to geographic coordinate (lng, lat).
 ///
 /// The range of (mx, my) is [0.0, 0.0]-[1.0, 1.0] (same as Mapbox/MapLibre API, etc.)
 pub fn web_mercator_to_lnglat(mx: f64, my: f64) -> (f64, f64) {
@@ -22,12 +25,30 @@ pub fn web_mercator_to_lnglat(mx: f64, my: f64) -> (f64, f64) {
     (lng, lat)
 }
 
+/// Converts geographic coordinate (lng, lat) to Web Mercator coordinate (mx, my) in meters.
+///
+/// The range of (mx, my) is [-20037508.342789244, -20037508.342789244, 20037508.342789244, 20037508.342789244]
+pub fn lnglat_to_web_mercator_meters(lng: f64, lat: f64) -> (f64, f64) {
+    let mx = lng / 360.0 * CIRCUMFERENCE;
+    let my = ((90.0 + lat).to_radians() / 2.0).tan().ln() * A;
+    (mx, my)
+}
+
+/// Converts Web Mercator coordinate (mx, my) in meters to geographic coordinate (lng, lat).
+///
+/// The range of (mx, my) is [-20037508.342789244, -20037508.342789244, 20037508.342789244, 20037508.342789244]
+pub fn web_mercator_meters_to_lnglat(mx: f64, my: f64) -> (f64, f64) {
+    let lng = mx / CIRCUMFERENCE * 360.0;
+    let lat = (2.0 * (my / A).exp().atan()).to_degrees() - 90.0;
+    (lng, lat)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn roundtrip() {
+    fn roundtrip_normalized() {
         {
             let (lng, lat) = (136.08, 37.39);
             let (mx, my) = lnglat_to_web_mercator(lng, lat);
@@ -45,6 +66,24 @@ mod tests {
     }
 
     #[test]
+    fn roundtrip_in_meters() {
+        {
+            let (lng, lat) = (136.08, 37.39);
+            let (mx, my) = lnglat_to_web_mercator_meters(lng, lat);
+            let (lng2, lat2) = web_mercator_meters_to_lnglat(mx, my);
+            assert!((lng - lng2).abs() < 1e-9);
+            assert!((lat - lat2).abs() < 1e-9);
+        }
+        {
+            let (lng, lat) = (0.3, 0.2);
+            let (mx, my) = lnglat_to_web_mercator_meters(lng, lat);
+            let (lng2, lat2) = web_mercator_meters_to_lnglat(mx, my);
+            assert!((lng - lng2).abs() < 1e-9);
+            assert!((lat - lat2).abs() < 1e-9);
+        }
+    }
+
+    #[test]
     fn null_island() {
         // https://en.wikipedia.org/wiki/Null_Island
         // (lng: 0, lat: 0) -> (mx: 0.5, my: 0.5)
@@ -52,5 +91,25 @@ mod tests {
         let (mx, my) = lnglat_to_web_mercator(lng, lat);
         assert!((mx - 0.5).abs() < 1e-10);
         assert!((my - 0.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn null_island_in_meters() {
+        // https://en.wikipedia.org/wiki/Null_Island
+        // (lng: 0, lat: 0) -> (mx: 0.5, my: 0.5)
+        let (lng, lat) = (0., 0.);
+        let (mx, my) = lnglat_to_web_mercator_meters(lng, lat);
+        println!("{}, {}", mx, my);
+        assert!((mx - 0.0).abs() < 1e-9);
+        assert!((my - 0.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn bound_in_meters() {
+        let (lng, lat) = (180., 85.0511287798066);
+        let (mx, my) = lnglat_to_web_mercator_meters(lng, lat);
+        println!("{}", CIRCUMFERENCE / 2.);
+        assert!((mx - CIRCUMFERENCE / 2.).abs() < 1e-7);
+        assert!((my - CIRCUMFERENCE / 2.).abs() < 1e-7);
     }
 }

--- a/nusamai-projection/src/crs.rs
+++ b/nusamai-projection/src/crs.rs
@@ -4,6 +4,9 @@ pub const EPSG_WGS84_GEOGRAPHIC_2D: EpsgCode = 4326;
 pub const EPSG_WGS84_GEOGRAPHIC_3D: EpsgCode = 4979;
 pub const EPSG_WGS84_GEOCENTRIC: EpsgCode = 4978;
 
+// Web Mercator
+pub const EPSG_WEB_MERCATOR: EpsgCode = 3857;
+
 /// JGD2011
 pub const EPSG_JGD2011_GEOGRAPHIC_2D: EpsgCode = 6668;
 

--- a/nusamai/src/sink/shapefile/crs.rs
+++ b/nusamai/src/sink/shapefile/crs.rs
@@ -7,7 +7,7 @@ pub struct ProjectionRepository {
 }
 
 // Define WKT1_ESRI strings for various CRSs
-const WKT1_ESRI: [(u16, &str); 74] = [
+const WKT1_ESRI: [(u16, &str); 75] = [
     // WGS84 Geographic 2D
     (
         4326,
@@ -18,8 +18,13 @@ const WKT1_ESRI: [(u16, &str); 74] = [
         4979,
         r#"GEOGCS["WGS_1984_3D",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433],LINUNIT["Meter",1.0]]"#,
     ),
-    // WGS84 Geocentric(Geocentric CRS not supported in WKT1_ESRI)
+    // WGS84 Geocentric (Geocentric CRS is not supported in WKT1_ESRI)
     // (4978, r#""#);
+    // Web Mercator (WGS84 / Pseudo-Mercator)
+    (
+        3857,
+        r#"PROJCS["WGS_1984_Web_Mercator_Auxiliary_Sphere",GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Mercator_Auxiliary_Sphere"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",0.0],PARAMETER["Standard_Parallel_1",0.0],PARAMETER["Auxiliary_Sphere_Type",0.0],UNIT["Meter",1.0]]"#,
+    ),
     // JGD2011 Geographic 2D
     (
         6668,

--- a/nusamai/src/transformer/transform/projection.rs
+++ b/nusamai/src/transformer/transform/projection.rs
@@ -43,6 +43,17 @@ impl Transform for ProjectionTransform {
                     });
                     geom_store.epsg = self.output_epsg;
                 }
+                EPSG_WEB_MERCATOR => {
+                    let mut geom_store = entity.geometry_store.write().unwrap();
+                    geom_store.vertices.iter_mut().for_each(|v| {
+                        // Swap x and y (lat, lng -> lng, lat)
+                        let (lng, lat) = (v[1], v[0]);
+                        // LngLat to Web Mercator
+                        (v[0], v[1]) =
+                            nusamai_mvt::webmercator::lnglat_to_web_mercator_meters(lng, lat)
+                    });
+                    geom_store.epsg = self.output_epsg;
+                }
                 EPSG_JGD2011_JPRECT_I_JGD2011_HEIGHT
                 | EPSG_JGD2011_JPRECT_II_JGD2011_HEIGHT
                 | EPSG_JGD2011_JPRECT_III_JGD2011_HEIGHT


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #514

### Description（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- 何のために、どのような変更をしますか？ -->

出力先CRSとして Web Mercator に対応する。ユーザからの要望があった。対応は容易。技術的負債にもならないと考える。

- CRS変換を担う ProjectionTransform に、JGD2011 → Web Mercator のサポートを追加する。
- Gpkg と Shapefile のターゲットCRSとして Web Mercator を追加する。（他の形式は、任意のCRSに対応していないため対応を保留する）

### Manual Testing（手動テスト）
<!-- Describe the manual testing procedure if needed. -->
<!-- 手動の動作確認が必要なら、その手順を記述してください。-->

Not required / 不要



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- Web Mercator (EPSG:3857) をサポートする機能が追加されました。
	- 'WGS 84' と 'Web Mercator (EPSG:3857)' のラベルが更新されました。
- **バグ修正**
	- 地理座標とWeb Mercator座標の変換機能が改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->