### PR TITLE
3D Tilesのglbファイルをgzipで圧縮した状態で表示するオプションを追加

### DIFF
--- a/nusamai-plateau/src/models/mod.rs
+++ b/nusamai-plateau/src/models/mod.rs
@@ -29,6 +29,7 @@ pub use tunnel::Tunnel;
 pub use vegetation::{PlantCover, SolitaryVegetationObject};
 pub use waterbody::WaterBody;
 
+#[allow(clippy::large_enum_variant)]
 #[citygml_property(name = "_:TopLevelFeatureProperty")]
 pub enum TopLevelCityObject {
     //

--- a/nusamai-plateau/src/models/mod.rs
+++ b/nusamai-plateau/src/models/mod.rs
@@ -29,7 +29,6 @@ pub use tunnel::Tunnel;
 pub use vegetation::{PlantCover, SolitaryVegetationObject};
 pub use waterbody::WaterBody;
 
-#[allow(clippy::large_enum_variant)]
 #[citygml_property(name = "_:TopLevelFeatureProperty")]
 pub enum TopLevelCityObject {
     //
@@ -309,7 +308,7 @@ pub enum TopLevelCityObject {
     #[citygml(path = b"urf:TideFacility")]
     TideFacility(urf::TideFacility),
     #[citygml(path = b"urf:TrafficFacility")]
-    TrafficFacility(urf::TrafficFacility),
+    TrafficFacility(Box<urf::TrafficFacility>),
     #[citygml(path = b"urf:TreatmentFacility")]
     TreatmentFacility(urf::TreatmentFacility),
     #[citygml(path = b"urf:TreePlantingDistrict")]

--- a/nusamai/src/sink/cesiumtiles/gltf.rs
+++ b/nusamai/src/sink/cesiumtiles/gltf.rs
@@ -17,6 +17,7 @@ pub struct PrimitiveInfo {
 
 pub type Primitives = HashMap<material::Material, PrimitiveInfo>;
 
+#[allow(clippy::too_many_arguments)]
 pub fn write_gltf_glb<W: Write>(
     feedback: &feedback::Feedback,
     writer: W,

--- a/nusamai/src/sink/cesiumtiles/mod.rs
+++ b/nusamai/src/sink/cesiumtiles/mod.rs
@@ -95,6 +95,15 @@ impl DataSinkProvider for CesiumTilesSinkProvider {
             },
         });
         params.define(limit_texture_resolution_parameter(false));
+        params.define(ParameterDefinition {
+            key: "gzip".into(),
+            entry: ParameterEntry {
+                description: "gzip compress".into(),
+                required: false,
+                parameter: ParameterType::Boolean(BooleanParameter { value: Some(false) }),
+                label: Some("gzipで圧縮する".into()),
+            },
+        });
 
         params
     }
@@ -112,12 +121,14 @@ impl DataSinkProvider for CesiumTilesSinkProvider {
         let max_z = get_parameter_value!(params, "max_z", Integer).unwrap() as u8;
         let limit_texture_resolution =
             *get_parameter_value!(params, "limit_texture_resolution", Boolean);
+        let gzip_compress = *get_parameter_value!(params, "gzip", Boolean);
         let transform_settings = self.transformer_options();
 
         Box::<CesiumTilesSink>::new(CesiumTilesSink {
             output_path: output_path.as_ref().unwrap().into(),
             transform_settings,
             limit_texture_resolution,
+            gzip_compress,
             min_z,
             max_z,
         })
@@ -128,6 +139,7 @@ struct CesiumTilesSink {
     output_path: PathBuf,
     transform_settings: TransformerRegistry,
     limit_texture_resolution: Option<bool>,
+    gzip_compress: Option<bool>,
     min_z: u8,
     max_z: u8,
 }
@@ -157,6 +169,7 @@ impl DataSink for CesiumTilesSink {
         let max_zoom = self.max_z;
 
         let limit_texture_resolution = self.limit_texture_resolution;
+        let gzip_compress = self.gzip_compress;
 
         // TODO: refactoring
 
@@ -205,6 +218,7 @@ impl DataSink for CesiumTilesSink {
                             tile_id_conv,
                             schema,
                             limit_texture_resolution,
+                            gzip_compress,
                         ) {
                             feedback.fatal_error(error);
                         }
@@ -327,6 +341,7 @@ fn tile_writing_stage(
     tile_id_conv: TileIdMethod,
     schema: &Schema,
     limit_texture_resolution: Option<bool>,
+    gzip_compress: Option<bool>,
 ) -> Result<()> {
     let ellipsoid = nusamai_projection::ellipsoid::wgs84();
     let contents: Arc<Mutex<Vec<TileContent>>> = Default::default();
@@ -707,6 +722,7 @@ fn tile_writing_stage(
                 primitives,
                 features.len(),
                 metadata_encoder,
+                gzip_compress.unwrap_or_default(),
             )?;
 
             Ok::<(), PipelineError>(())

--- a/nusamai/src/sink/option.rs
+++ b/nusamai/src/sink/option.rs
@@ -26,7 +26,7 @@ pub fn limit_texture_resolution_parameter(default_value: bool) -> ParameterDefin
             parameter: ParameterType::Boolean(BooleanParameter {
                 value: Some(default_value),
             }),
-            label: Some("距離(メートル)あたりのテクスチャの解像度を制限する".into()),
+            label: Some("距離あたりの解像度を制限する".into()),
         },
     }
 }


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #665

### What I did（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- どのような変更をしますか？ 目的は？ -->

- gzipで圧縮するオプションを追加した
- 拡張子は変更なしで「.glb」のまま
- そのままではCesiumで読み込めない（配信サーバーでヘッダーを付与する必要がある）ことをマニュアルに追記する必要がある

### Notes（連絡事項）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら手順を簡単に伝えてください。そのほか連絡事項など。 -->

None / なし
