### PR TITLE
Fix: DisasterRiskAttributeProperty for backward compatibility

### DIFF
--- a/nusamai-plateau/src/models/iur/uro/building.rs
+++ b/nusamai-plateau/src/models/iur/uro/building.rs
@@ -1,6 +1,4 @@
-use nusamai_citygml::{
-    citygml_data, citygml_property, CityGmlElement, Code, Date, GYear, Length, Measure,
-};
+use nusamai_citygml::{citygml_data, CityGmlElement, Code, Date, GYear, Length, Measure};
 
 #[citygml_data(name = "uro:BuildingIDAttribute")]
 pub struct BuildingIDAttribute {
@@ -135,98 +133,6 @@ pub struct BuildingDetailAttribute {
 
     #[citygml(path = b"uro:surveyYear", required)]
     pub survey_year: Option<GYear>,
-}
-
-#[citygml_property(name = "uro:BuildingDisasterRiskAttributeProperty")]
-pub enum BuildingDisasterRiskAttributeProperty {
-    #[citygml(path = b"uro:BuildingHighTideRiskAttribute")]
-    BuildingHighTideRiskAttribute(BuildingHighTideRiskAttribute),
-    #[citygml(path = b"uro:BuildingInlandFloodingRiskAttribute")]
-    BuildingInlandFloodingRiskAttribute(BuildingInlandFloodingRiskAttribute),
-    #[citygml(path = b"uro:BuildingLandSlideRiskAttribute")]
-    BuildingLandSlideRiskAttribute(BuildingLandSlideRiskAttribute),
-    #[citygml(path = b"uro:BuildingRiverFloodingRiskAttribute")]
-    BuildingRiverFloodingRiskAttribute(BuildingRiverFloodingRiskAttribute),
-    #[citygml(path = b"uro:BuildingTsunamiRiskAttribute")]
-    BuildingTsunamiRiskAttribute(BuildingTsunamiRiskAttribute),
-}
-
-#[citygml_data(name = "uro:BuildingHighTideRiskAttribute")]
-pub struct BuildingHighTideRiskAttribute {
-    #[citygml(path = b"uro:description", required)]
-    pub description: Option<Code>,
-
-    #[citygml(path = b"uro:rank")]
-    pub rank: Option<Code>,
-
-    #[citygml(path = b"uro:rankOrg")]
-    pub rank_org: Option<Code>,
-
-    #[citygml(path = b"uro:depth")]
-    pub depth: Option<Measure>,
-}
-
-#[citygml_data(name = "uro:BuildingInlandFloodingRiskAttribute")]
-pub struct BuildingInlandFloodingRiskAttribute {
-    #[citygml(path = b"uro:description", required)]
-    pub description: Option<Code>,
-
-    #[citygml(path = b"uro:rank")]
-    pub rank: Option<Code>,
-
-    #[citygml(path = b"uro:rankOrg")]
-    pub rank_org: Option<Code>,
-
-    #[citygml(path = b"uro:depth")]
-    pub depth: Option<Measure>,
-}
-
-#[citygml_data(name = "uro:BuildingLandSlideRiskAttribute")]
-pub struct BuildingLandSlideRiskAttribute {
-    #[citygml(path = b"uro:description", required)]
-    pub description: Option<Code>,
-
-    #[citygml(path = b"uro:areaType", required)]
-    pub area_type: Option<Code>,
-}
-
-#[citygml_data(name = "uro:BuildingTsunamiRiskAttribute")]
-pub struct BuildingTsunamiRiskAttribute {
-    #[citygml(path = b"uro:description", required)]
-    pub description: Option<Code>,
-
-    #[citygml(path = b"uro:rank")]
-    pub rank: Option<Code>,
-
-    #[citygml(path = b"uro:rankOrg")]
-    pub rank_org: Option<Code>,
-
-    #[citygml(path = b"uro:depth")]
-    pub depth: Option<Measure>,
-}
-
-#[citygml_data(name = "uro:BuildingRiverFloodingRiskAttribute")]
-pub struct BuildingRiverFloodingRiskAttribute {
-    #[citygml(path = b"uro:description", required)]
-    pub description: Option<Code>,
-
-    #[citygml(path = b"uro:rank")]
-    pub rank: Option<Code>,
-
-    #[citygml(path = b"uro:rankOrg")]
-    pub rank_org: Option<Code>,
-
-    #[citygml(path = b"uro:depth")]
-    pub depth: Option<Measure>,
-
-    #[citygml(path = b"uro:adminType", required)]
-    pub admin_type: Option<Code>,
-
-    #[citygml(path = b"uro:scale", required)]
-    pub scale: Option<Code>,
-
-    #[citygml(path = b"uro:duration")]
-    pub duration: Option<Measure>,
 }
 
 #[citygml_data(name = "uro:RealEstateIDAttribute")]

--- a/nusamai-plateau/src/models/iur/uro/disaster_risk.rs
+++ b/nusamai-plateau/src/models/iur/uro/disaster_risk.rs
@@ -2,16 +2,21 @@ use nusamai_citygml::{citygml_data, citygml_property, CityGmlElement, Code, Leng
 
 #[citygml_property(name = "uro:DisasterRiskAttributeProperty")]
 pub enum DisasterRiskAttributeProperty {
+    #[citygml(path = b"uro:BuildingHighTideRiskAttribute")] // for backward compatibility
     #[citygml(path = b"uro:HighTideRiskAttribute")]
     HighTideRiskAttribute(HighTideRiskAttribute),
+    #[citygml(path = b"uro:BuildingInlandFloodingRiskAttribute")] // for backward compatibility
     #[citygml(path = b"uro:InlandFloodingRiskAttribute")]
     InlandFloodingRiskAttribute(InlandFloodingRiskAttribute),
+    #[citygml(path = b"uro:BuildingLandSlideRiskAttribute")] // for backward compatibility
     #[citygml(path = b"uro:LandSlideRiskAttribute")]
     LandSlideRiskAttribute(LandSlideRiskAttribute),
     #[citygml(path = b"uro:ReservoirFloodingRiskAttribute")]
     ReservoirFloodingRiskAttribute(ReservoirFloodingRiskAttribute),
+    #[citygml(path = b"uro:BuildingRiverFloodingRiskAttribute")] // for backward compatibility
     #[citygml(path = b"uro:RiverFloodingRiskAttribute")]
     RiverFloodingRiskAttribute(RiverFloodingRiskAttribute),
+    #[citygml(path = b"uro:BuildingTsunamiRiskAttribute")] // for backward compatibility
     #[citygml(path = b"uro:TsunamiRiskAttribute")]
     TsunamiRiskAttribute(TsunamiRiskAttribute),
 }


### PR DESCRIPTION
## Description（変更内容）

#524 の修正

### 詳細

PLATEAU 4.0において `uro:BuildingHighTideRiskAttribute`（建築物で使用） と `uro:HighTideRiskAttribute` （その他の地物で使用）が1つの `uro:HighTideRiskAttribute` に統一されたため #524 で対応したが、後方互換性のために `uro:BuildingHighTideRiskAttribute` 要素も拾うような対処はしていなかった。対応する。

