### PR TITLE
Add x86_64-apple-darwin toolchain to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Rust setup
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin
+          targets: x86_64-apple-darwin,aarch64-apple-darwin
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2


### PR DESCRIPTION
### Description（変更内容）

macOS用のリリースが以下のように失敗するようになった。Rustの x86_64-apple-darwin 用ツールチェインを明示的に追加する。

```
Error failed to build x86_64-apple-darwin binary: Target x86_64-apple-darwin is not installed (installed targets: aarch64-apple-darwin). Please run `rustup target add x86_64-apple-darwin`.
Error: Command failed with exit code 1: tauri build --target universal-apple-darwin -- --profile release-lto
```