### PR TITLE
地下街モデルのthematicSrcDescのスキーマを追加

### DIFF
--- a/nusamai-plateau/src/models/iur/uro/common.rs
+++ b/nusamai-plateau/src/models/iur/uro/common.rs
@@ -99,6 +99,9 @@ pub struct BuildingDataQualityAttribute {
 
     #[citygml(path = b"uro:lodType")]
     pub lod_type: Vec<Code>,
+
+    #[citygml(path = b"uro:thematicSrcDesc")]
+    pub thematic_src_desc: Vec<Code>,
 }
 
 #[citygml_data(name = "uro:PublicSurveyDataQualityAttribute")]


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #0

### What I did（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- どのような変更をしますか？ 目的は？ -->

- 新宿区の地下街モデル変換時にスキーマが不足していたため対応

`13104_shinjuku-ku_city_2023_citygml_1_op/udx/ubld/53394536_ubld_6697.gml`

![image](https://github.com/user-attachments/assets/0507da9b-01d1-490c-ae00-a16fba9eb2b8)


### Notes（連絡事項）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら手順を簡単に伝えてください。そのほか連絡事項など。 -->

None / なし
