### PR TITLE
projection: Cartesian to Geodetic

### DIFF
--- a/nusamai-projection/src/cartesian.rs
+++ b/nusamai-projection/src/cartesian.rs
@@ -176,7 +176,7 @@ mod tests {
             let (lng2, lat2, height2) = geocentric_to_geodetic(&wgs84, x, y, z);
             assert!((lng - lng2).abs() < 1e-10);
             assert!((lat - lat2).abs() < 1e-10);
-            assert!((height - height2).abs() < 1e-9);
+            assert!((height - height2).abs() < 1e-7);
         }
 
         // On or inside the evolute and not in the singular disc
@@ -186,7 +186,7 @@ mod tests {
             let (lng2, lat2, height2) = geocentric_to_geodetic(&wgs84, x, y, z);
             assert!((lng - lng2).abs() < 1e-10);
             assert!((lat - lat2).abs() < 1e-10);
-            assert!((height - height2).abs() < 1e-9);
+            assert!((height - height2).abs() < 1e-7);
         }
 
         // In the singular disc
@@ -207,7 +207,7 @@ mod tests {
             let (lng2, lat2, height2) = geocentric_to_geodetic(&wgs84, x, y, z);
             assert!((lng - lng2).abs() < 1e-9);
             assert!((lat - lat2).abs() < 1e-9);
-            assert!((height - height2).abs() < 1e-9);
+            assert!((height - height2).abs() < 1e-7);
         }
     }
 

--- a/nusamai-projection/src/cartesian.rs
+++ b/nusamai-projection/src/cartesian.rs
@@ -1,6 +1,6 @@
 //! Conversion between geodetic and geocentric (cartesian) coordinate systems.
 
-use std::f64::consts::{FRAC_2_PI, FRAC_PI_6};
+use std::f64::consts::FRAC_PI_6;
 
 use crate::ellipsoid::Ellipsoid;
 
@@ -23,12 +23,10 @@ pub fn geodetic_to_geocentric(
     (x, y, z)
 }
 
