### PR TITLE
テクスチャのスケーリングに関するオプションの追加

### DIFF
--- a/nusamai/src/parameters/mod.rs
+++ b/nusamai/src/parameters/mod.rs
@@ -118,7 +118,6 @@ impl ParameterEntry {
             ParameterType::String(p) => p.validate(self.required),
             ParameterType::Boolean(p) => p.validate(self.required),
             ParameterType::Integer(p) => p.validate(self.required),
-            ParameterType::Float64(p) => p.validate(self.required),
         }
     }
 
@@ -129,7 +128,6 @@ impl ParameterEntry {
             ParameterType::String(p) => p.update_value_with_str(s),
             ParameterType::Boolean(p) => p.update_value_with_str(s),
             ParameterType::Integer(p) => p.update_value_with_str(s),
-            ParameterType::Float64(p) => p.update_value_with_str(s),
         }
     }
 
@@ -140,7 +138,6 @@ impl ParameterEntry {
             ParameterType::String(p) => p.update_value_with_json(v),
             ParameterType::Boolean(p) => p.update_value_with_json(v),
             ParameterType::Integer(p) => p.update_value_with_json(v),
-            ParameterType::Float64(p) => p.update_value_with_json(v),
         }
     }
 }
@@ -151,7 +148,6 @@ pub enum ParameterType {
     String(StringParameter),
     Boolean(BooleanParameter),
     Integer(IntegerParameter),
-    Float64(Float64Parameter),
     // and so on ...
 }
 
@@ -254,44 +250,6 @@ impl BooleanParameter {
         } else {
             Err(Error::InvalidValue("Value must be a boolean.".into()))
         }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct Float64Parameter {
-    pub value: Option<f64>,
-}
-
-impl Float64Parameter {
-    pub fn validate(&self, required: bool) -> Result<(), Error> {
-        if required {
-            match &self.value {
-                Some(_) => Ok(()),
-                _ => Err(Error::RequiredValueNotProvided),
-            }
-        } else {
-            Ok(())
-        }
-    }
-
-    pub fn update_value_with_str(&mut self, s: &str) -> Result<(), Error> {
-        let Ok(v) = s.parse::<f64>() else {
-            return Err(Error::InvalidValue("Value must be a boolean.".into()));
-        };
-        self.value = Some(v);
-        Ok(())
-    }
-
-    pub fn update_value_with_json(&mut self, v: &serde_json::Value) -> Result<(), Error> {
-        if let serde_json::Value::Number(n) = v {
-            if let Some(v) = n.as_f64() {
-                self.value = Some(v);
-                return Ok(());
-            }
-        }
-        Err(Error::InvalidValue(
-            "Value must be a floating-point number.".into(),
-        ))
     }
 }
 

--- a/nusamai/src/parameters/mod.rs
+++ b/nusamai/src/parameters/mod.rs
@@ -118,6 +118,7 @@ impl ParameterEntry {
             ParameterType::String(p) => p.validate(self.required),
             ParameterType::Boolean(p) => p.validate(self.required),
             ParameterType::Integer(p) => p.validate(self.required),
+            ParameterType::Float64(p) => p.validate(self.required),
         }
     }
 
@@ -128,6 +129,7 @@ impl ParameterEntry {
             ParameterType::String(p) => p.update_value_with_str(s),
             ParameterType::Boolean(p) => p.update_value_with_str(s),
             ParameterType::Integer(p) => p.update_value_with_str(s),
+            ParameterType::Float64(p) => p.update_value_with_str(s),
         }
     }
 
@@ -138,6 +140,7 @@ impl ParameterEntry {
             ParameterType::String(p) => p.update_value_with_json(v),
             ParameterType::Boolean(p) => p.update_value_with_json(v),
             ParameterType::Integer(p) => p.update_value_with_json(v),
+            ParameterType::Float64(p) => p.update_value_with_json(v),
         }
     }
 }
@@ -148,6 +151,7 @@ pub enum ParameterType {
     String(StringParameter),
     Boolean(BooleanParameter),
     Integer(IntegerParameter),
+    Float64(Float64Parameter),
     // and so on ...
 }
 
