### PR TITLE
Fix and improve the voxelizer impl.

### DIFF
--- a/nusamai-voxelize/Cargo.toml
+++ b/nusamai-voxelize/Cargo.toml
@@ -10,3 +10,7 @@ byteorder = "1.5.0"
 serde_json = "1.0.115"
 glam = "0.27.0"
 hashbrown = "0.14.5"
+indexmap = "2.2.6"
+
+[dev-dependencies]
+bytemuck = { version = "1.16.0", features = ["derive"] }

--- a/nusamai-voxelize/src/lib.rs
+++ b/nusamai-voxelize/src/lib.rs
@@ -1,1 +1,3 @@
-pub mod voxelize;
+mod voxelize;
+
+pub use voxelize::*;

--- a/nusamai-voxelize/src/voxelize.rs
+++ b/nusamai-voxelize/src/voxelize.rs
@@ -9,7 +9,7 @@ pub struct Voxel {
 pub type VoxelPosition = [i32; 3];
 
 pub trait MeshVoxelizer {
-    fn add_triangle(&mut self, triangle: &[[f32; 3]], voxel_size: f32);
+    fn add_triangle(&mut self, triangle: &[[f32; 3]; 3]);
     fn finalize(self) -> HashMap<VoxelPosition, Voxel>;
 }
 
@@ -18,26 +18,23 @@ pub struct DdaVoxelizer {
 }
 
 impl MeshVoxelizer for DdaVoxelizer {
-    fn add_triangle(&mut self, triangle: &[[f32; 3]], voxel_size: f32) {
-        fill_triangle(&mut self.voxels, voxel_size, triangle);
+    fn add_triangle(&mut self, triangle: &[[f32; 3]; 3]) {
+        fill_triangle(&mut self.voxels, triangle);
     }
     fn finalize(self) -> HashMap<VoxelPosition, Voxel> {
         self.voxels
     }
 }
 
-fn draw_line(voxels: &mut HashMap<VoxelPosition, Voxel>, start: Vec3, end: Vec3, voxel_size: f32) {
-    let start = start + Vec3::splat(voxel_size * 0.5);
-    let end = end + Vec3::splat(voxel_size * 0.5);
-
+fn draw_line(voxels: &mut HashMap<VoxelPosition, Voxel>, start: Vec3, end: Vec3) {
     let direction = end - start;
     let max_dist = direction.abs().max_element();
-    let steps = (max_dist / voxel_size).ceil() as i32;
+    let steps = (max_dist).ceil() as i32;
     let step_size = direction / steps as f32;
 
     let mut current_voxel = start;
     for _ in 0..=steps {
-        let position = (current_voxel / voxel_size).floor().as_ivec3();
+        let position = current_voxel.as_ivec3();
         let voxel = Voxel {
             color: [255, 255, 255],
         };
@@ -46,15 +43,7 @@ fn draw_line(voxels: &mut HashMap<VoxelPosition, Voxel>, start: Vec3, end: Vec3,
     }
 }
 
-fn fill_triangle(
-    voxels: &mut HashMap<VoxelPosition, Voxel>,
-    voxel_size: f32,
-    triangle: &[[f32; 3]],
-) {
-    if triangle.len() != 3 {
-        panic!("The number of vertices is not 3")
-    }
-
+fn fill_triangle(voxels: &mut HashMap<VoxelPosition, Voxel>, triangle: &[[f32; 3]; 3]) {
     let p1 = Vec3::from(triangle[0]);
     let p2 = Vec3::from(triangle[1]);
     let p3 = Vec3::from(triangle[2]);
@@ -62,7 +51,7 @@ fn fill_triangle(
     // Calculate the lengths of the 3 sides
     // and if the triangle is small (all sides are less than voxel_size),
     // do not scan the face and fill one voxel
-    if is_small_triangle(&p1, &p2, &p3, voxel_size) {
+    if is_small_triangle(&p1, &p2, &p3) {
         println!("Triangles too small!");
 
         let p1_floor = p1.floor();
@@ -89,16 +78,11 @@ fn fill_triangle(
         );
     }
 
-    let v1 = p2 - p1;
-    let v2 = p3 - p1;
-
-    let mut normal = v1.cross(v2);
+    let mut normal = (p2 - p1).cross(p3 - p1);
     let normal_length = normal.length();
-
     if normal_length.is_nan() || normal_length == 0.0 {
         return;
     }
-
     normal /= normal_length;
 
     // Find the axis of maximum length
@@ -151,223 +135,211 @@ fn fill_triangle(
     match sweep_axis {
         // sweep x
         0 => {
-            let mut sorted_triangle = [triangle[0], triangle[1], triangle[2]];
-            if sorted_triangle[0][0] > sorted_triangle[1][0] {
-                sorted_triangle.swap(0, 1);
+            let mut ordered_verts = [triangle[0], triangle[1], triangle[2]];
+            if ordered_verts[0][0] > ordered_verts[1][0] {
+                ordered_verts.swap(0, 1);
             }
-            if sorted_triangle[1][0] > sorted_triangle[2][0] {
-                sorted_triangle.swap(1, 2);
+            if ordered_verts[1][0] > ordered_verts[2][0] {
+                ordered_verts.swap(1, 2);
             }
-            if sorted_triangle[0][0] > sorted_triangle[1][0] {
-                sorted_triangle.swap(0, 1);
+            if ordered_verts[0][0] > ordered_verts[1][0] {
+                ordered_verts.swap(0, 1);
             }
-            assert!(sorted_triangle[1][0] >= sorted_triangle[0][0]);
+            assert!(ordered_verts[1][0] >= ordered_verts[0][0]);
 
-            let sorted_triangle: [[f32; 3]; 3] = sorted_triangle.map(|inner| inner.map(|x| x));
+            let ordered_verts: [[f32; 3]; 3] = ordered_verts.map(|inner| inner.map(|x| x));
 
-            let mut edge_direction_1;
+            let mut edge_dir1;
             let mut start_point;
             let mut end_point;
             let mut end_vertex_x;
 
-            if (sorted_triangle[1][0] - sorted_triangle[0][0]).abs() >= 0.0
-                && (sorted_triangle[1][0] - sorted_triangle[0][0].floor() >= voxel_size)
+            if (ordered_verts[1][0] - ordered_verts[0][0]).abs() >= 0.0
+                && (ordered_verts[1][0] - ordered_verts[0][0].floor() >= 1.0)
             {
-                edge_direction_1 = (Vec3::from(sorted_triangle[1])
-                    - Vec3::from(sorted_triangle[0]))
-                    / (sorted_triangle[1][0] - sorted_triangle[0][0]);
-                start_point = Vec3::from(sorted_triangle[0])
-                    * (voxel_size - sorted_triangle[0][0] + sorted_triangle[0][0].floor());
+                edge_dir1 = (Vec3::from(ordered_verts[1]) - Vec3::from(ordered_verts[0]))
+                    / (ordered_verts[1][0] - ordered_verts[0][0]);
+                start_point = Vec3::from(ordered_verts[0])
+                    + edge_dir1 * (1.0 - ordered_verts[0][0] + ordered_verts[0][0].floor());
             } else {
-                edge_direction_1 = (Vec3::from(sorted_triangle[2])
-                    - Vec3::from(sorted_triangle[1]))
-                    / (sorted_triangle[2][0] - sorted_triangle[1][0]);
-                start_point = Vec3::from(sorted_triangle[1])
-                    * (voxel_size - sorted_triangle[1][0] + sorted_triangle[1][0].floor());
+                edge_dir1 = (Vec3::from(ordered_verts[2]) - Vec3::from(ordered_verts[1]))
+                    / (ordered_verts[2][0] - ordered_verts[1][0]);
+                start_point = Vec3::from(ordered_verts[1])
+                    + edge_dir1 * (1.0 - ordered_verts[1][0] + ordered_verts[1][0].floor());
             };
 
-            let edge_direction_2 = (Vec3::from(sorted_triangle[2])
-                - Vec3::from(sorted_triangle[0]))
-                / (sorted_triangle[2][0] - sorted_triangle[0][0]);
+            let edge_dir2 = (Vec3::from(ordered_verts[2]) - Vec3::from(ordered_verts[0]))
+                / (ordered_verts[2][0] - ordered_verts[0][0]);
+            end_point = Vec3::from(ordered_verts[0])
+                + edge_dir2 * (1.0 - ordered_verts[0][0] + ordered_verts[0][0].floor());
 
-            end_point = Vec3::from(sorted_triangle[0])
-                * (voxel_size - sorted_triangle[0][0] + sorted_triangle[0][0].floor());
-            end_vertex_x = sorted_triangle[1][0];
+            end_vertex_x = ordered_verts[1][0];
 
             if start_point.length() > 1000.0 || end_point.length() > 1000.0 {
                 println!("Direction vector magnitude is too large");
                 return;
             }
 
-            while end_point[0] <= sorted_triangle[2][0] {
-                draw_line(voxels, start_point, end_point, voxel_size);
+            while end_point[0] <= ordered_verts[2][0] {
+                draw_line(voxels, start_point, end_point);
 
-                start_point += edge_direction_1;
-                end_point += edge_direction_2;
+                start_point += edge_dir1;
+                end_point += edge_dir2;
 
                 if start_point[0] >= end_vertex_x {
-                    end_vertex_x = start_point[0] - sorted_triangle[1][0];
-                    start_point -= edge_direction_1 * end_vertex_x;
-                    if (sorted_triangle[2][0] - sorted_triangle[1][0]).abs() == 0.0 {
+                    end_vertex_x = start_point[0] - ordered_verts[1][0];
+                    start_point -= edge_dir1 * end_vertex_x;
+                    if (ordered_verts[2][0] - ordered_verts[1][0]).abs() == 0.0 {
                         continue;
                     }
-                    edge_direction_1 = (Vec3::from(sorted_triangle[2])
-                        - Vec3::from(sorted_triangle[1]))
-                        / (sorted_triangle[2][0] - sorted_triangle[1][0]);
-                    start_point += edge_direction_1 * end_vertex_x;
-                    end_vertex_x = sorted_triangle[2][0];
+                    edge_dir1 = (Vec3::from(ordered_verts[2]) - Vec3::from(ordered_verts[1]))
+                        / (ordered_verts[2][0] - ordered_verts[1][0]);
+                    start_point += edge_dir1 * end_vertex_x;
+                    end_vertex_x = ordered_verts[2][0];
                 }
             }
         }
         // sweep y
         1 => {
-            let mut sorted_triangle = [triangle[0], triangle[1], triangle[2]];
-            if sorted_triangle[0][1] > sorted_triangle[1][1] {
-                sorted_triangle.swap(0, 1);
+            let mut ordered_verts = [triangle[0], triangle[1], triangle[2]];
+            if ordered_verts[0][1] > ordered_verts[1][1] {
+                ordered_verts.swap(0, 1);
             }
-            if sorted_triangle[1][1] > sorted_triangle[2][1] {
-                sorted_triangle.swap(1, 2);
+            if ordered_verts[1][1] > ordered_verts[2][1] {
+                ordered_verts.swap(1, 2);
             }
-            if sorted_triangle[0][1] > sorted_triangle[1][1] {
-                sorted_triangle.swap(0, 1);
+            if ordered_verts[0][1] > ordered_verts[1][1] {
+                ordered_verts.swap(0, 1);
             }
-            assert!(sorted_triangle[1][1] >= sorted_triangle[0][1]);
+            assert!(ordered_verts[1][1] >= ordered_verts[0][1]);
 
-            let sorted_triangle: [[f32; 3]; 3] = sorted_triangle.map(|inner| inner.map(|x| x));
+            let ordered_verts: [[f32; 3]; 3] = ordered_verts.map(|inner| inner.map(|x| x));
 
-            let mut edge_direction_1;
+            let mut edge_dir1;
             let mut start_point;
             let mut end_point;
             let mut end_vertex_y;
 
-            if (sorted_triangle[1][1] - sorted_triangle[0][1]).abs() >= 0.0
-                && (sorted_triangle[1][1] - sorted_triangle[0][1].floor() >= voxel_size)
+            if (ordered_verts[1][1] - ordered_verts[0][1]).abs() >= 0.0
+                && (ordered_verts[1][1] - ordered_verts[0][1].floor() >= 1.0)
             {
-                edge_direction_1 = (Vec3::from(sorted_triangle[1])
-                    - Vec3::from(sorted_triangle[0]))
-                    / (sorted_triangle[1][1] - sorted_triangle[0][1]);
-                start_point = Vec3::from(sorted_triangle[0])
-                    * (voxel_size - sorted_triangle[0][1] + sorted_triangle[0][1].floor());
+                edge_dir1 = (Vec3::from(ordered_verts[1]) - Vec3::from(ordered_verts[0]))
+                    / (ordered_verts[1][1] - ordered_verts[0][1]);
+                start_point = Vec3::from(ordered_verts[0])
+                    + edge_dir1 * (1.0 - ordered_verts[0][1] + ordered_verts[0][1].floor());
             } else {
-                edge_direction_1 = (Vec3::from(sorted_triangle[2])
-                    - Vec3::from(sorted_triangle[1]))
-                    / (sorted_triangle[2][1] - sorted_triangle[1][1]);
-                start_point = Vec3::from(sorted_triangle[1])
-                    * (voxel_size - sorted_triangle[1][1] + sorted_triangle[1][1].floor());
+                edge_dir1 = (Vec3::from(ordered_verts[2]) - Vec3::from(ordered_verts[1]))
+                    / (ordered_verts[2][1] - ordered_verts[1][1]);
+                start_point = Vec3::from(ordered_verts[1])
+                    + edge_dir1 * (1.0 - ordered_verts[1][1] + ordered_verts[1][1].floor());
             };
 
-            let edge_direction_2 = (Vec3::from(sorted_triangle[2])
-                - Vec3::from(sorted_triangle[0]))
-                / (sorted_triangle[2][1] - sorted_triangle[0][1]);
+            let edge_dir2 = (Vec3::from(ordered_verts[2]) - Vec3::from(ordered_verts[0]))
+                / (ordered_verts[2][1] - ordered_verts[0][1]);
+            end_point = Vec3::from(ordered_verts[0])
+                + edge_dir2 * (1.0 - ordered_verts[0][1] + ordered_verts[0][1].floor());
 
-            end_point = Vec3::from(sorted_triangle[0])
-                * (voxel_size - sorted_triangle[0][1] + sorted_triangle[0][1].floor());
-            end_vertex_y = sorted_triangle[1][1];
+            end_vertex_y = ordered_verts[1][1];
 
             if start_point.length() > 1000.0 || end_point.length() > 1000.0 {
                 println!("Direction vector magnitude is too large");
                 return;
             }
 
-            while end_point[1] <= sorted_triangle[2][1] {
-                draw_line(voxels, start_point, end_point, voxel_size);
+            while end_point[1] <= ordered_verts[2][1] {
+                draw_line(voxels, start_point, end_point);
 
-                start_point += edge_direction_1;
-                end_point += edge_direction_2;
+                start_point += edge_dir1;
+                end_point += edge_dir2;
 
                 if start_point[1] >= end_vertex_y {
-                    end_vertex_y = start_point[1] - sorted_triangle[1][1];
-                    start_point -= edge_direction_1 * end_vertex_y;
-                    if (sorted_triangle[2][1] - sorted_triangle[1][1]).abs() == 0.0 {
+                    end_vertex_y = start_point[1] - ordered_verts[1][1];
+                    start_point -= edge_dir1 * end_vertex_y;
+                    if (ordered_verts[2][1] - ordered_verts[1][1]).abs() == 0.0 {
                         continue;
                     }
-                    edge_direction_1 = (Vec3::from(sorted_triangle[2])
-                        - Vec3::from(sorted_triangle[1]))
-                        / (sorted_triangle[2][1] - sorted_triangle[1][1]);
-                    start_point += edge_direction_1 * end_vertex_y;
-                    end_vertex_y = sorted_triangle[2][1];
+                    edge_dir1 = (Vec3::from(ordered_verts[2]) - Vec3::from(ordered_verts[1]))
+                        / (ordered_verts[2][1] - ordered_verts[1][1]);
+                    start_point += edge_dir1 * end_vertex_y;
+                    end_vertex_y = ordered_verts[2][1];
                 }
             }
         }
         // sweep z
         _ => {
-            let mut sorted_triangle = [triangle[0], triangle[1], triangle[2]];
-            if sorted_triangle[0][2] > sorted_triangle[1][2] {
-                sorted_triangle.swap(0, 1);
+            let mut ordered_verts = [triangle[0], triangle[1], triangle[2]];
+            if ordered_verts[0][2] > ordered_verts[1][2] {
+                ordered_verts.swap(0, 1);
             }
-            if sorted_triangle[1][2] > sorted_triangle[2][2] {
-                sorted_triangle.swap(1, 2);
+            if ordered_verts[1][2] > ordered_verts[2][2] {
+                ordered_verts.swap(1, 2);
             }
-            if sorted_triangle[0][2] > sorted_triangle[1][2] {
-                sorted_triangle.swap(0, 1);
+            if ordered_verts[0][2] > ordered_verts[1][2] {
+                ordered_verts.swap(0, 1);
             }
-            assert!(sorted_triangle[1][2] >= sorted_triangle[0][2]);
+            assert!(ordered_verts[1][2] >= ordered_verts[0][2]);
 
-            let sorted_triangle: [[f32; 3]; 3] = sorted_triangle.map(|inner| inner.map(|x| x));
+            let ordered_verts: [[f32; 3]; 3] = ordered_verts.map(|inner| inner.map(|x| x));
 
-            let mut edge_direction_1;
+            let mut edge_dir1;
             let mut start_point;
             let mut end_point;
             let mut end_vertex_z;
 
-            if (sorted_triangle[1][2] - sorted_triangle[0][2]).abs() >= 0.0
-                && (sorted_triangle[1][2] - sorted_triangle[0][2].floor() >= voxel_size)
+            if (ordered_verts[1][2] - ordered_verts[0][2]).abs() >= 0.0
+                && (ordered_verts[1][2] - ordered_verts[0][2].floor() >= 1.0)
             {
-                edge_direction_1 = (Vec3::from(sorted_triangle[1])
-                    - Vec3::from(sorted_triangle[0]))
-                    / (sorted_triangle[1][2] - sorted_triangle[0][2]);
-                start_point = Vec3::from(sorted_triangle[0])
-                    * (voxel_size - sorted_triangle[0][2] + sorted_triangle[0][2].floor());
+                edge_dir1 = (Vec3::from(ordered_verts[1]) - Vec3::from(ordered_verts[0]))
+                    / (ordered_verts[1][2] - ordered_verts[0][2]);
+                start_point = Vec3::from(ordered_verts[0])
+                    + edge_dir1 * (1.0 - ordered_verts[0][2] + ordered_verts[0][2].floor());
             } else {
-                edge_direction_1 = (Vec3::from(sorted_triangle[2])
-                    - Vec3::from(sorted_triangle[1]))
-                    / (sorted_triangle[2][2] - sorted_triangle[1][2]);
-                start_point = Vec3::from(sorted_triangle[1])
-                    * (voxel_size - sorted_triangle[1][2] + sorted_triangle[1][2].floor());
+                edge_dir1 = (Vec3::from(ordered_verts[2]) - Vec3::from(ordered_verts[1]))
+                    / (ordered_verts[2][2] - ordered_verts[1][2]);
+                start_point = Vec3::from(ordered_verts[1])
+                    + edge_dir1 * (1.0 - ordered_verts[1][2] + ordered_verts[1][2].floor());
             };
 
-            let edge_direction_2 = (Vec3::from(sorted_triangle[2])
-                - Vec3::from(sorted_triangle[0]))
-                / (sorted_triangle[2][2] - sorted_triangle[0][2]);
+            let edge_dir2 = (Vec3::from(ordered_verts[2]) - Vec3::from(ordered_verts[0]))
+                / (ordered_verts[2][2] - ordered_verts[0][2]);
+            end_point = Vec3::from(ordered_verts[0])
+                + edge_dir2 * (1.0 - ordered_verts[0][2] + ordered_verts[0][2].floor());
 
-            end_point = Vec3::from(sorted_triangle[0])
-                * (voxel_size - sorted_triangle[0][2] + sorted_triangle[0][2].floor());
-            end_vertex_z = sorted_triangle[1][2];
+            end_vertex_z = ordered_verts[1][2];
 
             if start_point.length() > 1000.0 || end_point.length() > 1000.0 {
                 println!("Direction vector magnitude is too large");
                 return;
             }
 
-            while end_point[2] <= sorted_triangle[2][2] {
-                draw_line(voxels, start_point, end_point, voxel_size);
+            while end_point[2] <= ordered_verts[2][2] {
+                draw_line(voxels, start_point, end_point);
 
-                start_point += edge_direction_1;
-                end_point += edge_direction_2;
+                start_point += edge_dir1;
+                end_point += edge_dir2;
 
                 if start_point[2] >= end_vertex_z {
-                    end_vertex_z = start_point[2] - sorted_triangle[1][2];
-                    start_point -= edge_direction_1 * end_vertex_z;
-                    if (sorted_triangle[2][2] - sorted_triangle[1][2]).abs() == 0.0 {
+                    end_vertex_z = start_point[2] - ordered_verts[1][2];
+                    start_point -= edge_dir1 * end_vertex_z;
+                    if (ordered_verts[2][2] - ordered_verts[1][2]).abs() == 0.0 {
                         continue;
                     }
-                    edge_direction_1 = (Vec3::from(sorted_triangle[2])
-                        - Vec3::from(sorted_triangle[1]))
-                        / (sorted_triangle[2][2] - sorted_triangle[1][2]);
-                    start_point += edge_direction_1 * end_vertex_z;
-                    end_vertex_z = sorted_triangle[2][2];
+                    edge_dir1 = (Vec3::from(ordered_verts[2]) - Vec3::from(ordered_verts[1]))
+                        / (ordered_verts[2][2] - ordered_verts[1][2]);
+                    start_point += edge_dir1 * end_vertex_z;
+                    end_vertex_z = ordered_verts[2][2];
                 }
             }
         }
     }
 }
 
-fn is_small_triangle(p1: &Vec3, p2: &Vec3, p3: &Vec3, size: f32) -> bool {
+fn is_small_triangle(p1: &Vec3, p2: &Vec3, p3: &Vec3) -> bool {
     let d12 = p1.distance(*p2);
     let d23 = p2.distance(*p3);
     let d31 = p3.distance(*p1);
 
-    d12 <= size && d23 <= size && d31 <= size
+    d12 <= 1.0 && d23 <= 1.0 && d31 <= 1.0
 }
 
 #[cfg(test)]
@@ -390,10 +362,13 @@ mod tests {
         mpoly.add_exterior([0, 1, 2, 3, 0]);
 
         let mut earcutter = Earcut::new();
-        let mut buf3d: Vec<[f64; 3]> = Vec::new();
-        let mut buf2d: Vec<[f64; 2]> = Vec::new();
+        let mut buf3d: Vec<[f32; 3]> = Vec::new();
+        let mut buf2d: Vec<[f32; 2]> = Vec::new();
         let mut index_buf: Vec<u32> = Vec::new();
-        let mut triangles: Vec<[f64; 3]> = Vec::new();
+
+        let mut voxelizer = DdaVoxelizer {
+            voxels: HashMap::new(),
+        };
 
         for idx_poly in mpoly.iter() {
             let poly = idx_poly.transform(|idx| vertices[*idx as usize]);
@@ -403,28 +378,25 @@ mod tests {
             };
 
             buf3d.clear();
-            buf3d.extend(poly.raw_coords().iter());
+            buf3d.extend(
+                poly.raw_coords()
+                    .iter()
+                    .map(|v| [v[0] as f32, v[1] as f32, v[2] as f32]),
+            );
 
             if project3d_to_2d(&buf3d, num_outer, &mut buf2d) {
                 earcutter.earcut(buf2d.iter().cloned(), poly.hole_indices(), &mut index_buf);
-                triangles.extend(index_buf.iter().map(|&idx| buf3d[idx as usize]));
+                for indx in index_buf.chunks_exact(3) {
+                    voxelizer.add_triangle(&[
+                        buf3d[indx[0] as usize],
+                        buf3d[indx[1] as usize],
+                        buf3d[indx[2] as usize],
+                    ]);
+                }
             }
         }
 
-        let voxel_size = 1.0_f32;
-
-        let mut voxelizer = DdaVoxelizer {
-            voxels: HashMap::new(),
-        };
-        let triangles: Vec<[f32; 3]> = triangles
-            .into_iter()
-            .map(|arr| [arr[0] as f32, arr[1] as f32, arr[2] as f32])
-            .collect();
-        for t in triangles.chunks(3) {
-            voxelizer.add_triangle(t, voxel_size);
-        }
         let occupied_voxels = voxelizer.finalize();
-
         let mut test_voxels: HashMap<VoxelPosition, Voxel> = HashMap::new();
         test_voxels.insert(
             [0, 0, 0],
@@ -450,11 +422,13 @@ mod tests {
         mpoly.add_exterior([0, 1, 2, 3, 0]);
 
         let mut earcutter = Earcut::new();
-        let mut buf3d: Vec<[f64; 3]> = Vec::new();
-        let mut buf2d: Vec<[f64; 2]> = Vec::new();
+        let mut buf3d: Vec<[f32; 3]> = Vec::new();
+        let mut buf2d: Vec<[f32; 2]> = Vec::new();
         let mut index_buf: Vec<u32> = Vec::new();
-        let mut triangles: Vec<[f64; 3]> = Vec::new();
 
+        let mut voxelizer = DdaVoxelizer {
+            voxels: HashMap::new(),
+        };
         for idx_poly in mpoly.iter() {
             let poly = idx_poly.transform(|idx| vertices[*idx as usize]);
             let num_outer = match poly.hole_indices().first() {
@@ -463,26 +437,24 @@ mod tests {
             };
 
             buf3d.clear();
-            buf3d.extend(poly.raw_coords().iter());
+            buf3d.extend(
+                poly.raw_coords()
+                    .iter()
+                    .map(|v| [v[0] as f32, v[1] as f32, v[2] as f32]),
+            );
 
             if project3d_to_2d(&buf3d, num_outer, &mut buf2d) {
                 earcutter.earcut(buf2d.iter().cloned(), poly.hole_indices(), &mut index_buf);
-                triangles.extend(index_buf.iter().map(|&idx| buf3d[idx as usize]));
+                for indx in index_buf.chunks_exact(3) {
+                    voxelizer.add_triangle(&[
+                        buf3d[indx[0] as usize],
+                        buf3d[indx[1] as usize],
+                        buf3d[indx[2] as usize],
+                    ]);
+                }
             }
         }
 
-        let voxel_size = 1.0;
-
-        let mut voxelizer = DdaVoxelizer {
-            voxels: HashMap::new(),
-        };
-        let triangles: Vec<[f32; 3]> = triangles
-            .into_iter()
-            .map(|arr| [arr[0] as f32, arr[1] as f32, arr[2] as f32])
-            .collect();
-        for t in triangles.chunks(3) {
-            voxelizer.add_triangle(t, voxel_size);
-        }
         let occupied_voxels = voxelizer.finalize();
 
         let mut test_voxels: HashMap<VoxelPosition, Voxel> = HashMap::new();
@@ -533,10 +505,13 @@ mod tests {
         mpoly.add_interior([4, 5, 6, 7, 4]);
 
         let mut earcutter = Earcut::new();
-        let mut buf3d: Vec<[f64; 3]> = Vec::new();
-        let mut buf2d: Vec<[f64; 2]> = Vec::new();
+        let mut buf3d: Vec<[f32; 3]> = Vec::new();
+        let mut buf2d: Vec<[f32; 2]> = Vec::new();
         let mut index_buf: Vec<u32> = Vec::new();
-        let mut triangles: Vec<[f64; 3]> = Vec::new();
+
+        let mut voxelizer = DdaVoxelizer {
+            voxels: HashMap::new(),
+        };
 
         for idx_poly in mpoly.iter() {
             let poly = idx_poly.transform(|idx| vertices[*idx as usize]);
@@ -546,26 +521,24 @@ mod tests {
             };
 
             buf3d.clear();
-            buf3d.extend(poly.raw_coords().iter());
+            buf3d.extend(
+                poly.raw_coords()
+                    .iter()
+                    .map(|v| [v[0] as f32, v[1] as f32, v[2] as f32]),
+            );
 
             if project3d_to_2d(&buf3d, num_outer, &mut buf2d) {
                 earcutter.earcut(buf2d.iter().cloned(), poly.hole_indices(), &mut index_buf);
-                triangles.extend(index_buf.iter().map(|&idx| buf3d[idx as usize]));
+                for indx in index_buf.chunks_exact(3) {
+                    voxelizer.add_triangle(&[
+                        buf3d[indx[0] as usize],
+                        buf3d[indx[1] as usize],
+                        buf3d[indx[2] as usize],
+                    ]);
+                }
             }
         }
 
-        let voxel_size = 1.0;
-
-        let mut voxelizer = DdaVoxelizer {
-            voxels: HashMap::new(),
-        };
-        let triangles: Vec<[f32; 3]> = triangles
-            .into_iter()
-            .map(|arr| [arr[0] as f32, arr[1] as f32, arr[2] as f32])
-            .collect();
-        for t in triangles.chunks(3) {
-            voxelizer.add_triangle(t, voxel_size);
-        }
         let occupied_voxels = voxelizer.finalize();
 
         let mut test_voxels: HashMap<VoxelPosition, Voxel> = HashMap::new();
@@ -711,10 +684,13 @@ mod tests {
         mpoly.add_exterior([3, 0, 4, 7, 3]);
 
         let mut earcutter = Earcut::new();
-        let mut buf3d: Vec<[f64; 3]> = Vec::new();
-        let mut buf2d: Vec<[f64; 2]> = Vec::new();
+        let mut buf3d: Vec<[f32; 3]> = Vec::new();
+        let mut buf2d: Vec<[f32; 2]> = Vec::new();
         let mut index_buf: Vec<u32> = Vec::new();
-        let mut triangles: Vec<[f64; 3]> = Vec::new();
+
+        let mut voxelizer = DdaVoxelizer {
+            voxels: HashMap::new(),
+        };
 
         for idx_poly in mpoly.iter() {
             let poly = idx_poly.transform(|idx| vertices[*idx as usize]);
@@ -724,28 +700,25 @@ mod tests {
             };
 
             buf3d.clear();
-            buf3d.extend(poly.raw_coords().iter());
+            buf3d.extend(
+                poly.raw_coords()
+                    .iter()
+                    .map(|v| [v[0] as f32, v[1] as f32, v[2] as f32]),
+            );
 
             if project3d_to_2d(&buf3d, num_outer, &mut buf2d) {
                 earcutter.earcut(buf2d.iter().cloned(), poly.hole_indices(), &mut index_buf);
-                triangles.extend(index_buf.iter().map(|&idx| buf3d[idx as usize]));
+                for indx in index_buf.chunks_exact(3) {
+                    voxelizer.add_triangle(&[
+                        buf3d[indx[0] as usize],
+                        buf3d[indx[1] as usize],
+                        buf3d[indx[2] as usize],
+                    ]);
+                }
             }
         }
 
-        let voxel_size = 1.0;
-
-        let mut voxelizer = DdaVoxelizer {
-            voxels: HashMap::new(),
-        };
-        let triangles: Vec<[f32; 3]> = triangles
-            .into_iter()
-            .map(|arr| [arr[0] as f32, arr[1] as f32, arr[2] as f32])
-            .collect();
-        for t in triangles.chunks(3) {
-            voxelizer.add_triangle(t, voxel_size);
-        }
         let occupied_voxels = voxelizer.finalize();
-
         assert_eq!(occupied_voxels.len(), 584);
     }
 }


### PR DESCRIPTION
#520 で実装されているDDA voxelizerのバグを修正します。

- `start_point`, `end_point` の計算の誤りを修正します。
- 出力デモの改善（立方体を出力）とRustコードの微調整も含みます。

![327e084fb133084553562a8a8b489228](https://github.com/MIERUNE/plateau-gis-converter/assets/5351911/2221c178-e45c-48a6-9e71-4ef23ac57946)