-pub fn geocentric_to_geodetic_vermeille(
-    ellips: &Ellipsoid,
-    x: f64,
-    y: f64,
-    z: f64,
-) -> (f64, f64, f64) {
+/// Convert from geocentric to geodetic coordinate system.
+///
+/// We uses Hugues Vermeille's *[An analytical method to transform geocentric into geodetic coordinates](https://DOI.org/10.1007/s00190-010-0419-x)*, J. Geodesy (2011) 85, page 105-117.
+pub fn geocentric_to_geodetic(ellips: &Ellipsoid, x: f64, y: f64, z: f64) -> (f64, f64, f64) {
     let a = ellips.a();
     let e_sq = ellips.e_sq();
     let e_quad = e_sq * e_sq;
@@ -37,18 +35,17 @@ pub fn geocentric_to_geodetic_vermeille(
     let q = (1. - e_sq) * z * z / (a * a);
     let r = (p + q - e_quad) / 6.;
 
-    let res = 8. * r.powi(3) + e_quad * p * q;
-    let res2 = e_quad * p * q;
+    let evol = 8. * r.powi(3) + e_quad * p * q;
 
-    let (phi, h) = if res > 0. || q != 0. {
-        // Outside the evolute i.e. when 8r 3 + e4 pq > 0,
-        // compute u, v, w, k, D, h, φ from Eqs. (25), (33), (36),
-        // (39), (42), (44) and (46)
-        let u = if res > 0. {
-            let l = (res.sqrt() + res2.sqrt()).cbrt();
+    let (phi, h) = if evol > 0. || q != 0. {
+        let u = if evol > 0. {
+            // Outside the evolute
+            let l = (evol.sqrt() + (e_quad * p * q).sqrt()).cbrt();
             (3. * r * r) / (2. * l * l) + 0.5 * (l + r / l) * (l + r / l)
         } else {
-            let t = 2. / 3. * (res2.sqrt()).atan2((-res).sqrt() + (-8. * r * r * r).sqrt());
+            // On or inside the evolute and not in the singular disc
+            let t = 2. / 3.
+                * ((e_quad * p * q).sqrt()).atan2((-evol).sqrt() + (-8. * r * r * r).sqrt());
             -4. * r * (t).sin() * (FRAC_PI_6 + t).cos()
         };
         let v = (u * u + e_quad * q).sqrt();
@@ -59,16 +56,11 @@ pub fn geocentric_to_geodetic_vermeille(
         let phi = 2. * z.atan2(d + (d * d + z * z).sqrt());
         (phi, h)
     } else {
+        // In the singular disc
         let h = -a * ((1. - e_sq) * (e_sq - p) / e_sq).sqrt();
-        let phi = 2.
-            * ((e_quad - p).sqrt()).atan2(
-                (e_quad - p).sqrt() / ((e_sq * (e_sq - p)).sqrt() + ((1. - e_sq) * p).sqrt()),
-            );
-        if z > 0. {
-            (phi, h)
-        } else {
-            (-phi, h)
-        }
+        let phi =
+            2. * ((e_quad - p).sqrt()).atan2((e_sq * (e_sq - p)).sqrt() + ((1. - e_sq) * p).sqrt());
+        (phi, h)
     };
 
     let lam = f64::atan2(y, x);
@@ -76,152 +68,151 @@ pub fn geocentric_to_geodetic_vermeille(
     (lam.to_degrees(), phi.to_degrees(), h)
 }
 
-/// Convert from geocentric to geodetic coordinate system.
-pub fn geocentric_to_geodetic_proj(ellips: &Ellipsoid, x: f64, y: f64, z: f64) -> (f64, f64, f64) {
-    // Ported from PROJ
-
-    let (lam, p_div_a, z_div_a) = {
-        let ra = 1. / ellips.a();
-        let x_div_a = x * ra;
-        let y_div_a = y * ra;
-        let z_div_a = z * ra;
-        let lam = f64::atan2(y_div_a, x_div_a);
-
-        // Perpendicular distance from point to Z-axis (HM eq. 5-28)
-        let p_div_a = (x_div_a * x_div_a + y_div_a * y_div_a).sqrt();
-
-        (lam, p_div_a, z_div_a)
-    };
-
-    // Non-optimized version:
-    // theta = atan2(z * ellips.a(), p * ellips.b());
-    // c = cos(theta);
-    // s = sin(theta);
-    let b_div_a = 1. - ellips.f();
-    let (c, s) = {
-        let p_div_a_b_div_a = p_div_a * b_div_a;
-        let norm = (z_div_a * z_div_a + p_div_a_b_div_a * p_div_a_b_div_a).sqrt();
-        if norm != 0.0 {
-            let inv_norm = 1.0 / norm;
-            let c = p_div_a_b_div_a * inv_norm;
-            let s = z_div_a * inv_norm;
-            (c, s)
-        } else {
-            (1., 0.)
-        }
-    };
-
-    let e2s = ellips.e_sq() / (1.0 - ellips.e_sq());
-    let y_phi = z_div_a + e2s * b_div_a * s * s * s;
-    let x_phi = p_div_a - ellips.e_sq() * c * c * c;
-    let norm_phi = (y_phi * y_phi + x_phi * x_phi).sqrt();
-
-    let (mut cosphi, mut sinphi) = if norm_phi != 0. {
-        let inv_norm_phi = 1.0 / norm_phi;
-        (x_phi * inv_norm_phi, y_phi * inv_norm_phi)
-    } else {
-        (1., 0.)
-    };
-    let phi = if x_phi <= 0. {
-        // this happen on non-sphere ellipsoid when x,y,z is very close to 0
-        // there is no single solution to the cart->geodetic conversion in
-        // that case, clamp to -90/90 deg and avoid a discontinuous boundary
-        // near the poles
-        cosphi = 0.;
-        sinphi = if z >= 0. { 1. } else { -1. };
-        if z >= 0. {
-            FRAC_2_PI
-        } else {
-            -FRAC_2_PI
-        }
-    } else {
-        f64::atan2(y_phi, x_phi)
-    };
-
-    fn geocentric_radius(a: f64, b_div_a: f64, cosphi: f64, sinphi: f64) -> f64 {
-        // Non-optimized version:
-        // const double b = a * b_div_a;
-        // return hypot(a * a * cosphi, b * b * sinphi) /
-        //        hypot(a * cosphi, b * sinphi);
-        let cosphi_sq = cosphi * cosphi;
-        let sinphi_sq = sinphi * sinphi;
-        let b_div_a_sq = b_div_a * b_div_a;
-        let b_div_a_sq_mul_sinphi_sq = b_div_a_sq * sinphi_sq;
-        a * ((cosphi_sq + b_div_a_sq * b_div_a_sq_mul_sinphi_sq)
-            / (cosphi_sq + b_div_a_sq_mul_sinphi_sq))
-            .sqrt()
-    }
-
-    let height = if cosphi < 1e-6 {
-        // poleward of 89.99994 deg, we avoid division by zero
-        // by computing the height as the cartesian z value
-        // minus the geocentric radius of the Earth at the given latitude
-        z.abs() - geocentric_radius(ellips.a(), b_div_a, cosphi, sinphi)
-    } else {
-        let n = if ellips.e_sq() == 0.0 {
-            ellips.a() // optimization for sphere (e=0)
-        } else {
-            ellips.a() / (1. - ellips.e_sq() * sinphi * sinphi).sqrt()
-        };
-        ellips.a() * p_div_a / cosphi - n
-    };
-
-    (lam.to_degrees(), phi.to_degrees(), height)
-}
+// /// Convert from geocentric to geodetic coordinate system.
+// pub fn geocentric_to_geodetic(ellips: &Ellipsoid, x: f64, y: f64, z: f64) -> (f64, f64, f64) {
+//     // Ported from OJ
+//
+//     let (lam, p_div_a, z_div_a) = {
+//         let ra = 1. / ellips.a();
+//         let x_div_a = x * ra;
+//         let y_div_a = y * ra;
+//         let z_div_a = z * ra;
+//         let lam = f64::atan2(y_div_a, x_div_a);
+//
+//         // Perpendicular distance from point to Z-axis (HM eq. 5-28)
+//         let p_div_a = (x_div_a * x_div_a + y_div_a * y_div_a).sqrt();
+//
+//         (lam, p_div_a, z_div_a)
+//     };
+//
+//     // Non-optimized version:
+//     // theta = atan2(z * ellips.a(), p * ellips.b());
+//     // c = cos(theta);
+//     // s = sin(theta);
+//     let b_div_a = 1. - ellips.f();
+//     let (c, s) = {
+//         let p_div_a_b_div_a = p_div_a * b_div_a;
+//         let norm = (z_div_a * z_div_a + p_div_a_b_div_a * p_div_a_b_div_a).sqrt();
+//         if norm != 0.0 {
+//             let inv_norm = 1.0 / norm;
+//             let c = p_div_a_b_div_a * inv_norm;
+//             let s = z_div_a * inv_norm;
+//             (c, s)
+//         } else {
+//             (1., 0.)
+//         }
+//     };
+//
+//     let e2s = ellips.e_sq() / (1.0 - ellips.e_sq());
+//     let y_phi = z_div_a + e2s * b_div_a * s * s * s;
+//     let x_phi = p_div_a - ellips.e_sq() * c * c * c;
+//     let norm_phi = (y_phi * y_phi + x_phi * x_phi).sqrt();
+//
+//     let (mut cosphi, mut sinphi) = if norm_phi != 0. {
+//         let inv_norm_phi = 1.0 / norm_phi;
+//         (x_phi * inv_norm_phi, y_phi * inv_norm_phi)
+//     } else {
+//         (1., 0.)
+//     };
+//     let phi = if x_phi <= 0. {
+//         // this happen on non-sphere ellipsoid when x,y,z is very close to 0
+//         // there is no single solution to the cart->geodetic conversion in
+//         // that case, clamp to -90/90 deg and avoid a discontinuous boundary
+//         // near the poles
+//         cosphi = 0.;
+//         sinphi = if z >= 0. { 1. } else { -1. };
+//         if z >= 0. {
+//             FRAC_2_PI
+//         } else {
+//             -FRAC_2_PI
+//         }
+//     } else {
+//         f64::atan2(y_phi, x_phi)
+//     };
+//
+//     fn geocentric_radius(a: f64, b_div_a: f64, cosphi: f64, sinphi: f64) -> f64 {
+//         // Non-optimized version:
+//         // const double b = a * b_div_a;
+//         // return hypot(a * a * cosphi, b * b * sinphi) /
+//         //        hypot(a * cosphi, b * sinphi);
+//         let cosphi_sq = cosphi * cosphi;
+//         let sinphi_sq = sinphi * sinphi;
+//         let b_div_a_sq = b_div_a * b_div_a;
+//         let b_div_a_sq_mul_sinphi_sq = b_div_a_sq * sinphi_sq;
+//         a * ((cosphi_sq + b_div_a_sq * b_div_a_sq_mul_sinphi_sq)
+//             / (cosphi_sq + b_div_a_sq_mul_sinphi_sq))
+//             .sqrt()
+//     }
+//
+//     let height = if cosphi < 1e-6 {
+//         // poleward of 89.99994 deg, we avoid division by zero
+//         // by computing the height as the cartesian z value
+//         // minus the geocentric radius of the Earth at the given latitude
+//         z.abs() - geocentric_radius(ellips.a(), b_div_a, cosphi, sinphi)
+//     } else {
+//         let n = if ellips.e_sq() == 0.0 {
+//             ellips.a() // optimization for sphere (e=0)
+//         } else {
+//             ellips.a() / (1. - ellips.e_sq() * sinphi * sinphi).sqrt()
+//         };
+//         ellips.a() * p_div_a / cosphi - n
+//     };
+//
+//     (lam.to_degrees(), phi.to_degrees(), height)
+// }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn roundtrip_vermeille() {
+    fn roundtrip() {
         let wgs84 = crate::ellipsoid::wgs84();
 
+        // Outside the evolute
         {
             let (lng, lat, height) = (140., 37., 50.);
             let (x, y, z) = geodetic_to_geocentric(&wgs84, lng, lat, height);
-            let (lng2, lat2, height2) = geocentric_to_geodetic_vermeille(&wgs84, x, y, z);
-            println!("{} {} {}", lng2, lat2, height2);
-            assert!(lng - lng2 < 1e-9);
-            assert!(lat - lat2 < 1e-9);
-            assert!(height - height2 < 1e-9);
+            let (lng2, lat2, height2) = geocentric_to_geodetic(&wgs84, x, y, z);
+            assert!((lng - lng2).abs() < 1e-10);
+            assert!((lat - lat2).abs() < 1e-10);
+            assert!((height - height2).abs() < 1e-9);
         }
 
+        // On or inside the evolute and not in the singular disc
         {
-            let (lng, lat, height) = (134., 89.99999, 100.);
+            let (lng, lat, height) = (45., 74.58501644931525, -6344866.234164982);
             let (x, y, z) = geodetic_to_geocentric(&wgs84, lng, lat, height);
-            let (lng2, lat2, height2) = geocentric_to_geodetic_vermeille(&wgs84, x, y, z);
-            assert!(lng - lng2 < 1e-9);
-            assert!(lat - lat2 < 1e-9);
-            assert!(height - height2 < 1e-9);
+            let (lng2, lat2, height2) = geocentric_to_geodetic(&wgs84, x, y, z);
+            assert!((lng - lng2).abs() < 1e-10);
+            assert!((lat - lat2).abs() < 1e-10);
+            assert!((height - height2).abs() < 1e-9);
+        }
+
+        // In the singular disc
+        {
+            let (lng, lat, height) = (120., 88.10828645, -6356728.972246517);
+            let (x, y, _) = geodetic_to_geocentric(&wgs84, lng, lat, height);
+            let z = 0.;
+            let (lng2, lat2, height2) = geocentric_to_geodetic(&wgs84, x, y, z);
+            assert!((lng - lng2).abs() < 1e-10);
+            assert!((lat - lat2).abs() < 1e-10);
+            assert!((height - height2).abs() < 30.);
+        }
+
+        // Earth's center
+        {
+            let (lng, lat, height) = (0., 90., wgs84.b());
+            let (x, y, z) = geodetic_to_geocentric(&wgs84, lng, lat, height);
+            let (lng2, lat2, height2) = geocentric_to_geodetic(&wgs84, x, y, z);
+            assert!((lng - lng2).abs() < 1e-9);
+            assert!((lat - lat2).abs() < 1e-9);
+            assert!((height - height2).abs() < 1e-9);
         }
     }
 
     #[test]
-    fn roundtrip_proj() {
-        let wgs84 = crate::ellipsoid::wgs84();
-
-        {
-            let (lng, lat, height) = (140., 37., 50.);
-            let (x, y, z) = geodetic_to_geocentric(&wgs84, lng, lat, height);
-            let (lng2, lat2, height2) = geocentric_to_geodetic_proj(&wgs84, x, y, z);
-            assert!(lng - lng2 < 1e-10);
-            assert!(lat - lat2 < 1e-10);
-            assert!(height - height2 < 1e-10);
-        }
-
-        {
-            let (lng, lat, height) = (134., 89.99999, 100.);
-            let (x, y, z) = geodetic_to_geocentric(&wgs84, lng, lat, height);
-            let (lng2, lat2, height2) = geocentric_to_geodetic_proj(&wgs84, x, y, z);
-            assert!(lng - lng2 < 1e-7);
-            assert!(lat - lat2 < 1e-7);
-            assert!(height - height2 < 1e-7);
-        }
-    }
-
-    #[test]
-    fn fixtures() {
+    fn to_geocentric() {
         let wgs84 = crate::ellipsoid::wgs84();
 
         {

--- a/nusamai-projection/src/cartesian.rs
+++ b/nusamai-projection/src/cartesian.rs
@@ -1,32 +1,120 @@
-//! Conversion between geographic and geocentric (cartesian) coordinate systems.
+//! Conversion between geodetic and geocentric (cartesian) coordinate systems.
+
+use std::f64::consts::FRAC_2_PI;
 
 use crate::ellipsoid::Ellipsoid;
 
-/// Convert from geographic to geocentric coordinate system.
-pub fn geographic_to_geocentric(
+/// Convert from geodetic to geocentric coordinate system.
+pub fn geodetic_to_geocentric(
     ellips: &Ellipsoid,
     lng: f64,
     lat: f64,
     height: f64,
 ) -> (f64, f64, f64) {
-    let (lng_rad, lat_rad) = (lng.to_radians(), lat.to_radians());
-    let tan_psi = (1. - ellips.e_sq()) * lat_rad.tan();
-    let z = ellips.a()
-        * (1. / (1. / (tan_psi * tan_psi) + 1. / ((1. - ellips.f()) * (1. - ellips.f())))).sqrt();
-    let r = ellips.a()
-        * (1. / (1. + (tan_psi * tan_psi) / ((1. - ellips.f()) * (1. - ellips.f())))).sqrt();
-    let x = r * lng_rad.cos();
-    let y = r * lng_rad.sin();
-    let dhz = lat_rad.sin();
-    let dhx = lat_rad.cos() * lng_rad.cos();
-    let dhy = lat_rad.cos() * lng_rad.sin();
-    (x + dhx * height, y + dhy * height, z + dhz * height)
+    let (lam, phi) = (lng.to_radians(), lat.to_radians());
+    let n = if ellips.e_sq() == 0.0 {
+        ellips.a() // optimization for sphere (e=0)
+    } else {
+        ellips.a() / (1. - ellips.e_sq() * phi.sin() * phi.sin()).sqrt()
+    };
+    let x = (n + height) * phi.cos() * lam.cos();
+    let y = (n + height) * phi.cos() * lam.sin();
+    let z = (n * (1. - ellips.e_sq()) + height) * phi.sin();
+    (x, y, z)
 }
 
-/// Convert from geocentric to geographic coordinate system.
-pub fn geocentric_to_geographic(x: f64, y: f64, z: f64, _ellips: &Ellipsoid) -> (f64, f64, f64) {
-    println!("not implemented: {:?}", (x, y, z));
-    todo!();
+/// Convert from geocentric to geodetic coordinate system.
+pub fn geocentric_to_geodetic(ellips: &Ellipsoid, x: f64, y: f64, z: f64) -> (f64, f64, f64) {
+    // Ported from PROJ
+
+    let (lam, p_div_a, z_div_a) = {
+        let ra = 1. / ellips.a();
+        let x_div_a = x * ra;
+        let y_div_a = y * ra;
+        let z_div_a = z * ra;
+        let lam = f64::atan2(y_div_a, x_div_a);
+
+        // Perpendicular distance from point to Z-axis (HM eq. 5-28)
+        let p_div_a = (x_div_a * x_div_a + y_div_a * y_div_a).sqrt();
+
+        (lam, p_div_a, z_div_a)
+    };
+
+    let b_div_a = 1. - ellips.f();
+    // Non-optimized version:
+    // theta = atan2(z * ellips.a(), p * ellips.b());
+    // c = cos(theta);
+    // s = sin(theta);
+    let (c, s) = {
+        let p_div_a_b_div_a = p_div_a * b_div_a;
+        let norm = (z_div_a * z_div_a + p_div_a_b_div_a * p_div_a_b_div_a).sqrt();
+        if norm != 0.0 {
+            let inv_norm = 1.0 / norm;
+            let c = p_div_a_b_div_a * inv_norm;
+            let s = z_div_a * inv_norm;
+            (c, s)
+        } else {
+            (1., 0.)
+        }
+    };
+
+    let e2s = ellips.e_sq() / (1.0 - ellips.e_sq());
+    let y_phi = z_div_a + e2s * b_div_a * s * s * s;
+    let x_phi = p_div_a - ellips.e_sq() * c * c * c;
+    let norm_phi = (y_phi * y_phi + x_phi * x_phi).sqrt();
+
+    let (mut cosphi, mut sinphi) = if norm_phi != 0. {
+        let inv_norm_phi = 1.0 / norm_phi;
+        (x_phi * inv_norm_phi, y_phi * inv_norm_phi)
+    } else {
+        (1., 0.)
+    };
+
+    let phi = if x_phi <= 0. {
+        // this happen on non-sphere ellipsoid when x,y,z is very close to 0
+        // there is no single solution to the cart->geodetic conversion in
+        // that case, clamp to -90/90 deg and avoid a discontinuous boundary
+        // near the poles
+        cosphi = 0.;
+        sinphi = if z >= 0. { 1. } else { -1. };
+        if z >= 0. {
+            FRAC_2_PI
+        } else {
+            -FRAC_2_PI
+        }
+    } else {
+        f64::atan2(y_phi, x_phi)
+    };
+
+    let height = if cosphi < 1e-6 {
+        // poleward of 89.99994 deg, we avoid division by zero
+        // by computing the height as the cartesian z value
+        // minus the geocentric radius of the Earth at the given latitude
+        z.abs() - geocentric_radius(ellips.a(), b_div_a, cosphi, sinphi)
+    } else {
+        let n = if ellips.e_sq() == 0.0 {
+            ellips.a() // optimization for sphere (e=0)
+        } else {
+            ellips.a() / (1. - ellips.e_sq() * sinphi * sinphi).sqrt()
+        };
+        ellips.a() * p_div_a / cosphi - n
+    };
+
+    (lam.to_degrees(), phi.to_degrees(), height)
+}
+
+fn geocentric_radius(a: f64, b_div_a: f64, cosphi: f64, sinphi: f64) -> f64 {
+    // Non-optimized version:
+    // const double b = a * b_div_a;
+    // return hypot(a * a * cosphi, b * b * sinphi) /
+    //        hypot(a * cosphi, b * sinphi);
+    let cosphi_sq = cosphi * cosphi;
+    let sinphi_sq = sinphi * sinphi;
+    let b_div_a_sq = b_div_a * b_div_a;
+    let b_div_a_sq_mul_sinphi_sq = b_div_a_sq * sinphi_sq;
+    a * ((cosphi_sq + b_div_a_sq * b_div_a_sq_mul_sinphi_sq)
+        / (cosphi_sq + b_div_a_sq_mul_sinphi_sq))
+        .sqrt()
 }
 
 #[cfg(test)]
@@ -34,20 +122,43 @@ mod tests {
     use super::*;
 
     #[test]
+    fn roundtrip() {
+        let wgs84 = crate::ellipsoid::wgs84();
+
+        {
+            let (lng, lat, height) = (140., 37., 50.);
+            let (x, y, z) = geodetic_to_geocentric(&wgs84, lng, lat, height);
+            let (lng2, lat2, height2) = geocentric_to_geodetic(&wgs84, x, y, z);
+            assert!(lng - lng2 < 1e-10);
+            assert!(lat - lat2 < 1e-10);
+            assert!(height - height2 < 1e-10);
+        }
+
+        {
+            let (lng, lat, height) = (134., 89.99999, 100.);
+            let (x, y, z) = geodetic_to_geocentric(&wgs84, lng, lat, height);
+            let (lng2, lat2, height2) = geocentric_to_geodetic(&wgs84, x, y, z);
+            assert!(lng - lng2 < 1e-7);
+            assert!(lat - lat2 < 1e-7);
+            assert!(height - height2 < 1e-7);
+        }
+    }
+
+    #[test]
     fn fixtures() {
         let wgs84 = crate::ellipsoid::wgs84();
 
         {
-            let (x, y, z) = geographic_to_geocentric(&wgs84, 140., 37., 50.);
-            assert!((x - -3906851.9770472576).abs() < 1e-9);
-            assert!((y - 3278238.0530045824).abs() < 1e-9);
-            assert!((z - 3817423.251099322).abs() < 1e-9);
+            let (x, y, z) = geodetic_to_geocentric(&wgs84, 140., 37., 50.);
+            assert!((x - -3906851.9770472576).abs() < 1e-10);
+            assert!((y - 3278238.0530045824).abs() < 1e-10);
+            assert!((z - 3817423.251099322).abs() < 1e-10);
         }
 
         // north pole
         {
             let height = 150.;
-            let (x, y, z) = geographic_to_geocentric(&wgs84, 123., 90., 150.);
+            let (x, y, z) = geodetic_to_geocentric(&wgs84, 123., 90., 150.);
             assert!((x - 0.).abs() < 1e-9);
             assert!((y - 0.).abs() < 1e-9);
             assert!((z - (wgs84.b() + height)).abs() < 1e-9);
@@ -56,7 +167,7 @@ mod tests {
         // null island
         {
             let height = 100.;
-            let (x, y, z) = geographic_to_geocentric(&wgs84, 0., 0., height);
+            let (x, y, z) = geodetic_to_geocentric(&wgs84, 0., 0., height);
             assert!((x - (wgs84.a() + height)).abs() < 1e-9);
             assert!((y - 0.).abs() < 1e-9);
             assert!((z - 0.).abs() < 1e-9);

--- a/nusamai/src/sink/cesiumtiles/mod.rs
+++ b/nusamai/src/sink/cesiumtiles/mod.rs
@@ -24,7 +24,7 @@ use indexmap::IndexSet;
 use itertools::Itertools;
 use nusamai_citygml::{object::Value, schema::Schema};
 use nusamai_mvt::tileid::TileIdMethod;
-use nusamai_projection::cartesian::geographic_to_geocentric;
+use nusamai_projection::cartesian::geographic_to_geodetic;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use slice::{slice_to_tiles, SlicedFeature};
@@ -274,7 +274,7 @@ fn tile_writing_stage(
 
                 // Use the tile center as the translation of the glTF mesh
                 let translation = {
-                    let (tx, ty, tz) = geographic_to_geocentric(&ellipsoid, (min_lng + max_lng) / 2.0, (min_lat + max_lat) / 2.0, 0.);
+                    let (tx, ty, tz) = geographic_to_geodetic(&ellipsoid, (min_lng + max_lng) / 2.0, (min_lat + max_lat) / 2.0, 0.);
                     // z-up to y-up
                     let [tx, ty, tz] = [tx, tz, -ty];
                     // double-precision to single-precision
@@ -344,7 +344,7 @@ fn tile_writing_stage(
                             // - z-up to y-up
                             // - subtract the translation
                             // - flip the texture v-coordinate
-                            let (x, y, z) = geographic_to_geocentric(&ellipsoid, lng, lat, height);
+                            let (x, y, z) = geographic_to_geodetic(&ellipsoid, lng, lat, height);
                             [x - translation[0], z - translation[1], -y - translation[2], u, 1.0 - v]
                         });
 

--- a/nusamai/src/sink/cesiumtiles/mod.rs
+++ b/nusamai/src/sink/cesiumtiles/mod.rs
@@ -24,7 +24,7 @@ use indexmap::IndexSet;
 use itertools::Itertools;
 use nusamai_citygml::{object::Value, schema::Schema};
 use nusamai_mvt::tileid::TileIdMethod;
-use nusamai_projection::cartesian::geographic_to_geodetic;
+use nusamai_projection::cartesian::geodetic_to_geocentric;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use slice::{slice_to_tiles, SlicedFeature};
@@ -274,7 +274,7 @@ fn tile_writing_stage(
 
                 // Use the tile center as the translation of the glTF mesh
                 let translation = {
-                    let (tx, ty, tz) = geographic_to_geodetic(&ellipsoid, (min_lng + max_lng) / 2.0, (min_lat + max_lat) / 2.0, 0.);
+                    let (tx, ty, tz) = geodetic_to_geocentric(&ellipsoid, (min_lng + max_lng) / 2.0, (min_lat + max_lat) / 2.0, 0.);
                     // z-up to y-up
                     let [tx, ty, tz] = [tx, tz, -ty];
                     // double-precision to single-precision
@@ -344,7 +344,7 @@ fn tile_writing_stage(
                             // - z-up to y-up
                             // - subtract the translation
                             // - flip the texture v-coordinate
-                            let (x, y, z) = geographic_to_geodetic(&ellipsoid, lng, lat, height);
+                            let (x, y, z) = geodetic_to_geocentric(&ellipsoid, lng, lat, height);
                             [x - translation[0], z - translation[1], -y - translation[2], u, 1.0 - v]
                         });
 

--- a/nusamai/src/sink/gltf/mod.rs
+++ b/nusamai/src/sink/gltf/mod.rs
@@ -14,7 +14,7 @@ use material::{Material, Texture};
 use nusamai_citygml::{object::ObjectStereotype, schema::Schema, GeometryType, Value};
 use nusamai_geometry::MultiPolygon;
 use nusamai_plateau::appearance;
-use nusamai_projection::cartesian::geographic_to_geodetic;
+use nusamai_projection::cartesian::geodetic_to_geocentric;
 use rayon::iter::{IntoParallelIterator, ParallelBridge, ParallelIterator};
 use serde::{Deserialize, Serialize};
 
@@ -296,7 +296,7 @@ impl DataSink for GltfSink {
                 // triangulation and make vertices and primitives
                 let translation = {
                     let bounds = features.bounding_volume;
-                    let (tx, ty, tz) = geographic_to_geodetic(
+                    let (tx, ty, tz) = geodetic_to_geocentric(
                         &ellipsoid,
                         (bounds.min_lng + bounds.max_lng) / 2.0,
                         (bounds.min_lat + bounds.max_lat) / 2.0,
@@ -318,7 +318,7 @@ impl DataSink for GltfSink {
                         .polygons
                         .transform_inplace(|&[lng, lat, height, u, v]| {
                             // geographic to geocentric
-                            let (x, y, z) = geographic_to_geodetic(&ellipsoid, lng, lat, height);
+                            let (x, y, z) = geodetic_to_geocentric(&ellipsoid, lng, lat, height);
 
                             // z-up to y-up
                             // subtract the translation

--- a/nusamai/src/sink/gltf/mod.rs
+++ b/nusamai/src/sink/gltf/mod.rs
@@ -14,7 +14,7 @@ use material::{Material, Texture};
 use nusamai_citygml::{object::ObjectStereotype, schema::Schema, GeometryType, Value};
 use nusamai_geometry::MultiPolygon;
 use nusamai_plateau::appearance;
-use nusamai_projection::cartesian::geographic_to_geocentric;
+use nusamai_projection::cartesian::geographic_to_geodetic;
 use rayon::iter::{IntoParallelIterator, ParallelBridge, ParallelIterator};
 use serde::{Deserialize, Serialize};
 
@@ -296,7 +296,7 @@ impl DataSink for GltfSink {
                 // triangulation and make vertices and primitives
                 let translation = {
                     let bounds = features.bounding_volume;
-                    let (tx, ty, tz) = geographic_to_geocentric(
+                    let (tx, ty, tz) = geographic_to_geodetic(
                         &ellipsoid,
                         (bounds.min_lng + bounds.max_lng) / 2.0,
                         (bounds.min_lat + bounds.max_lat) / 2.0,
@@ -318,7 +318,7 @@ impl DataSink for GltfSink {
                         .polygons
                         .transform_inplace(|&[lng, lat, height, u, v]| {
                             // geographic to geocentric
-                            let (x, y, z) = geographic_to_geocentric(&ellipsoid, lng, lat, height);
+                            let (x, y, z) = geographic_to_geodetic(&ellipsoid, lng, lat, height);
 
                             // z-up to y-up
                             // subtract the translation

--- a/nusamai/src/sink/ply/mod.rs
+++ b/nusamai/src/sink/ply/mod.rs
@@ -11,7 +11,7 @@ use nusamai_citygml::{
     schema::Schema,
     GeometryType,
 };
-use nusamai_projection::cartesian::geographic_to_geocentric;
+use nusamai_projection::cartesian::geographic_to_geodetic;
 use rayon::prelude::*;
 
 use crate::{
@@ -126,7 +126,7 @@ impl DataSink for StanfordPlySink {
                                         // Convert to geocentric (x, y, z) coordinate.
                                         // (Earcut do not work in geographic space)
                                         let (x, y, z) =
-                                            geographic_to_geocentric(&ellipsoid, lng, lat, height);
+                                            geographic_to_geodetic(&ellipsoid, lng, lat, height);
                                         [x, y, z]
                                     });
                                     let num_outer = match poly.hole_indices().first() {

--- a/nusamai/src/sink/ply/mod.rs
+++ b/nusamai/src/sink/ply/mod.rs
@@ -11,7 +11,7 @@ use nusamai_citygml::{
     schema::Schema,
     GeometryType,
 };
-use nusamai_projection::cartesian::geographic_to_geodetic;
+use nusamai_projection::cartesian::geodetic_to_geocentric;
 use rayon::prelude::*;
 
 use crate::{
@@ -126,7 +126,7 @@ impl DataSink for StanfordPlySink {
                                         // Convert to geocentric (x, y, z) coordinate.
                                         // (Earcut do not work in geographic space)
                                         let (x, y, z) =
-                                            geographic_to_geodetic(&ellipsoid, lng, lat, height);
+                                            geodetic_to_geocentric(&ellipsoid, lng, lat, height);
                                         [x, y, z]
                                     });
                                     let num_outer = match poly.hole_indices().first() {


### PR DESCRIPTION
### Description（変更内容）

ライブラリとしての有用性を上げるため、実装済み変換の「逆変換」である cartesian (geocentric) → geodetic (geographic) の変換を実装しておきます。

Hugues Vermeilleの *[An analytical method to transform geocentric into geodetic coordinates](https://DOI.org/10.1007/s00190-010-0419-x)* の手法を使います。pygeodesyやgeographiclibもこの手法をベースにしています。

### Manual Testing（手動テスト）

Not required / 不要

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 地理座標系と地心座標系間の変換機能を更新し、より正確で効率的になりました。
- **バグ修正**
  - 座標変換の関数名を `geodetic_to_geocentric` と `geocentric_to_geodetic` に変更し、モジュール間の一貫性と明確さを向上させました。
- **テスト**
  - 新しい座標変換メソッドのテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->