@@ -250,6 +254,44 @@ impl BooleanParameter {
         } else {
             Err(Error::InvalidValue("Value must be a boolean.".into()))
         }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Float64Parameter {
+    pub value: Option<f64>,
+}
+
+impl Float64Parameter {
+    pub fn validate(&self, required: bool) -> Result<(), Error> {
+        if required {
+            match &self.value {
+                Some(_) => Ok(()),
+                _ => Err(Error::RequiredValueNotProvided),
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn update_value_with_str(&mut self, s: &str) -> Result<(), Error> {
+        let Ok(v) = s.parse::<f64>() else {
+            return Err(Error::InvalidValue("Value must be a boolean.".into()));
+        };
+        self.value = Some(v);
+        Ok(())
+    }
+
+    pub fn update_value_with_json(&mut self, v: &serde_json::Value) -> Result<(), Error> {
+        if let serde_json::Value::Number(n) = v {
+            if let Some(v) = n.as_f64() {
+                self.value = Some(v);
+                return Ok(());
+            }
+        }
+        Err(Error::InvalidValue(
+            "Value must be a floating-point number.".into(),
+        ))
     }
 }
 

--- a/nusamai/src/sink/cesiumtiles/mod.rs
+++ b/nusamai/src/sink/cesiumtiles/mod.rs
@@ -46,8 +46,6 @@ use crate::{
 };
 use utils::calculate_normal;
 
-const MAX_PIXEL_PER_DISTANCE: f64 = 30.0;
-
 // WARN: This function has an equivalent in `atlas-packer/src/texture.rs`.
 fn uv_to_pixel_coords(uv_coords: &[(f64, f64)], width: u32, height: u32) -> Vec<(u32, u32)> {
     uv_coords
@@ -98,6 +96,16 @@ impl DataSinkProvider for CesiumTilesSinkProvider {
             },
         );
 
+        params.define(
+            "max-texture-pixels-per-meter".into(),
+            ParameterEntry {
+                description: "limiting texture resolution".into(),
+                required: false,
+                parameter: ParameterType::Float64(Float64Parameter { value: Some(30.0) }),
+                label: Some("距離(メートル)あたりのテクスチャの最大解像度".into()),
+            },
+        );
+
         params
     }
 
@@ -116,11 +124,14 @@ impl DataSinkProvider for CesiumTilesSinkProvider {
 
     fn create(&self, params: &Parameters) -> Box<dyn DataSink> {
         let output_path = get_parameter_value!(params, "@output", FileSystemPath);
+        let max_texture_pixels_per_meter =
+            *get_parameter_value!(params, "max-texture-pixels-per-meter", Float64);
         let transformer_registry = self.available_transformer();
 
         Box::<CesiumTilesSink>::new(CesiumTilesSink {
             output_path: output_path.as_ref().unwrap().into(),
             transformer_registry,
+            max_texture_pixels_per_meter,
         })
     }
 }
@@ -128,6 +139,7 @@ impl DataSinkProvider for CesiumTilesSinkProvider {
 struct CesiumTilesSink {
     output_path: PathBuf,
     transformer_registry: TransformerRegistry,
+    max_texture_pixels_per_meter: Option<f64>,
 }
 
 impl DataSink for CesiumTilesSink {
@@ -156,6 +168,8 @@ impl DataSink for CesiumTilesSink {
         // TODO: configurable
         let min_zoom = 12;
         let max_zoom = 18;
+
+        let max_texture_pixels_per_meter = self.max_texture_pixels_per_meter;
 
         // TODO: refactoring
 
@@ -203,6 +217,7 @@ impl DataSink for CesiumTilesSink {
                             receiver_sorted,
                             tile_id_conv,
                             schema,
+                            max_texture_pixels_per_meter,
                         ) {
                             feedback.fatal_error(error);
                         }
@@ -324,6 +339,7 @@ fn tile_writing_stage(
     receiver_sorted: mpsc::Receiver<(u64, String, Vec<Vec<u8>>)>,
     tile_id_conv: TileIdMethod,
     schema: &Schema,
+    max_texture_pixels_per_meter: Option<f64>,
 ) -> Result<()> {
     let ellipsoid = nusamai_projection::ellipsoid::wgs84();
     let contents: Arc<Mutex<Vec<TileContent>>> = Default::default();
@@ -560,9 +576,13 @@ fn tile_writing_stage(
                             .min_by(|a, b| a.total_cmp(b))
                             .unwrap_or(1.0);
 
-                        let max_pixel_per_distance = MAX_PIXEL_PER_DISTANCE;
-                        let downsample_scale =
-                            (1.0_f64).min(max_pixel_per_distance / pixel_per_distance);
+                        let downsample_scale = if let Some(max_texture_pixels_per_meter) =
+                            max_texture_pixels_per_meter
+                        {
+                            1.0_f64.min(max_texture_pixels_per_meter / pixel_per_distance)
+                        } else {
+                            1.0
+                        };
                         let factor = apply_downsample_factor(tile_zoom, downsample_scale as f32);
 
                         let downsample_factor = DownsampleFactor::new(&factor);


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #628 

### What I did（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- どのような変更をしますか？ 目的は？ -->

- オプション`limit-texture-pixels-per-meter` を追加し、テクスチャのスケーリングをオンオフできるように

### Notes（連絡事項）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら手順を簡単に伝えてください。そのほか連絡事項など。 -->

` -o limit-texture-pixels-per-meter=(true/false)` をコマンドに追加し実行
