### PR TITLE
OBJ Sinkにアトラス化を付与した`obj_atlas sink`の作成

### DIFF
--- a/nusamai/Cargo.toml
+++ b/nusamai/Cargo.toml
@@ -51,7 +51,7 @@ chrono = "0.4.35"
 kv-extsort = { git = "https://github.com/MIERUNE/kv-extsort-rs.git" }
 bytemuck = { version = "1.16.0", features = ["derive"] }
 dda-voxelize = "0.2.0-alpha.1"
-atlas-packer = { git = "https://github.com/MIERUNE/atlas-packer.git", branch = "fix/overflow" }
+atlas-packer = { git = "https://github.com/MIERUNE/atlas-packer.git" }
 tempfile = "3.10.1"
 glam = "0.28.0"
 

--- a/nusamai/Cargo.toml
+++ b/nusamai/Cargo.toml
@@ -51,7 +51,7 @@ chrono = "0.4.35"
 kv-extsort = { git = "https://github.com/MIERUNE/kv-extsort-rs.git" }
 bytemuck = { version = "1.16.0", features = ["derive"] }
 dda-voxelize = "0.2.0-alpha.1"
-atlas-packer = { git = "https://github.com/MIERUNE/atlas-packer.git" }
+atlas-packer = { git = "https://github.com/MIERUNE/atlas-packer.git", branch = "fix/overflow" }
 tempfile = "3.10.1"
 glam = "0.28.0"
 

--- a/nusamai/src/sink/obj_atlas/material.rs
+++ b/nusamai/src/sink/obj_atlas/material.rs
@@ -1,6 +1,6 @@
 //! Material mangement
 
