### PR TITLE
マインクラフト出力設定をGUIに追加

### DIFF
--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -13,9 +13,9 @@ use nusamai::{
     pipeline::{feedback, Canceller},
     sink::{
         cesiumtiles::CesiumTilesSinkProvider, czml::CzmlSinkProvider, geojson::GeoJsonSinkProvider,
-        gltf::GltfSinkProvider, gpkg::GpkgSinkProvider, kml::KmlSinkProvider, mvt::MvtSinkProvider,
-        ply::StanfordPlySinkProvider, serde::SerdeSinkProvider, shapefile::ShapefileSinkProvider,
-        DataSinkProvider,
+        gltf::GltfSinkProvider, gpkg::GpkgSinkProvider, kml::KmlSinkProvider,
+        minecraft::MinecraftSinkProvider, mvt::MvtSinkProvider, ply::StanfordPlySinkProvider,
+        serde::SerdeSinkProvider, shapefile::ShapefileSinkProvider, DataSinkProvider,
     },
     source::{citygml::CityGmlSourceProvider, DataSourceProvider},
     transformer::{
@@ -115,6 +115,7 @@ fn select_sink_provider(filetype: &str) -> Option<Box<dyn DataSinkProvider>> {
         "gltf" => Some(Box::new(GltfSinkProvider {})),
         "ply" => Some(Box::new(StanfordPlySinkProvider {})),
         "cesiumtiles" => Some(Box::new(CesiumTilesSinkProvider {})),
+        "minecraft" => Some(Box::new(MinecraftSinkProvider {})),
         _ => None,
     }
 }

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -123,6 +123,11 @@ const filetypeOptions: Record<string, { label: string; extensions: string[]; eps
 				{ value: 10173, label: 'JGD2011 / 平面直角座標系 XII + 標高 (EPSG:10173)' },
 				{ value: 10174, label: 'JGD2011 / 平面直角座標系 XIII + 標高 (EPSG:10174)' }
 			]
+		},
+		minecraft: {
+			label: 'Minecraft',
+			extensions: [''],
+			epsg: [{ value: 4979, label: 'WGS 84 (EPSG:4979)' }]
 		}
 	};
 


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #538

### Description（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- 何のために、どのような変更をしますか？ -->

- Minecraft SinkをGUIから指定できるようにしました。
- 座標系はMinecraft Sinkの中でUTMに変換されますが、Transform Stageでは4979に変換されることを想定しているので、「WGS 84 (EPSG:4979)」のような記載にしました。

### Manual Testing（手動テスト）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら、そのやり方を記述してください。-->

Not required / 不要
