### PR TITLE
atlas: 生成されたatlasの未使用ピクセル数（RGBA→0,0,0,0）を取得するexamplesの実装

### DIFF
--- a/nusamai-atlas/Cargo.toml
+++ b/nusamai-atlas/Cargo.toml
@@ -7,6 +7,7 @@ image = { version = "0.25.1", default-features = false, features = ["rayon", "ti
 thiserror = "1.0.61"
 hashbrown = "0.14.5"
 stretto = "0.8.4"
+clap = {version = "4.5.9", features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3.10.1"

--- a/nusamai-atlas/Cargo.toml
+++ b/nusamai-atlas/Cargo.toml
@@ -10,3 +10,7 @@ stretto = "0.8.4"
 
 [dev-dependencies]
 tempfile = "3.10.1"
+
+[[bin]]
+name = "nusamai-atlas"
+path = "examples/test_pack_dice.rs"

--- a/nusamai-atlas/examples/test_pack_dice.rs
+++ b/nusamai-atlas/examples/test_pack_dice.rs
@@ -3,6 +3,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use image::{GenericImageView, Rgba};
+
 use nusamai_atlas::{
     export::PngAtlasExporter,
     pack::TexturePacker,
@@ -178,7 +180,7 @@ fn main() {
 
     for (idx, (material, uv_coords)) in faces.iter().enumerate() {
         let texture_file = material_to_texture.get(material).unwrap();
-        let path_string = format!("nusamai-atlas/examples/assets/dice/{}", texture_file);
+        let path_string = format!("./examples/assets/dice/{}", texture_file);
         let image_path = PathBuf::from(path_string);
         polygons.push(Polygon {
             id: format!("texture_{}_{}", material, idx),
@@ -210,6 +212,15 @@ fn main() {
 
     packer.finalize();
 
-    let output_dir = Path::new("nusamai-atlas/examples/output/");
+    let output_dir = Path::new("./examples/output/");
+    let atlas_path = output_dir.join("0.png");
     packer.export(output_dir, &texture_cache, config.width(), config.height());
+
+    let img = image::open(&atlas_path).expect("Failed to open atlas image");
+    let unused_pixels = img
+        .pixels()
+        .filter(|&(_, _, pixel)| matches!(pixel, Rgba([0, 0, 0, 0])))
+        .count();
+
+    println!("Unused pixels: {}", unused_pixels);
 }

--- a/nusamai-atlas/examples/test_pack_dice.rs
+++ b/nusamai-atlas/examples/test_pack_dice.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use image::{GenericImageView, Rgba};
+use image::{open, GenericImageView, Rgba};
 
 use nusamai_atlas::{
     export::PngAtlasExporter,
@@ -12,6 +12,7 @@ use nusamai_atlas::{
     texture::{DownsampleFactor, TextureCache},
 };
 
+use clap::{Arg, ArgAction, Command};
 #[derive(Debug, Clone)]
 struct Polygon {
     id: String,
@@ -210,17 +211,37 @@ fn main() {
         println!("{:?}", info);
     });
 
-    packer.finalize();
-
     let output_dir = Path::new("./examples/output/");
-    let atlas_path = output_dir.join("0.png");
     packer.export(output_dir, &texture_cache, config.width(), config.height());
 
-    let img = image::open(&atlas_path).expect("Failed to open atlas image");
-    let unused_pixels = img
-        .pixels()
-        .filter(|&(_, _, pixel)| matches!(pixel, Rgba([0, 0, 0, 0])))
-        .count();
+    let matches = Command::new("Image Processor")
+        .about("Processes images to find unused pixels")
+        .arg(
+            Arg::new("INPUT")
+                .help("Outputs unused pixels")
+                .short('u')
+                .long("unused_pixels")
+                .value_name("FILE")
+                .action(ArgAction::Set),
+        )
+        .get_matches();
 
-    println!("Unused pixels: {}", unused_pixels);
+    let input = match matches.get_one::<String>("INPUT") {
+        Some(input_value) => input_value,
+        None => {
+            std::process::exit(0);
+        }
+    };
+    let output_unused_pixels = matches.contains_id("INPUT");
+
+    let img = open(input).expect("Failed to open image");
+
+    if output_unused_pixels {
+        let unused_pixels = img
+            .pixels()
+            .filter(|&(_, _, pixel)| matches!(pixel, Rgba([0, 0, 0, 0])))
+            .count();
+
+        println!("unused pixels: {}", unused_pixels);
+    }
 }


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #600

### Description（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- 何のために、どのような変更をしますか？ -->
- https://github.com/MIERUNE/plateau-gis-converter/issues/582 にて調査したアルゴリズムを実装するために、アルゴリズム間の比較を行うための前準備として、最適化度を計測する指標（atlasの未使用ピクセル数を取得する）のexamplesを追加しました。


### Manual Testing（手動テスト）
プロジェクトのディレクトリ直下で以下のコマンドを実行すると、挙動が確認できます。

```sh
git checkout feature/examples-texture-atlas-unused-pixels
cd nusamai-atlas
cargo run -- -u examples/output/0.png
# cargo run -- -unused_pixels examples/output/0.png
```

出力結果
```
PlacedTextureInfo { id: "texture_yellow_dice_0", atlas_id: "0", origin: (1, 1), width: 80, height: 48, placed_uv_coords: [(0.158203125, 0.998046875), (0.001953125, 0.904296875), (0.158203125, 0.904296875)] }
PlacedTextureInfo { id: "texture_yellow_dice_1", atlas_id: "0", origin: (82, 1), width: 80, height: 47, placed_uv_coords: [(0.16015625, 0.998046875), (0.31640625, 0.90625), (0.31640625, 0.998046875)] }
PlacedTextureInfo { id: "texture_yellow_dice_2", atlas_id: "0", origin: (1, 50), width: 80, height: 48, placed_uv_coords: [(0.001953125, 0.90234375), (0.158203125, 0.80859375), (0.158203125, 0.90234375)] }
// ...
Unused pixels: 231195
```