### PR TITLE
gltfをテクスチャつきで出力できる用に修正

### DIFF
--- a/nusamai/src/sink/gltf/mod.rs
+++ b/nusamai/src/sink/gltf/mod.rs
@@ -52,6 +52,17 @@ impl DataSinkProvider for GltfSinkProvider {
                 label: None,
             },
         );
+
+        params.define(
+            "transform".into(),
+            ParameterEntry {
+                description: "transform option".into(),
+                required: false,
+                parameter: ParameterType::String(StringParameter { value: None }),
+                label: None,
+            },
+        );
+
         params
     }
 

--- a/nusamai/src/transformer/transform/attrname.rs
+++ b/nusamai/src/transformer/transform/attrname.rs
@@ -20,7 +20,7 @@ use crate::{pipeline::Feedback, transformer::Transform};
 /// You may specify the rules in two ways:
 /// - Exact match: Rename if the key matches exactly (e.g., `{"ns:foo": "bar"}`)
 /// - General match: Rename for any namespace prefix (e.g., `{"*:foo": "bar"}`)
-/// Note that the exact match takes precedence over the general match.
+///   Note that the exact match takes precedence over the general match.
 #[derive(Default, Clone)]
 pub struct EditFieldNamesTransform {
     // Exact string match dictionary


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #0

### Description（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- 何のために、どのような変更をしますか？ -->

- gltfがテクスチャ付き出力できない状態だったので修正しました
- ビルドテストが失敗するため、ドキュメンテーションコメントのインデントを一部修正しました。
- https://github.com/MIERUNE/plateau-gis-converter/actions/runs/10137562564/job/28028430283

### Notes（連絡事項）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動の動作確認が必要なら、手順を簡単に伝えてください。その他連絡事項など。 -->

### 動作テスト
- コマンドラインでテクスチャ付き出力を確認する
```sh
cargo run -- <input_path> --sink gltf -o transform=use_texture --output <output_path>
```
- GUIでテクスチャ付き出力を確認する
![image](https://github.com/user-attachments/assets/b422a4dd-ca03-47f7-af17-d69b5e9ed7bf)

![image](https://github.com/user-attachments/assets/a3702dd5-016f-4660-a3c4-ec3d47500284)
