### PR TITLE
gltf sink: ENU座標系で出力する

### DIFF
--- a/nusamai/Cargo.toml
+++ b/nusamai/Cargo.toml
@@ -51,6 +51,7 @@ chrono = "0.4.35"
 kv-extsort = { git = "https://github.com/MIERUNE/kv-extsort-rs.git" }
 bytemuck = { version = "1.16.0", features = ["derive"] }
 dda-voxelize = "0.2.0-alpha.1"
+glam = "0.28.0"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/nusamai/src/sink/gltf/gltf_writer.rs
+++ b/nusamai/src/sink/gltf/gltf_writer.rs
@@ -17,7 +17,6 @@ use crate::{
 pub fn write_gltf_glb<W: Write>(
     feedback: &feedback::Feedback,
     writer: W,
-    transform: [f64; 16],
     vertices: impl IntoIterator<Item = [u32; 9]>,
     primitives: Primitives,
     metadata_encoder: metadata::MetadataEncoder,
@@ -237,7 +236,6 @@ pub fn write_gltf_glb<W: Write>(
         }],
         nodes: vec![Node {
             mesh: (!primitives.is_empty()).then_some(0),
-            matrix: transform,
             ..Default::default()
         }],
         meshes: gltf_meshes,

--- a/nusamai/src/sink/gltf/gltf_writer.rs
+++ b/nusamai/src/sink/gltf/gltf_writer.rs
@@ -1,8 +1,4 @@
-use std::{
-    fs::File,
-    io::{BufWriter, Write},
-    path::Path,
-};
+use std::io::Write;
 
 use byteorder::{ByteOrder, LittleEndian};
 use indexmap::IndexSet;
@@ -264,52 +260,6 @@ pub fn write_gltf_glb<W: Write>(
         bin: Some(bin_content.into()),
     }
     .to_writer_with_alignment(writer, 8)?;
-
-    Ok(())
-}
-
-// This is the code to verify the operation with Cesium
-pub fn write_3dtiles(
-    bounding_volume: [f64; 6],
-    transform: [f64; 16],
-    output_path: &Path,
-    filenames: &[String],
-) -> std::io::Result<()> {
-    // write 3DTiles
-    let tileset_path = output_path.join("tileset.json");
-
-    let contents: Vec<cesiumtiles::tileset::Content> = filenames
-        .iter()
-        .map(|filename| {
-            let uri = filename.to_string();
-            cesiumtiles::tileset::Content {
-                uri,
-                ..Default::default()
-            }
-        })
-        .collect();
-
-    let tileset = cesiumtiles::tileset::Tileset {
-        geometric_error: 1e+100,
-        asset: cesiumtiles::tileset::Asset {
-            version: "1.1".to_string(),
-            ..Default::default()
-        },
-        root: cesiumtiles::tileset::Tile {
-            bounding_volume: cesiumtiles::tileset::BoundingVolume {
-                region: Some(bounding_volume),
-                ..Default::default()
-            },
-            transform,
-            contents: Some(contents),
-            ..Default::default()
-        },
-        ..Default::default()
-    };
-
-    let mut tileset_file = File::create(tileset_path)?;
-    let tileset_writer = BufWriter::with_capacity(1024 * 1024, &mut tileset_file);
-    serde_json::to_writer_pretty(tileset_writer, &tileset)?;
 
     Ok(())
 }

