### PR TITLE
fix: GeoJSONのGeometryCollectionを明示的に拒否する

### DIFF
--- a/nusamai/src/source/geojson.rs
+++ b/nusamai/src/source/geojson.rs
@@ -29,6 +29,8 @@ mod schema;
 const GEOJSON_TYPENAME: &str = "geojson:Feature";
 const DIRECT_GEOMETRY_ERROR: &str =
     "Direct geometry is not supported. Please use Feature or FeatureCollection.";
+const GEOMETRY_COLLECTION_ERROR: &str =
+    "GeoJSON GeometryCollection is not supported. Please use separate Features for each geometry.";
 
 pub struct GeoJsonSourceProvider {
     pub filenames: Vec<PathBuf>,
@@ -358,11 +360,8 @@ fn convert_geometry(
                 });
             }
         }
-        GeometryCollection(geometries) => {
-            for geom in geometries {
-                let sub_refs = convert_geometry(geom, geometry_store)?;
-                refs.extend(sub_refs);
-            }
+        GeometryCollection(_) => {
+            return Err(PipelineError::Other(GEOMETRY_COLLECTION_ERROR.to_owned()));
         }
     }
 


### PR DESCRIPTION
## 概要

GeoJSON Sourceで`GeometryCollection`を再帰展開せず、明示的な非対応エラーとして拒否するよう変更します。

## 背景

`GeometryCollection`を受け入れると、1つの入力Featureから複数のgeometry familyを持つEntityが生成され、Sinkごとに分割・無視・エラーなど挙動が分かれます。GeoJSON Sourceの対応範囲を単一familyのgeometryに限定し、曖昧な変換を防ぎます。

## 変更内容

- `GeometryCollection`を検出した場合に`PipelineError::Other`を返す
- エラーメッセージで、geometryごとに別Featureを使用するよう案内する
- FeatureCollection内でFeatureごとに異なるgeometry typeを持つ入力には影響しない

## 影響

これまで再帰的に展開されていた`GeometryCollection`入力は、明示的な非対応エラーになります。

## 確認

- `cargo fmt --check`
- `git diff --check`
- 依頼範囲に従い、テストの追加・実行は行っていません