-use std::{hash::Hash, path::Path, time::Instant};
+use std::hash::Hash;
 
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -30,34 +30,3 @@ pub struct Texture {
 pub struct Image {
     pub uri: Url,
 }
-
-// // NOTE: temporary implementation
-// pub fn load_image(path: &Path) -> std::io::Result<Vec<u8>> {
-//     if let Some(ext) = path.extension() {
-//         match ext.to_ascii_lowercase().to_str() {
-//             Some("tif" | "tiff" | "png") => {
-//                 let image = image::open(path)
-//                     .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
-
-//                 let t = Instant::now();
-//                 let mut writer = std::io::Cursor::new(Vec::new());
-//                 let encoder = image::codecs::png::PngEncoder::new(&mut writer);
-//                 image
-//                     .write_with_encoder(encoder)
-//                     .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
-//                 log::debug!("Image encoding took {:?}", t.elapsed());
-
-//                 Ok(writer.into_inner())
-//             }
-//             Some("jpg" | "jpeg") => Ok(std::fs::read(path)?),
-//             _ => {
-//                 let err = format!("Unsupported image format: {:?}", path);
-//                 Err(std::io::Error::new(std::io::ErrorKind::InvalidData, err))
-//             }
-//         }
-//     } else {
-//         let err = format!("Unsupported image format: {:?}", path);
-//         log::error!("{}", err);
-//         Err(std::io::Error::new(std::io::ErrorKind::InvalidData, err))
-//     }
-// }

--- a/nusamai/src/sink/obj_atlas/material.rs
+++ b/nusamai/src/sink/obj_atlas/material.rs
@@ -31,33 +31,33 @@ pub struct Image {
     pub uri: Url,
 }
 
-// NOTE: temporary implementation
-pub fn load_image(path: &Path) -> std::io::Result<Vec<u8>> {
-    if let Some(ext) = path.extension() {
-        match ext.to_ascii_lowercase().to_str() {
-            Some("tif" | "tiff" | "png") => {
-                let image = image::open(path)
-                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+// // NOTE: temporary implementation
+// pub fn load_image(path: &Path) -> std::io::Result<Vec<u8>> {
+//     if let Some(ext) = path.extension() {
+//         match ext.to_ascii_lowercase().to_str() {
+//             Some("tif" | "tiff" | "png") => {
+//                 let image = image::open(path)
+//                     .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
 
-                let t = Instant::now();
-                let mut writer = std::io::Cursor::new(Vec::new());
-                let encoder = image::codecs::png::PngEncoder::new(&mut writer);
-                image
-                    .write_with_encoder(encoder)
-                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
-                log::debug!("Image encoding took {:?}", t.elapsed());
+//                 let t = Instant::now();
+//                 let mut writer = std::io::Cursor::new(Vec::new());
+//                 let encoder = image::codecs::png::PngEncoder::new(&mut writer);
+//                 image
+//                     .write_with_encoder(encoder)
+//                     .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+//                 log::debug!("Image encoding took {:?}", t.elapsed());
 
-                Ok(writer.into_inner())
-            }
-            Some("jpg" | "jpeg") => Ok(std::fs::read(path)?),
-            _ => {
-                let err = format!("Unsupported image format: {:?}", path);
-                Err(std::io::Error::new(std::io::ErrorKind::InvalidData, err))
-            }
-        }
-    } else {
-        let err = format!("Unsupported image format: {:?}", path);
-        log::error!("{}", err);
-        Err(std::io::Error::new(std::io::ErrorKind::InvalidData, err))
-    }
-}
+//                 Ok(writer.into_inner())
+//             }
+//             Some("jpg" | "jpeg") => Ok(std::fs::read(path)?),
+//             _ => {
+//                 let err = format!("Unsupported image format: {:?}", path);
+//                 Err(std::io::Error::new(std::io::ErrorKind::InvalidData, err))
+//             }
+//         }
+//     } else {
+//         let err = format!("Unsupported image format: {:?}", path);
+//         log::error!("{}", err);
+//         Err(std::io::Error::new(std::io::ErrorKind::InvalidData, err))
+//     }
+// }

--- a/nusamai/src/sink/obj_atlas/mod.rs
+++ b/nusamai/src/sink/obj_atlas/mod.rs
@@ -452,8 +452,10 @@ impl DataSink for ObjAtlasSink {
                             );
 
                             // Unique id required for placement in atlas
-                            let texture_id =
-                                format!("{}_{}_{}", typename, feature.feature_id, poly_count);
+                            let texture_id = format!(
+                                "{}_{}_{}",
+                                base_folder_name, feature.feature_id, poly_count
+                            );
                             let info = packer.add_texture(texture_id, texture);
 
                             let atlas_placed_uv_coords = info
@@ -467,7 +469,7 @@ impl DataSink for ObjAtlasSink {
                                 .map(|((x, y, z, _, _), (u, v))| (*x, *y, *z, *u, *v))
                                 .collect::<Vec<(f64, f64, f64, f64, f64)>>();
 
-                            // update_verticesを利用して、polyのtransform_inplaceメソッドで頂点を更新する
+                            // Apply the UV coordinates placed in the atlas to the original polygon
                             poly.transform_inplace(|&[x, y, z, _, _]| {
                                 let (u, v) = updated_vertices
                                     .iter()

--- a/nusamai/src/sink/obj_atlas/mod.rs
+++ b/nusamai/src/sink/obj_atlas/mod.rs
@@ -480,8 +480,7 @@ impl DataSink for ObjAtlasSink {
                                 [x, y, z, u, v]
                             });
 
-                            let atlas_file_name =
-                                format!("{}_{}", typename.replace(":", "_"), &info.atlas_id);
+                            let atlas_file_name = info.atlas_id.to_string();
 
                             let atlas_uri =
                                 atlas_dir.join(atlas_file_name).with_extension(ext.clone());

--- a/nusamai/src/sink/obj_atlas/mod.rs
+++ b/nusamai/src/sink/obj_atlas/mod.rs
@@ -380,10 +380,11 @@ impl DataSink for ObjAtlasSink {
 
                 // file output destination
                 let mut folder_path = self.output_path.clone();
-                let file_name = typename.replace(':', "_").to_string();
-                folder_path.push(&file_name);
+                let base_folder_name = typename.replace(':', "_").to_string();
+                folder_path.push(&base_folder_name);
 
-                let atlas_dir = folder_path.join("textures");
+                let texture_folder_name = "textures";
+                let atlas_dir = folder_path.join(texture_folder_name);
                 std::fs::create_dir_all(&atlas_dir)?;
 
                 // Triangulation
@@ -502,7 +503,33 @@ impl DataSink for ObjAtlasSink {
                         let poly_material = new_mat;
                         let poly_color = poly_material.base_color;
                         let poly_texture = poly_material.base_texture.as_ref();
-                        let poly_material_key = format!("{}_{}", feature.feature_id, orig_mat_id);
+                        let texture_name = poly_texture.map_or_else(
+                            || "".to_string(),
+                            |t| {
+                                t.uri
+                                    .to_file_path()
+                                    .unwrap()
+                                    .file_stem()
+                                    .unwrap()
+                                    .to_str()
+                                    .unwrap()
+                                    .to_string()
+                            },
+                        );
+                        let poly_material_key = poly_material.base_texture.as_ref().map_or_else(
+                            || {
+                                format!(
+                                    "material_{}_{}_{}",
+                                    poly_color[0], poly_color[1], poly_color[2]
+                                )
+                            },
+                            |_| {
+                                format!(
+                                    "{}_{}_{}",
+                                    base_folder_name, texture_folder_name, texture_name
+                                )
+                            },
+                        );
 
                         all_materials.insert(
                             poly_material_key.clone(),

--- a/nusamai/src/sink/obj_atlas/obj_writer.rs
+++ b/nusamai/src/sink/obj_atlas/obj_writer.rs
@@ -5,7 +5,6 @@ use std::{collections::HashMap, path::Path};
 
 use super::{material, ObjInfo, ObjMaterials};
 use crate::pipeline::PipelineError;
-use material::load_image;
 
 pub fn write(
     meshes: ObjInfo,
@@ -54,6 +53,7 @@ fn write_obj(
         for tex_coord in &mesh.uvs {
             writeln!(obj_writer, "vt {} {}", tex_coord[0], tex_coord[1])?;
         }
+
         for (material_key, indices) in &mesh.primitives {
             if material_cache.contains_key(material_key) {
                 writeln!(obj_writer, "usemtl {}", material_key)?;
@@ -102,8 +102,10 @@ fn write_mtl(
 
         if let Some(uri) = &material.texture_uri {
             if let Ok(path) = uri.to_file_path() {
+                // todo: 同一のテクスチャを利用しているときにはキーを発行しない
                 writeln!(mtl_writer, "newmtl {}", material_key)?;
-                writeln!(mtl_writer, "map_Kd .\\textures\\{}", path.to_str().unwrap())?;
+                let texture_name = path.file_name().unwrap().to_str().unwrap();
+                writeln!(mtl_writer, "map_Kd .\\textures\\{}", texture_name)?;
                 material_cache.insert(material_key.to_string(), path.to_str().unwrap().to_string());
             }
         } else {

--- a/nusamai/src/sink/obj_atlas/obj_writer.rs
+++ b/nusamai/src/sink/obj_atlas/obj_writer.rs
@@ -103,17 +103,8 @@ fn write_mtl(
         if let Some(uri) = &material.texture_uri {
             if let Ok(path) = uri.to_file_path() {
                 writeln!(mtl_writer, "newmtl {}", material_key)?;
-                let content = load_image(&path)?;
-
-                let textures_dir = folder_path.join("textures");
-                std::fs::create_dir_all(&textures_dir)?;
-
-                let image_file_name = format!("{}.jpg", material_key);
-                let image_path = textures_dir.join(&image_file_name);
-                std::fs::write(&image_path, content)?;
-
-                writeln!(mtl_writer, "map_Kd .\\textures\\{}", image_file_name)?;
-                material_cache.insert(material_key.to_string(), image_file_name);
+                writeln!(mtl_writer, "map_Kd .\\textures\\{}", path.to_str().unwrap())?;
+                material_cache.insert(material_key.to_string(), path.to_str().unwrap().to_string());
             }
         } else {
             let (r, g, b) = (


### PR DESCRIPTION
<!-- Close or Related Issues -->

### Description（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- 何のために、どのような変更をしますか？ -->

- 以下の事象に対応し、アトラス化されたテクスチャの出力と対応するOBJファイルを出力するように変更
  - UV座標をアトラスの座標に差し替え
  - mtlに書き込むテクスチャのパスと、アトラスの出力パスが不整合を修正
  - UV座標をピクセル座標に変換する際に、微妙な誤差や境界付近の取り扱い方により画像の範囲をはみ出してクロップしていた箇所を修正（atlas-packer）
- アトラス化により処理時間が10倍以上になっているため、注意
  - 上記の理由などにより、本実装ではなくPoCです

### Notes（連絡事項）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動の動作確認が必要なら、手順を簡単に伝えてください。その他連絡事項など。 -->

```bash
cargo run -- <input_path> --sink obj_atlas -o transform=use_texture -o split=true --output <output_path>
```