--- a/nusamai/src/sink/gltf/gltf_writer.rs
+++ b/nusamai/src/sink/gltf/gltf_writer.rs
@@ -17,7 +17,7 @@ use crate::{
 pub fn write_gltf_glb<W: Write>(
     feedback: &feedback::Feedback,
     writer: W,
-    translation: [f64; 3],
+    transform: [f64; 16],
     vertices: impl IntoIterator<Item = [u32; 9]>,
     primitives: Primitives,
     metadata_encoder: metadata::MetadataEncoder,
@@ -237,7 +237,7 @@ pub fn write_gltf_glb<W: Write>(
         }],
         nodes: vec![Node {
             mesh: (!primitives.is_empty()).then_some(0),
-            translation,
+            matrix: transform,
             ..Default::default()
         }],
         meshes: gltf_meshes,
@@ -273,6 +273,7 @@ pub fn write_gltf_glb<W: Write>(
 // This is the code to verify the operation with Cesium
 pub fn write_3dtiles(
     bounding_volume: [f64; 6],
+    transform: [f64; 16],
     output_path: &Path,
     filenames: &[String],
 ) -> std::io::Result<()> {
@@ -301,6 +302,7 @@ pub fn write_3dtiles(
                 region: Some(bounding_volume),
                 ..Default::default()
             },
+            transform,
             contents: Some(contents),
             ..Default::default()
         },

--- a/nusamai/src/sink/gltf/mod.rs
+++ b/nusamai/src/sink/gltf/mod.rs
@@ -434,14 +434,7 @@ impl DataSink for GltfSink {
                 let mut file = File::create(file_path)?;
                 let writer = BufWriter::with_capacity(1024 * 1024, &mut file);
 
-                write_gltf_glb(
-                    feedback,
-                    writer,
-                    DMat4::IDENTITY.to_cols_array(), // no transformation
-                    vertices,
-                    primitives,
-                    metadata_encoder,
-                )?;
+                write_gltf_glb(feedback, writer, vertices, primitives, metadata_encoder)?;
 
                 Ok::<(), PipelineError>(())
             })?;

--- a/nusamai/src/sink/gltf/mod.rs
+++ b/nusamai/src/sink/gltf/mod.rs
@@ -9,7 +9,7 @@ use ahash::{HashMap, HashSet, RandomState};
 use earcut::{utils3d::project3d_to_2d, Earcut};
 use flatgeom::MultiPolygon;
 use glam::{DMat4, DVec3, DVec4};
-use gltf_writer::{write_3dtiles, write_gltf_glb};
+use gltf_writer::write_gltf_glb;
 use indexmap::IndexSet;
 use itertools::Itertools;
 use material::{Material, Texture};
@@ -320,7 +320,7 @@ impl DataSink for GltfSink {
                 * DMat4::from_rotation_x(-(FRAC_PI_2 - psi))
                 * DMat4::from_rotation_y((-center_lng - 90.).to_radians())
         };
-        let transform_matrix_inv = transform_matrix.inverse();
+        let _ = transform_matrix.inverse();
 
         classified_features
             .into_par_iter()
@@ -438,23 +438,6 @@ impl DataSink for GltfSink {
 
                 Ok::<(), PipelineError>(())
             })?;
-
-        // write 3DTiles
-        let bounds = &global_bvol;
-        let region: [f64; 6] = [
-            bounds.min_lng.to_radians(),
-            bounds.min_lat.to_radians(),
-            bounds.max_lng.to_radians(),
-            bounds.max_lat.to_radians(),
-            bounds.min_height,
-            bounds.max_height,
-        ];
-        write_3dtiles(
-            region,
-            transform_matrix_inv.to_cols_array(),
-            &self.output_path,
-            &tileset_content_files.lock().unwrap(),
-        )?;
 
         Ok(())
     }


### PR DESCRIPTION
Close #602

### Description（変更内容）

See #602

- 「glTF出力」のglTFを 局所座標系（ENU座標系）で出力する。
- グローバルバウンディングボックスの計算を改善する（事前に計算しておくことが必要、かつ、より良い）

![Screenshot 2024-07-10 at 15 16 50](https://github.com/MIERUNE/plateau-gis-converter/assets/5351911/693a7a86-adff-4b1d-9239-c2b90017e1c2)

### Notes（連絡事項）

- おまけで生成される 3D Tiles 用のデータの正しさはまだ確認していないです。
