### PR TITLE
hotfix: Shapefile 用のフィールド名辞書を更新する

### DIFF
--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -260,7 +260,11 @@ fn run_conversion(
     .unwrap();
 
     // Wait for the pipeline to finish
-    handle.join();
+    if let Err(msg) = handle.join() {
+        return Err(Error::ConversionFailed(format!(
+            "Pipeline thread panicked: {msg}"
+        )));
+    }
 
     // Return error if an error occurred in the pipeline
     if let Some(err) = first_error {

--- a/nusamai/src/main.rs
+++ b/nusamai/src/main.rs
@@ -283,7 +283,10 @@ fn run(
     });
 
     // wait for the pipeline to finish
-    handle.join();
+    if let Err(msg) = handle.join() {
+        log::error!("Pipeline thread panicked: {:?}", msg);
+    }
+
     if canceller.lock().unwrap().is_canceled() {
         log::info!("Pipeline canceled");
     }

--- a/nusamai/src/sink/shapefile/attributes.rs
+++ b/nusamai/src/sink/shapefile/attributes.rs
@@ -24,7 +24,10 @@ pub fn make_table_builder(
     };
 
     for (field_name, attr) in attributes {
-        let name = field_name.as_str().try_into().unwrap(); // FIXME: handle errors
+        let Ok(name) = field_name.as_str().try_into() else {
+            log::error!("Field name '{}' cannot be used in Shapefile", field_name);
+            continue;
+        };
         let key = field_name.to_string();
 
         match attr.type_ref {

--- a/nusamai/src/transformer/transform/shp_field_dict.json
+++ b/nusamai/src/transformer/transform/shp_field_dict.json
@@ -847,5 +847,21 @@
   "zonalDisasterPreventionFacilities": "zoneDPFacl",
   "zonalDisasterPreventionFacilitiesAllocation": "zDiPrFcAlc",
   "zoneName": "zoneName",
-  "zoneNumber": "zone#"
+  "zoneNumber": "zone#",
+  "geometrySrcDesc0": "geomSrcD0",
+  "geometrySrcDesc1": "geomSrcD1",
+  "geometrySrcDesc2": "geomSrcD2",
+  "geometrySrcDesc3": "geomSrcD3",
+  "geometrySrcDesc4": "geomSrcD4",
+  "appearanceSrcDescLod0": "appSDLod0",
+  "appearanceSrcDescLod1": "appSDLod1",
+  "appearanceSrcDescLod2": "appSDLod2",
+  "appearanceSrcDescLod3": "appSDLod3",
+  "appearanceSrcDescLod4": "appSDLod4",
+  "tranDataAcquisition": "tranDtaAcq",
+  "publicSurveyDataQualityAttribute": "pubSvDQual",
+  "bldgUsecaseAttribute": "bldgUC",
+  "frnKeyValuePairAttribute": "frnKVPair",
+  "tranKeyValuePairAttribute": "tranKVPair",
+  "tranUsecaseAttribute": "tranUC"
 }

--- a/nusamai/tests/mod.rs
+++ b/nusamai/tests/mod.rs
@@ -1,1 +1,0 @@
-mod sink;

--- a/nusamai/tests/pipeline.rs
+++ b/nusamai/tests/pipeline.rs
@@ -162,5 +162,5 @@ fn test_run_pipeline() {
     });
 
     // wait for the pipeline to finish
-    handle.join();
+    handle.join().unwrap();
 }

--- a/nusamai/tests/sink.rs
+++ b/nusamai/tests/sink.rs
@@ -64,7 +64,7 @@ pub(crate) fn simple_run_sink<S: DataSinkProvider>(sink_provider: S, output: Opt
 
     let (handle, watcher, canceller) =
         nusamai::pipeline::run(source, transformer, sink, schema.into());
-    handle.join();
+    handle.join().unwrap();
 
     for msg in watcher {
         println!("Feedback message from the pipeline {:?}", msg);


### PR DESCRIPTION
PLATEAU 4.0 対応 (#524) により、出現するフィールド名の種類が増えたが、Shapefile 用の属性名変換辞書を辞書を更新していなかった。また、11文字以上のフィールド名が含まれていると panic する実装になっていた。

- これらを修正する。
- 上記の問題をテストで検出できるようにするため、パイプライン全体を最後に join する際のエラーを捕捉するようにする。現在はパイプライン内のスレッドが panic してもテストが通ることがある。
