### PR TITLE
mtlファイルの指定とグループ作成 (#630)

### DIFF
--- a/nusamai/src/sink/obj/obj_writer.rs
+++ b/nusamai/src/sink/obj/obj_writer.rs
@@ -64,6 +64,7 @@ fn write_obj(
             let mut local_obj = Vec::new();
 
             if is_split {
+                local_obj.push(format!("o {}", feature_id));
                 local_obj.push(format!("g {}", feature_id));
             }
 

--- a/nusamai/src/sink/obj/obj_writer.rs
+++ b/nusamai/src/sink/obj/obj_writer.rs
@@ -47,8 +47,10 @@ fn write_obj(
 
         mesh_data.push((feature_id, mesh, vertex_offset, uv_offset));
     }
-
     let mut obj_writer = BufWriter::new(File::create(&obj_path)?);
+
+    writeln!(obj_writer, "mtllib {}.mtl", file_name)?;
+
     for vertex in &all_vertices {
         writeln!(obj_writer, "v {} {} {}", vertex[0], vertex[1], vertex[2])?;
     }
@@ -62,7 +64,7 @@ fn write_obj(
             let mut local_obj = Vec::new();
 
             if is_split {
-                local_obj.push(format!("o {}", feature_id));
+                local_obj.push(format!("g {}", feature_id));
             }
 
             for (material_key, indices) in &mesh.primitives {


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #630 

### What I did（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- どのような変更をしますか？ 目的は？ -->

- ファイル1行目にmtlファイルの指定を追加
- `g`タグによるポリゴングループ分割

Unity/Blenderにて
- テクスチャが適用されていることを確認
- ポリゴングループごとにオブジェクトが分割されていることを確認

### Notes（連絡事項）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら手順を簡単に伝えてください。そのほか連絡事項など。 -->

- `o`タグを残す必要があるか検討 (後述より残すことを決定)
- オブジェクトの座標上の位置が(0,0,0)固定となっている (代わりに、頂点のローカル座標によって位置が定まっている)
