### PR TITLE
chore(gpkg): .gpkg-wal や .gpkg-shm が残らないようにする

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,15 @@ jobs:
         run: mkdir -p app/build
       - name: Test
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info --all-features
+        env:
+          GPKG_TEST_OUTPUT_DIR: /tmp/gpkg_test
+      - name: Validate GeoPackage
+        run: |
+          # check if the output has no WAL/SHM sidecars
+          if ls /tmp/gpkg_test/*-wal /tmp/gpkg_test/*-shm 2>/dev/null; then
+            echo "::error::GeoPackage sidecar files (-wal/-shm) found. Ensure GpkgHandler::close() is called."
+            exit 1
+          fi
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v6
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,8 +52,8 @@ jobs:
       - name: Validate GeoPackage
         run: |
           # check if the output has no WAL/SHM sidecars
-          if ls /tmp/gpkg_test/*-wal /tmp/gpkg_test/*-shm 2>/dev/null; then
-            echo "::error::GeoPackage sidecar files (-wal/-shm) found. Ensure GpkgHandler::close() is called."
+          if find /tmp/gpkg_test -maxdepth 1 \( -name '*-wal' -o -name '*-shm' \) -print -quit | grep -q .; then
+            echo "::error::GeoPackage sidecar files (-wal/-shm) found. Ensure GpkgHandler::finalize() is called."
             exit 1
           fi
       - name: Upload coverage reports to Codecov

--- a/nusamai-citygml/macros/src/derive.rs
+++ b/nusamai-citygml/macros/src/derive.rs
@@ -167,11 +167,9 @@ fn generate_citygml_impl_for_struct(
                         b"tran" => {
                             add_arm( 0, b"lod0Network", "MultiCurve");
                         }
-                        b"uro" => {
-                            if typename.as_str() == "uro:RailwayTrackAttribute" {
-                                add_arm(2, b"lod2Network", "MultiCurve");
-                                add_arm(3, b"lod3Network", "MultiCurve");
-                            }
+                        b"uro" if typename.as_str() == "uro:RailwayTrackAttribute" => {
+                            add_arm(2, b"lod2Network", "MultiCurve");
+                            add_arm(3, b"lod3Network", "MultiCurve");
                         }
                         b"wtr" => {
                             add_arm( 2, b"lod2Surface", "Surface");

--- a/nusamai-gpkg/src/handler.rs
+++ b/nusamai-gpkg/src/handler.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use indexmap::IndexMap;
-use sqlx::{sqlite::*, Acquire, ConnectOptions, Pool, Row};
+use sqlx::{sqlite::*, Acquire, ConnectOptions, Connection, Pool, Row};
 use thiserror::Error;
 use url::Url;
 
@@ -32,12 +32,7 @@ impl GpkgHandler {
             .create_if_missing(true)
             .synchronous(SqliteSynchronous::Normal)
             .journal_mode(SqliteJournalMode::Wal);
-        // Use a single connection so that `finalize()` can reliably switch the
-        // journal mode away from WAL on the same connection that holds it.
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect_with(conn_opts)
-            .await?;
+        let pool = SqlitePoolOptions::new().connect_with(conn_opts).await?;
 
         // Initialize the database with minimum GeoPackage schema
         let create_query = include_str!("sql/init.sql");
@@ -188,11 +183,20 @@ impl GpkgHandler {
     /// `-wal` and `-shm` sidecar files and makes the `.gpkg` a single
     /// self-contained file. Call this after all writes are done and before
     /// handing the file to external tools (e.g. `gdal driver gpkg validate`).
-    pub async fn finalize(&self) {
-        sqlx::query("PRAGMA journal_mode=DELETE;")
-            .execute(&self.pool)
-            .await
-            .ok();
+    ///
+    /// Changing the journal mode requires exclusive access to the database, so
+    /// the pool is closed first to release all connections, then a fresh
+    /// connection is opened to perform the switch.
+    pub async fn finalize(self) {
+        let opts = self.pool.connect_options();
+        self.pool.close().await;
+
+        if let Ok(mut conn) = SqliteConnection::connect_with(&opts).await {
+            sqlx::query("PRAGMA journal_mode=DELETE;")
+                .execute(&mut conn)
+                .await
+                .ok();
+        }
     }
 }
 

--- a/nusamai-gpkg/src/handler.rs
+++ b/nusamai-gpkg/src/handler.rs
@@ -176,6 +176,22 @@ impl GpkgHandler {
     pub async fn begin(&mut self) -> Result<GpkgTransaction<'_>, GpkgError> {
         Ok(GpkgTransaction::new(self.pool.begin().await?))
     }
+
+    /// Close the database connection pool.
+    ///
+    /// This checkpoints the WAL journal into the main database file and then
+    /// shuts down the pool, ensuring the `.gpkg` file is self-contained.
+    /// Required before external validation tools (e.g. `gdal driver gpkg validate`)
+    /// can read the file.
+    pub async fn close(self) {
+        // Switch from WAL to DELETE journal mode so that the -wal and -shm
+        // sidecar files are removed and the .gpkg file is fully self-contained.
+        sqlx::query("PRAGMA journal_mode=DELETE;")
+            .execute(&self.pool)
+            .await
+            .ok();
+        self.pool.close().await;
+    }
 }
 
 pub struct GpkgTransaction<'c> {
@@ -343,11 +359,31 @@ mod tests {
     use super::*;
     use crate::table::ColumnInfo;
 
+    /// Create a GpkgHandler for testing.
+    ///
+    /// By default, uses an in-memory SQLite database. When the `GPKG_TEST_OUTPUT_DIR`
+    /// environment variable is set, writes a persistent `.gpkg` file to that directory
+    /// instead. This allows external tools (e.g. `gdal driver gpkg validate`) to validate
+    /// the generated files on CI.
+    async fn test_handler(name: &str) -> GpkgHandler {
+        match std::env::var("GPKG_TEST_OUTPUT_DIR") {
+            Ok(dir) => {
+                let dir = std::path::Path::new(&dir);
+                std::fs::create_dir_all(dir).unwrap();
+                let path = dir.join(format!("{name}.gpkg"));
+                let _ = std::fs::remove_file(&path);
+                let conn_str = format!("file:{}", path.display());
+                GpkgHandler::from_str(&conn_str).await.unwrap()
+            }
+            Err(_) => GpkgHandler::from_url(&Url::parse("sqlite::memory:").unwrap())
+                .await
+                .unwrap(),
+        }
+    }
+
     #[tokio::test]
     async fn test_init_connect() {
-        let handler = GpkgHandler::from_url(&Url::parse("sqlite::memory:").unwrap())
-            .await
-            .unwrap();
+        let handler = test_handler("init_connect").await;
 
         let application_id = handler.application_id().await;
         assert_eq!(application_id, 1196444487);
@@ -363,13 +399,13 @@ mod tests {
                 "gpkg_spatial_ref_sys",
             ]
         );
+
+        handler.close().await;
     }
 
     #[tokio::test]
     async fn test_add_table() {
-        let mut handler = GpkgHandler::from_url(&Url::parse("sqlite::memory:").unwrap())
-            .await
-            .unwrap();
+        let mut handler = test_handler("add_table").await;
 
         let srs_id = 4326;
         let table_name = "mpoly3d";
@@ -453,13 +489,13 @@ mod tests {
                 0
             )]
         );
+
+        handler.close().await;
     }
 
     #[tokio::test]
     async fn test_add_table_no_geometry() {
-        let mut handler = GpkgHandler::from_url(&Url::parse("sqlite::memory:").unwrap())
-            .await
-            .unwrap();
+        let mut handler = test_handler("add_table_no_geometry").await;
 
         let srs_id = 4326;
         let table_name = "without_geometry";
@@ -513,13 +549,13 @@ mod tests {
         // No record in `gpkg_geometry_columns`
         let gpkg_geometry_columns = handler.gpkg_geometry_columns().await.unwrap();
         assert!(gpkg_geometry_columns.is_empty());
+
+        handler.close().await;
     }
 
     #[tokio::test]
     async fn test_insert_feature() {
-        let mut handler = GpkgHandler::from_url(&Url::parse("sqlite::memory:").unwrap())
-            .await
-            .unwrap();
+        let mut handler = test_handler("insert_feature").await;
         let mut tx: GpkgTransaction<'_> = handler.begin().await.unwrap();
 
         let srs_id = 4326;
@@ -575,13 +611,13 @@ mod tests {
         assert_eq!(row.get::<i64, &str>("attr2"), 2);
         assert_eq!(row.get::<f64, &str>("attr3"), 3.33);
         assert!(row.get::<bool, &str>("attr4"));
+
+        handler.close().await;
     }
 
     #[tokio::test]
     async fn test_insert_attribute() {
-        let mut handler = GpkgHandler::from_url(&Url::parse("sqlite::memory:").unwrap())
-            .await
-            .unwrap();
+        let mut handler = test_handler("insert_attribute").await;
         let mut tx: GpkgTransaction<'_> = handler.begin().await.unwrap();
 
         let srs_id = 4326;
@@ -634,13 +670,13 @@ mod tests {
         assert_eq!(row.get::<i64, &str>("attr2"), 2);
         assert_eq!(row.get::<f64, &str>("attr3"), 3.33);
         assert!(row.get::<bool, &str>("attr4"));
+
+        handler.close().await;
     }
 
     #[tokio::test]
     async fn test_bbox() {
-        let mut handler = GpkgHandler::from_url(&Url::parse("sqlite::memory:").unwrap())
-            .await
-            .unwrap();
+        let mut handler = test_handler("bbox").await;
 
         let srs_id = 4326;
         let table_name = "mpoly3d";
@@ -671,5 +707,7 @@ mod tests {
         assert_eq!(min_y, 222.0);
         assert_eq!(max_x, 333.0);
         assert_eq!(max_y, -444.0);
+
+        handler.close().await;
     }
 }

--- a/nusamai-gpkg/src/handler.rs
+++ b/nusamai-gpkg/src/handler.rs
@@ -192,7 +192,10 @@ impl GpkgHandler {
         self.pool.close().await;
 
         // Reopen with DELETE journal mode to remove -wal/-shm sidecar files.
-        let opts = opts.as_ref().clone().journal_mode(SqliteJournalMode::Delete);
+        let opts = opts
+            .as_ref()
+            .clone()
+            .journal_mode(SqliteJournalMode::Delete);
         let conn = SqliteConnection::connect_with(&opts).await?;
         conn.close().await?;
         Ok(())

--- a/nusamai-gpkg/src/handler.rs
+++ b/nusamai-gpkg/src/handler.rs
@@ -187,13 +187,15 @@ impl GpkgHandler {
     /// Changing the journal mode requires exclusive access to the database, so
     /// the pool is closed first to release all connections, then a fresh
     /// connection is opened to perform the switch.
-    pub async fn finalize(self) {
+    pub async fn finalize(self) -> Result<(), GpkgError> {
         let opts = self.pool.connect_options();
         self.pool.close().await;
 
         // Reopen with DELETE journal mode to remove -wal/-shm sidecar files.
         let opts = opts.as_ref().clone().journal_mode(SqliteJournalMode::Delete);
-        let _ = SqliteConnection::connect_with(&opts).await;
+        let conn = SqliteConnection::connect_with(&opts).await?;
+        conn.close().await?;
+        Ok(())
     }
 }
 
@@ -375,6 +377,8 @@ mod tests {
                 std::fs::create_dir_all(dir).unwrap();
                 let path = dir.join(format!("{name}.gpkg"));
                 let _ = std::fs::remove_file(&path);
+                let _ = std::fs::remove_file(format!("{}-wal", path.display()));
+                let _ = std::fs::remove_file(format!("{}-shm", path.display()));
                 let conn_str = format!("file:{}", path.display());
                 GpkgHandler::from_str(&conn_str).await.unwrap()
             }
@@ -403,7 +407,7 @@ mod tests {
             ]
         );
 
-        handler.finalize().await;
+        handler.finalize().await.unwrap();
     }
 
     #[tokio::test]
@@ -493,7 +497,7 @@ mod tests {
             )]
         );
 
-        handler.finalize().await;
+        handler.finalize().await.unwrap();
     }
 
     #[tokio::test]
@@ -553,7 +557,7 @@ mod tests {
         let gpkg_geometry_columns = handler.gpkg_geometry_columns().await.unwrap();
         assert!(gpkg_geometry_columns.is_empty());
 
-        handler.finalize().await;
+        handler.finalize().await.unwrap();
     }
 
     #[tokio::test]
@@ -615,7 +619,7 @@ mod tests {
         assert_eq!(row.get::<f64, &str>("attr3"), 3.33);
         assert!(row.get::<bool, &str>("attr4"));
 
-        handler.finalize().await;
+        handler.finalize().await.unwrap();
     }
 
     #[tokio::test]
@@ -674,7 +678,7 @@ mod tests {
         assert_eq!(row.get::<f64, &str>("attr3"), 3.33);
         assert!(row.get::<bool, &str>("attr4"));
 
-        handler.finalize().await;
+        handler.finalize().await.unwrap();
     }
 
     #[tokio::test]
@@ -711,6 +715,6 @@ mod tests {
         assert_eq!(max_x, 333.0);
         assert_eq!(max_y, -444.0);
 
-        handler.finalize().await;
+        handler.finalize().await.unwrap();
     }
 }

--- a/nusamai-gpkg/src/handler.rs
+++ b/nusamai-gpkg/src/handler.rs
@@ -32,7 +32,12 @@ impl GpkgHandler {
             .create_if_missing(true)
             .synchronous(SqliteSynchronous::Normal)
             .journal_mode(SqliteJournalMode::Wal);
-        let pool = SqlitePoolOptions::new().connect_with(conn_opts).await?;
+        // Use a single connection so that `finalize()` can reliably switch the
+        // journal mode away from WAL on the same connection that holds it.
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(conn_opts)
+            .await?;
 
         // Initialize the database with minimum GeoPackage schema
         let create_query = include_str!("sql/init.sql");
@@ -177,20 +182,17 @@ impl GpkgHandler {
         Ok(GpkgTransaction::new(self.pool.begin().await?))
     }
 
-    /// Close the database connection pool.
+    /// Finalize the GeoPackage file for external consumption.
     ///
-    /// This checkpoints the WAL journal into the main database file and then
-    /// shuts down the pool, ensuring the `.gpkg` file is self-contained.
-    /// Required before external validation tools (e.g. `gdal driver gpkg validate`)
-    /// can read the file.
-    pub async fn close(self) {
-        // Switch from WAL to DELETE journal mode so that the -wal and -shm
-        // sidecar files are removed and the .gpkg file is fully self-contained.
+    /// Switches the journal mode from WAL to DELETE, which removes the
+    /// `-wal` and `-shm` sidecar files and makes the `.gpkg` a single
+    /// self-contained file. Call this after all writes are done and before
+    /// handing the file to external tools (e.g. `gdal driver gpkg validate`).
+    pub async fn finalize(&self) {
         sqlx::query("PRAGMA journal_mode=DELETE;")
             .execute(&self.pool)
             .await
             .ok();
-        self.pool.close().await;
     }
 }
 
@@ -400,7 +402,7 @@ mod tests {
             ]
         );
 
-        handler.close().await;
+        handler.finalize().await;
     }
 
     #[tokio::test]
@@ -490,7 +492,7 @@ mod tests {
             )]
         );
 
-        handler.close().await;
+        handler.finalize().await;
     }
 
     #[tokio::test]
@@ -550,7 +552,7 @@ mod tests {
         let gpkg_geometry_columns = handler.gpkg_geometry_columns().await.unwrap();
         assert!(gpkg_geometry_columns.is_empty());
 
-        handler.close().await;
+        handler.finalize().await;
     }
 
     #[tokio::test]
@@ -612,7 +614,7 @@ mod tests {
         assert_eq!(row.get::<f64, &str>("attr3"), 3.33);
         assert!(row.get::<bool, &str>("attr4"));
 
-        handler.close().await;
+        handler.finalize().await;
     }
 
     #[tokio::test]
@@ -671,7 +673,7 @@ mod tests {
         assert_eq!(row.get::<f64, &str>("attr3"), 3.33);
         assert!(row.get::<bool, &str>("attr4"));
 
-        handler.close().await;
+        handler.finalize().await;
     }
 
     #[tokio::test]
@@ -708,6 +710,6 @@ mod tests {
         assert_eq!(max_x, 333.0);
         assert_eq!(max_y, -444.0);
 
-        handler.close().await;
+        handler.finalize().await;
     }
 }

--- a/nusamai-gpkg/src/handler.rs
+++ b/nusamai-gpkg/src/handler.rs
@@ -191,12 +191,9 @@ impl GpkgHandler {
         let opts = self.pool.connect_options();
         self.pool.close().await;
 
-        if let Ok(mut conn) = SqliteConnection::connect_with(&opts).await {
-            sqlx::query("PRAGMA journal_mode=DELETE;")
-                .execute(&mut conn)
-                .await
-                .ok();
-        }
+        // Reopen with DELETE journal mode to remove -wal/-shm sidecar files.
+        let opts = opts.as_ref().clone().journal_mode(SqliteJournalMode::Delete);
+        let _ = SqliteConnection::connect_with(&opts).await;
     }
 }
 

--- a/nusamai-plateau/src/appearance.rs
+++ b/nusamai-plateau/src/appearance.rs
@@ -91,7 +91,7 @@ impl AppearanceStore {
                     for tex_assoc in texture.target.drain(..) {
                         if let TextureAssociation::TexCoordList(tcl) = tex_assoc {
                             for (ring, coords) in
-                                tcl.rings.into_iter().zip(tcl.coords_list.into_iter())
+                                tcl.rings.into_iter().zip(tcl.coords_list)
                             {
                                 let coords = coords
                                     .chunks_exact(2)

--- a/nusamai/src/sink/cesiumtiles/mod.rs
+++ b/nusamai/src/sink/cesiumtiles/mod.rs
@@ -543,7 +543,7 @@ fn tile_writing_stage(
                         };
 
                         let geom_error = tiling::geometric_error(tile_zoom, tile_y);
-                        let factor = apply_downsample_factor(geom_error, downsample_scale as f32);
+                        let factor = apply_downsample_factor(geom_error, downsample_scale);
                         let downsample_factor = DownsampleFactor::new(&factor);
                         let cropped_texture = PolygonMappedTexture::new(
                             &texture_uri,

--- a/nusamai/src/sink/gpkg/mod.rs
+++ b/nusamai/src/sink/gpkg/mod.rs
@@ -254,15 +254,18 @@ impl GpkgSink {
             .await
             .map_err(|e| PipelineError::Other(e.to_string()))?;
 
-        // Switch from WAL to DELETE journal mode so that the output is a single
-        // self-contained .gpkg file without -wal/-shm sidecars.
-        handler
-            .finalize()
-            .await
-            .map_err(|e| PipelineError::Other(e.to_string()))?;
+        let producer_result = producers.await.unwrap();
 
-        match producers.await.unwrap() {
-            Ok(_) | Err(PipelineError::Canceled) => Ok(()),
+        match producer_result {
+            Ok(_) | Err(PipelineError::Canceled) => {
+                // Switch from WAL to DELETE journal mode so that the output is a single
+                // self-contained .gpkg file without -wal/-shm sidecars.
+                handler
+                    .finalize()
+                    .await
+                    .map_err(|e| PipelineError::Other(e.to_string()))?;
+                Ok(())
+            }
             error @ Err(_) => error,
         }
     }

--- a/nusamai/src/sink/gpkg/mod.rs
+++ b/nusamai/src/sink/gpkg/mod.rs
@@ -254,9 +254,9 @@ impl GpkgSink {
             .await
             .map_err(|e| PipelineError::Other(e.to_string()))?;
 
-        // Flush the WAL journal into the main .gpkg file so that the output is
-        // a single self-contained file without -wal/-shm sidecars.
-        handler.close().await;
+        // Switch from WAL to DELETE journal mode so that the output is a single
+        // self-contained .gpkg file without -wal/-shm sidecars.
+        handler.finalize().await;
 
         match producers.await.unwrap() {
             Ok(_) | Err(PipelineError::Canceled) => Ok(()),

--- a/nusamai/src/sink/gpkg/mod.rs
+++ b/nusamai/src/sink/gpkg/mod.rs
@@ -256,7 +256,10 @@ impl GpkgSink {
 
         // Switch from WAL to DELETE journal mode so that the output is a single
         // self-contained .gpkg file without -wal/-shm sidecars.
-        handler.finalize().await;
+        handler
+            .finalize()
+            .await
+            .map_err(|e| PipelineError::Other(e.to_string()))?;
 
         match producers.await.unwrap() {
             Ok(_) | Err(PipelineError::Canceled) => Ok(()),

--- a/nusamai/src/sink/gpkg/mod.rs
+++ b/nusamai/src/sink/gpkg/mod.rs
@@ -254,6 +254,10 @@ impl GpkgSink {
             .await
             .map_err(|e| PipelineError::Other(e.to_string()))?;
 
+        // Flush the WAL journal into the main .gpkg file so that the output is
+        // a single self-contained file without -wal/-shm sidecars.
+        handler.close().await;
+
         match producers.await.unwrap() {
             Ok(_) | Err(PipelineError::Canceled) => Ok(()),
             error @ Err(_) => error,


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #0

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

Gpkg への変換で、`.gpkg-wal` や `.gpkg-shm` といった拡張子を持ったファイルができていることがあります。
これは、journal mode を WAL にしているので当然なのですが、最後に journal mode を `DELETE` にすると `.gpkg` に全てのデータをコミットして消えるようです。

https://github.com/MIERUNE/plateau-gis-converter/blob/3384680b7eb12797c8f3e35b2d2149b82b7828fa/nusamai-gpkg/src/handler.rs#L34

ただし、WAL journal mode で開いているコネクションがひとつでも残っている状態では journal mode を変更できません。このため、一度 connection pool を閉じて、新しくコネクションを開き直します。

`Drop` trait として実装したりできればよかったんですが、async である `.close()` を呼び出せなくてむりみたいです。


### Notes
<!-- If manual testing is required, please describe the procedure. -->

