### PR TITLE
feat: ベクタータイルのPoint・LineString出力に対応する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8319,11 +8319,11 @@ dependencies = [
 
 [[package]]
 name = "tinymvt"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa8879764a11e1dfe9b88eeb42dc6d7078bf25809129da6444190ee41b628a4"
+checksum = "acce6e20ffc2791c892da973076117815f2aad9a79601190f5ca196241e552ba"
 dependencies = [
- "foldhash 0.1.5",
+ "foldhash 0.2.0",
  "indexmap 2.13.0",
  "prost",
  "prost-build",

--- a/nusamai/Cargo.toml
+++ b/nusamai/Cargo.toml
@@ -22,7 +22,7 @@ cesiumtiles = { git = "https://github.com/MIERUNE/cesiumtiles-rs.git" }
 flatgeom = { version = "0.0", features = ["serde"] }
 nusamai-czml = { path = "../nusamai-czml" }
 nusamai-projection = { path = "../nusamai-projection" }
-tinymvt = "0.2.4"
+tinymvt = "0.3.0"
 mlt-core = "0.12.0"
 fastanvil = "0.32.0"
 fastnbt = "2.6.0"

--- a/nusamai/src/sink/mlt/encode.rs
+++ b/nusamai/src/sink/mlt/encode.rs
@@ -2,7 +2,9 @@ use std::collections::BTreeMap;
 
 use mlt_core::{
     encoder::EncoderConfig,
-    geo_types::{Coord, Geometry, LineString, MultiPolygon, Polygon},
+    geo_types::{
+        Coord, Geometry, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
+    },
     PropKind, PropValue, TileLayer,
 };
 use nusamai_citygml::{
@@ -14,8 +16,8 @@ use nusamai_citygml::{
 use crate::{
     pipeline::{PipelineError, Result},
     sink::vector_tile::{
-        geometry::{quantize_polygons, QuantizedPolygon},
-        model::{hash_feature_id, SlicedFeature},
+        feature::{hash_feature_id, SlicedFeature, SlicedGeometry},
+        geometry::{quantize_linestrings, quantize_points, quantize_polygons, QuantizedPolygon},
         TileEncoder,
     },
 };
@@ -89,7 +91,7 @@ impl MltPropertyValue {
 }
 
 impl TileEncoder for MltTileEncoder<'_> {
-    fn encode_tile(&self, detail: i32, serialized_features: &[Vec<u8>]) -> Result<Vec<u8>> {
+    fn encode_tile(&self, detail: i32, serialized_features: &[Vec<u8>]) -> Result<Option<Vec<u8>>> {
         let mut layers: BTreeMap<String, LayerData> = BTreeMap::new();
         let extent = 1_i32 << detail;
         let bincode_config = bincode::config::standard();
@@ -129,15 +131,12 @@ impl TileEncoder for MltTileEncoder<'_> {
                     properties,
                 });
             } else {
-                layers
-                    .entry("Unknown".to_string())
-                    .or_default()
-                    .features
-                    .push(MltFeature {
-                        geometry,
-                        id: None,
-                        properties: BTreeMap::new(),
-                    });
+                let layer = layers.entry("Unknown".to_string()).or_default();
+                layer.features.push(MltFeature {
+                    geometry,
+                    id: None,
+                    properties: BTreeMap::new(),
+                });
             }
         }
 
@@ -148,7 +147,11 @@ impl TileEncoder for MltTileEncoder<'_> {
             }
             tile.extend(encode_layer(name, layer_data, extent as u32)?);
         }
-        Ok(tile)
+        if tile.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(tile))
+        }
     }
 }
 
@@ -199,28 +202,42 @@ fn encode_layer(name: String, layer_data: LayerData, extent: u32) -> Result<Vec<
         .map_err(|error| PipelineError::Other(format!("Failed to encode MLT layer: {error:?}")))
 }
 
-fn make_geometry(multipolygon: &flatgeom::MultiPolygon2, extent: i32) -> Option<Geometry<i32>> {
-    let polygons = quantize_polygons(multipolygon, extent)
-        .into_iter()
-        .map(|polygon| {
-            let QuantizedPolygon {
-                exterior,
-                interiors,
-            } = polygon;
-            Polygon::new(
-                to_linestring(&exterior),
-                interiors
-                    .into_iter()
-                    .map(|ring| to_linestring(&ring))
-                    .collect(),
-            )
-        })
-        .collect::<Vec<_>>();
-
-    (!polygons.is_empty()).then_some(Geometry::MultiPolygon(MultiPolygon(polygons)))
+fn make_geometry(geometry: &SlicedGeometry, extent: i32) -> Option<Geometry<i32>> {
+    match geometry {
+        SlicedGeometry::Point(points) => {
+            let points = quantize_points(points, extent)
+                .into_iter()
+                .map(|[x, y]| Point::new(x, y))
+                .collect::<Vec<_>>();
+            (!points.is_empty()).then_some(Geometry::MultiPoint(MultiPoint(points)))
+        }
+        SlicedGeometry::LineString(lines) => {
+            let lines = quantize_linestrings(lines, extent)
+                .into_iter()
+                .map(|line| to_open_linestring(&line))
+                .collect::<Vec<_>>();
+            (!lines.is_empty()).then_some(Geometry::MultiLineString(MultiLineString(lines)))
+        }
+        SlicedGeometry::Polygon(polygons) => {
+            let polygons = quantize_polygons(polygons, extent)
+                .into_iter()
+                .map(|polygon| {
+                    let QuantizedPolygon {
+                        exterior,
+                        interiors,
+                    } = polygon;
+                    Polygon::new(
+                        to_ring(&exterior),
+                        interiors.into_iter().map(|ring| to_ring(&ring)).collect(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            (!polygons.is_empty()).then_some(Geometry::MultiPolygon(MultiPolygon(polygons)))
+        }
+    }
 }
 
-fn to_linestring(ring: &[[i32; 2]]) -> LineString<i32> {
+fn to_ring(ring: &[[i32; 2]]) -> LineString<i32> {
     let mut coordinates = ring
         .iter()
         .map(|[x, y]| Coord { x: *x, y: *y })
@@ -231,6 +248,10 @@ fn to_linestring(ring: &[[i32; 2]]) -> LineString<i32> {
         }
     }
     LineString(coordinates)
+}
+
+fn to_open_linestring(line: &[[i32; 2]]) -> LineString<i32> {
+    LineString(line.iter().map(|[x, y]| Coord { x: *x, y: *y }).collect())
 }
 
 fn exact_i64_to_f64(value: i64) -> Option<f64> {

--- a/nusamai/src/sink/mvt/encode.rs
+++ b/nusamai/src/sink/mvt/encode.rs
@@ -6,8 +6,8 @@ use tinymvt::{geometry::GeometryEncoder, tag::TagsEncoder, vector_tile};
 use crate::{
     pipeline::{PipelineError, Result},
     sink::vector_tile::{
-        geometry::quantize_polygons,
-        model::{hash_feature_id, SlicedFeature},
+        feature::{hash_feature_id, SlicedFeature, SlicedGeometry},
+        geometry::{quantize_linestrings, quantize_points, quantize_polygons},
         TileEncoder,
     },
 };
@@ -45,7 +45,7 @@ struct LayerData {
 }
 
 impl TileEncoder for MvtTileEncoder {
-    fn encode_tile(&self, detail: i32, serialized_features: &[Vec<u8>]) -> Result<Vec<u8>> {
+    fn encode_tile(&self, detail: i32, serialized_features: &[Vec<u8>]) -> Result<Option<Vec<u8>>> {
         let mut layers: HashMap<String, LayerData> = HashMap::new();
         let extent = 1_i32 << detail;
         let bincode_config = bincode::config::standard();
@@ -59,23 +59,9 @@ impl TileEncoder for MvtTileEncoder {
                 PipelineError::Other(format!("Failed to deserialize a sliced feature: {error:?}"))
             })?;
 
-            let mut geometry_encoder = GeometryEncoder::new();
-            for polygon in quantize_polygons(&feature.geometry, extent) {
-                geometry_encoder.add_ring(
-                    polygon
-                        .exterior
-                        .into_iter()
-                        .map(|[x, y]| [x as i16, y as i16]),
-                );
-                for interior in polygon.interiors {
-                    geometry_encoder
-                        .add_ring(interior.into_iter().map(|[x, y]| [x as i16, y as i16]));
-                }
-            }
-            let geometry = geometry_encoder.into_vec();
-            if geometry.is_empty() {
+            let Some(encoded_geometry) = encode_geometry(&feature.geometry, extent) else {
                 continue;
-            }
+            };
 
             match &feature.properties {
                 object::Value::Object(object) => {
@@ -94,8 +80,8 @@ impl TileEncoder for MvtTileEncoder {
                     layer.features.push(vector_tile::tile::Feature {
                         id,
                         tags: layer.tags_encoder.take_tags(),
-                        r#type: Some(vector_tile::tile::GeomType::Polygon as i32),
-                        geometry,
+                        r#type: Some(encoded_geometry.geometry_type as i32),
+                        geometry: encoded_geometry.commands,
                     });
                 }
                 _ if matches!(self.profile, EncodingProfile::MvtDirectory) => {
@@ -103,15 +89,15 @@ impl TileEncoder for MvtTileEncoder {
                     layer.features.push(vector_tile::tile::Feature {
                         id: None,
                         tags: layer.tags_encoder.take_tags(),
-                        r#type: Some(vector_tile::tile::GeomType::Polygon as i32),
-                        geometry,
+                        r#type: Some(encoded_geometry.geometry_type as i32),
+                        geometry: encoded_geometry.commands,
                     });
                 }
                 _ => {}
             }
         }
 
-        let layers = layers
+        let layers: Vec<_> = layers
             .into_iter()
             .filter_map(|(name, layer_data)| {
                 if layer_data.features.is_empty() {
@@ -129,6 +115,59 @@ impl TileEncoder for MvtTileEncoder {
             })
             .collect();
 
-        Ok(vector_tile::Tile { layers }.encode_to_vec())
+        if layers.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(vector_tile::Tile { layers }.encode_to_vec()))
+        }
     }
+}
+
+struct EncodedGeometry {
+    geometry_type: vector_tile::tile::GeomType,
+    commands: Vec<u32>,
+}
+
+fn encode_geometry(geometry: &SlicedGeometry, extent: i32) -> Option<EncodedGeometry> {
+    let (geometry_type, commands) = match geometry {
+        SlicedGeometry::Point(points) => {
+            let points = quantize_points(points, extent);
+            if points.is_empty() {
+                return None;
+            }
+            let mut encoder = GeometryEncoder::new();
+            encoder.add_points(points);
+            (vector_tile::tile::GeomType::Point, encoder.into_vec())
+        }
+        SlicedGeometry::LineString(lines) => {
+            let lines = quantize_linestrings(lines, extent);
+            if lines.is_empty() {
+                return None;
+            }
+            let mut encoder = GeometryEncoder::new();
+            for line in lines {
+                encoder.add_linestring(line);
+            }
+            (vector_tile::tile::GeomType::Linestring, encoder.into_vec())
+        }
+        SlicedGeometry::Polygon(polygons) => {
+            let polygons = quantize_polygons(polygons, extent);
+            if polygons.is_empty() {
+                return None;
+            }
+            let mut encoder = GeometryEncoder::new();
+            for polygon in polygons {
+                encoder.add_ring(polygon.exterior);
+                for interior in polygon.interiors {
+                    encoder.add_ring(interior);
+                }
+            }
+            (vector_tile::tile::GeomType::Polygon, encoder.into_vec())
+        }
+    };
+
+    (!commands.is_empty()).then_some(EncodedGeometry {
+        geometry_type,
+        commands,
+    })
 }

--- a/nusamai/src/sink/pmtiles/mod.rs
+++ b/nusamai/src/sink/pmtiles/mod.rs
@@ -226,6 +226,7 @@ fn pmtiles_writing_stage(
 
     let mut tiles = receiver_tiles.into_iter().collect::<Vec<_>>();
     if tiles.is_empty() {
+        feedback.ensure_not_canceled()?;
         return Err(PipelineError::Other("No tiles to write".to_string()));
     }
 

--- a/nusamai/src/sink/vector_tile/feature.rs
+++ b/nusamai/src/sink/vector_tile/feature.rs
@@ -1,12 +1,19 @@
-//! Intermediate data models shared by vector tile sinks.
+//! Intermediate feature representation shared by vector tile sinks.
 
-use flatgeom::MultiPolygon2;
+use flatgeom::{MultiLineString2, MultiPoint2, MultiPolygon2};
 use nusamai_citygml::object;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
+pub(crate) enum SlicedGeometry<'a> {
+    Point(MultiPoint2<'a>),
+    LineString(MultiLineString2<'a>),
+    Polygon(MultiPolygon2<'a>),
+}
+
+#[derive(Serialize, Deserialize)]
 pub(crate) struct SlicedFeature<'a> {
-    pub(crate) geometry: MultiPolygon2<'a>,
+    pub(crate) geometry: SlicedGeometry<'a>,
     pub(crate) properties: object::Value,
 }
 

--- a/nusamai/src/sink/vector_tile/geometry.rs
+++ b/nusamai/src/sink/vector_tile/geometry.rs
@@ -1,11 +1,32 @@
 //! Geometry conversion shared by vector tile encoders.
 
-use flatgeom::MultiPolygon2;
+use flatgeom::{MultiLineString2, MultiPoint2, MultiPolygon2};
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct QuantizedPolygon {
     pub(crate) exterior: Vec<[i32; 2]>,
     pub(crate) interiors: Vec<Vec<[i32; 2]>>,
+}
+
+pub(crate) fn quantize_points(multipoint: &MultiPoint2, extent: i32) -> Vec<[i32; 2]> {
+    let mut points = multipoint
+        .iter()
+        .map(|point| quantize_coordinate(point, extent))
+        .collect::<Vec<_>>();
+    points.dedup();
+    points
+}
+
+pub(crate) fn quantize_linestrings(
+    multilinestring: &MultiLineString2,
+    extent: i32,
+) -> Vec<Vec<[i32; 2]>> {
+    multilinestring
+        .iter()
+        .filter_map(|line| {
+            simplify_linestring(line.iter().map(|point| quantize_coordinate(point, extent)))
+        })
+        .collect()
 }
 
 pub(crate) fn quantize_polygons(
@@ -47,6 +68,13 @@ pub(crate) fn quantize_polygons(
         .collect()
 }
 
+fn quantize_coordinate([x, y]: [f64; 2], extent: i32) -> [i32; 2] {
+    [
+        (x * f64::from(extent)).round() as i32,
+        (y * f64::from(extent)).round() as i32,
+    ]
+}
+
 fn simplify_ring(points: impl IntoIterator<Item = [i32; 2]>) -> Option<Vec<[i32; 2]>> {
     let points = points.into_iter().collect::<Vec<_>>();
     if points.len() < 3 {
@@ -65,6 +93,40 @@ fn simplify_ring(points: impl IntoIterator<Item = [i32; 2]>) -> Option<Vec<[i32;
     simplified.push(*points.last().unwrap());
 
     (simplified.len() >= 3).then_some(simplified)
+}
+
+fn simplify_linestring(points: impl IntoIterator<Item = [i32; 2]>) -> Option<Vec<[i32; 2]>> {
+    let mut simplified = Vec::new();
+
+    for point in points {
+        if simplified.last() == Some(&point) {
+            continue;
+        }
+
+        while simplified.len() >= 2 {
+            let previous = simplified[simplified.len() - 2];
+            let current = simplified[simplified.len() - 1];
+            if !is_forward_collinear(previous, current, point) {
+                break;
+            }
+            simplified.pop();
+        }
+
+        simplified.push(point);
+    }
+
+    (simplified.len() >= 2).then_some(simplified)
+}
+
+fn is_forward_collinear(previous: [i32; 2], current: [i32; 2], next: [i32; 2]) -> bool {
+    let [ax, ay] = previous.map(i128::from);
+    let [bx, by] = current.map(i128::from);
+    let [cx, cy] = next.map(i128::from);
+    let ab = [bx - ax, by - ay];
+    let bc = [cx - bx, cy - by];
+    let cross = ab[0] * bc[1] - ab[1] * bc[0];
+    let dot = ab[0] * bc[0] + ab[1] * bc[1];
+    cross == 0 && dot >= 0
 }
 
 fn is_collinear(previous: [i32; 2], current: [i32; 2], next: [i32; 2]) -> bool {
@@ -87,26 +149,4 @@ pub(crate) fn signed_ring_area2(ring: &[[i32; 2]]) -> i64 {
             (i64::from(*x1) * i64::from(*y2)) - (i64::from(*x2) * i64::from(*y1))
         })
         .sum()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{signed_ring_area2, simplify_ring};
-
-    #[test]
-    fn ring_simplification_removes_duplicates_and_collinear_points() {
-        let ring = simplify_ring([[0, 0], [0, 0], [1, 0], [2, 0], [2, 2], [0, 2]])
-            .expect("ring should remain valid");
-
-        assert_eq!(ring, vec![[0, 0], [2, 0], [2, 2], [0, 2]]);
-        assert!(signed_ring_area2(&ring) > 0);
-    }
-
-    #[test]
-    fn duplicate_next_point_is_not_treated_as_collinear() {
-        let ring = simplify_ring([[0, 0], [2, 0], [2, 0], [2, 2], [0, 2]])
-            .expect("ring should remain valid");
-
-        assert_eq!(ring, vec![[0, 0], [2, 0], [2, 2], [0, 2]]);
-    }
 }

--- a/nusamai/src/sink/vector_tile/mod.rs
+++ b/nusamai/src/sink/vector_tile/mod.rs
@@ -1,7 +1,7 @@
 //! Shared processing primitives for vector tile sinks.
 
+pub(crate) mod feature;
 pub(crate) mod geometry;
-pub(crate) mod model;
 pub(crate) mod pipeline;
 pub(crate) mod slice;
 pub(crate) mod sort;

--- a/nusamai/src/sink/vector_tile/pipeline.rs
+++ b/nusamai/src/sink/vector_tile/pipeline.rs
@@ -8,7 +8,7 @@ use rayon::prelude::*;
 use crate::pipeline::{Feedback, PipelineError, Receiver, Result};
 
 use super::{
-    model::SlicedFeature,
+    feature::SlicedFeature,
     slice::slice_cityobj_geoms,
     sort::{feature_sorting_stage, SerializedFeature, SortedTileFeatures},
     tile_id::TileIdMethod,
@@ -30,7 +30,7 @@ pub(crate) struct TilePipelineOptions {
 }
 
 pub(crate) trait TileEncoder: Sync {
-    fn encode_tile(&self, detail: i32, serialized_features: &[Vec<u8>]) -> Result<Vec<u8>>;
+    fn encode_tile(&self, detail: i32, serialized_features: &[Vec<u8>]) -> Result<Option<Vec<u8>>>;
 }
 
 pub(crate) struct EncodedTile {
@@ -57,11 +57,11 @@ pub(crate) fn slice_stage(
             options.max_z,
             DEFAULT_DETAIL as u32,
             SLICE_BUFFER_PIXELS,
-            |(z, x, y), multipolygon| {
+            |(z, x, y), geometry| {
                 feedback.ensure_not_canceled()?;
 
                 let feature = SlicedFeature {
-                    geometry: multipolygon,
+                    geometry,
                     properties: parcel.entity.root.clone(),
                 };
                 let bytes = bincode::serde::encode_to_vec(&feature, bincode_config).unwrap();
@@ -86,10 +86,10 @@ where
     E: TileEncoder,
     C: Fn(EncodedTile) -> Result<()> + Sync,
 {
-    receiver_sorted
+    let has_generated_tile = receiver_sorted
         .into_iter()
         .par_bridge()
-        .try_for_each(|(tile_id, serialized_features)| {
+        .map(|(tile_id, serialized_features)| -> Result<bool> {
             feedback.ensure_not_canceled()?;
             let zxy = tile_id_method.id_to_zxy(tile_id);
 
@@ -102,7 +102,9 @@ where
 
             for detail in (MINIMUM_DETAIL..=DEFAULT_DETAIL).rev() {
                 feedback.ensure_not_canceled()?;
-                let bytes = encoder.encode_tile(detail, &serialized_features)?;
+                let Some(bytes) = encoder.encode_tile(detail, &serialized_features)? else {
+                    return Ok(false);
+                };
                 let zlib_size = compressed_size(&bytes)?;
 
                 if detail != MINIMUM_DETAIL && zlib_size > max_compressed_tile_size {
@@ -121,11 +123,20 @@ where
                     bytes,
                     zlib_size,
                 })?;
-                break;
+                return Ok(true);
             }
 
-            Ok::<(), PipelineError>(())
+            Ok(false)
         })
+        .try_reduce(|| false, |generated, current| Ok(generated || current))?;
+
+    if has_generated_tile {
+        Ok(())
+    } else {
+        Err(PipelineError::Other(
+            "No vector tiles could be generated from the input geometries".to_string(),
+        ))
+    }
 }
 
 /// Runs the standard vector tile pipeline and writes each tile to `{z}/{x}/{y}.{extension}`.

--- a/nusamai/src/sink/vector_tile/slice.rs
+++ b/nusamai/src/sink/vector_tile/slice.rs
@@ -1,13 +1,58 @@
-//! Vector tile polygon slicing based on [geojson-vt](https://github.com/mapbox/geojson-vt).
+//! Vector tile geometry slicing based on [geojson-vt](https://github.com/mapbox/geojson-vt).
 
-use flatgeom::{LineString2, MultiPolygon2, Polygon2};
+use flatgeom::{LineString2, MultiLineString2, MultiPoint2, MultiPolygon2, Polygon2};
 use hashbrown::HashMap;
 use nusamai_citygml::{
     geometry::GeometryType,
     object::{ObjectStereotype, Value},
+    GeometryRef,
 };
 use nusamai_plateau::Entity;
 use tinymvt::{webmercator::lnglat_to_web_mercator, TileZXY};
+
+use crate::pipeline::PipelineError;
+
+use super::feature::SlicedGeometry;
+
+type TileKey = (u8, u32, u32);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum VectorTileGeometryType {
+    Point,
+    LineString,
+    Polygon,
+}
+
+impl From<GeometryType> for VectorTileGeometryType {
+    fn from(geometry_type: GeometryType) -> Self {
+        match geometry_type {
+            GeometryType::Point => Self::Point,
+            GeometryType::Curve => Self::LineString,
+            GeometryType::Solid | GeometryType::Surface | GeometryType::Triangle => Self::Polygon,
+        }
+    }
+}
+
+fn resolve_vector_tile_geometry_type(
+    geometries: &[GeometryRef],
+) -> Result<Option<VectorTileGeometryType>, PipelineError> {
+    let mut resolved = None;
+
+    for geometry in geometries {
+        let current = VectorTileGeometryType::from(geometry.ty);
+        match resolved {
+            Some(previous) if previous != current => {
+                return Err(PipelineError::Other(format!(
+                    "A vector tile feature must contain one geometry type, but found {previous:?} and {current:?}"
+                )));
+            }
+            Some(_) => {}
+            None => resolved = Some(current),
+        }
+    }
+
+    Ok(resolved)
+}
 
 pub(crate) fn validate_zoom_range(min_z: u8, max_z: u8) {
     assert!(
@@ -16,84 +61,315 @@ pub(crate) fn validate_zoom_range(min_z: u8, max_z: u8) {
     );
 }
 
-pub fn slice_cityobj_geoms<E>(
+pub(crate) fn slice_cityobj_geoms(
     obj: &Entity,
     min_z: u8,
     max_z: u8,
     max_detail: u32,
     buffer_pixels: u32,
-    f: impl Fn(TileZXY, MultiPolygon2) -> Result<(), E>,
-) -> Result<(), E> {
+    f: impl Fn(TileZXY, SlicedGeometry) -> Result<(), PipelineError>,
+) -> Result<(), PipelineError> {
     validate_zoom_range(min_z, max_z);
 
-    let geom_store = obj.geometry_store.read().unwrap();
-    if geom_store.multipolygon.is_empty() {
-        return Ok(());
-    }
-
-    let mut tiled_mpolys = HashMap::new();
-
-    let extent = 1 << max_detail;
+    let extent = 1_u32 << max_detail;
     let buffer = extent * buffer_pixels / 256;
 
-    let Value::Object(obj) = &obj.root else {
+    let Value::Object(root_object) = &obj.root else {
         return Ok(());
     };
-    let ObjectStereotype::Feature { geometries, .. } = &obj.stereotype else {
+    let ObjectStereotype::Feature { geometries, .. } = &root_object.stereotype else {
         return Ok(());
     };
 
-    geometries.iter().for_each(|entry| match entry.ty {
-        GeometryType::Solid | GeometryType::Surface | GeometryType::Triangle => {
-            for idx_poly in geom_store
-                .multipolygon
-                .iter_range(entry.pos as usize..(entry.pos + entry.len) as usize)
-            {
-                let poly = idx_poly.transform(|c| {
-                    let [lng, lat, _height] = geom_store.vertices[*c as usize];
-                    let (mx, my) = lnglat_to_web_mercator(lng, lat);
-                    [mx, my]
-                });
+    let Some(geometry_type) = resolve_vector_tile_geometry_type(geometries).map_err(|error| {
+        let feature_id = root_object.stereotype.id().unwrap_or("<unknown>");
+        PipelineError::Other(format!(
+            "Failed to slice vector tile feature '{feature_id}': {error}"
+        ))
+    })?
+    else {
+        return Ok(());
+    };
 
-                // Early rejection of polygons that are not front-facing.
-                if !poly.exterior().is_cw() {
-                    continue;
-                }
-                debug_assert!(poly.exterior().ring_area() > 0.0);
+    let geom_store = obj.geometry_store.read().unwrap();
 
-                let area = poly.area();
+    match geometry_type {
+        VectorTileGeometryType::Point => {
+            let mut tiled_points: HashMap<TileKey, MultiPoint2> = HashMap::new();
+            for entry in geometries {
+                for index in geom_store
+                    .multipoint
+                    .iter_range(entry.pos as usize..(entry.pos + entry.len) as usize)
+                {
+                    let [longitude, latitude, _height] = geom_store.vertices[index as usize];
+                    let (x, y) = lnglat_to_web_mercator(longitude, latitude);
 
-                // Slice for each zoom level
-                for zoom in min_z..=max_z {
-                    // Skip if the polygon is smaller than 4 square subpixels
-                    //
-                    // TODO: emulate the 'tiny-polygon-reduction' of tippecanoe
-                    if area * (4u64.pow(zoom as u32 + max_detail) as f64) < 4.0 {
-                        continue;
+                    for zoom in min_z..=max_z {
+                        slice_point(zoom, extent, buffer, [x, y], &mut tiled_points);
                     }
+                }
+            }
 
-                    slice_polygon(zoom, extent, buffer, &poly, &mut tiled_mpolys);
+            for ((z, x, y), points) in tiled_points {
+                if !points.is_empty() {
+                    f((z, x, y), SlicedGeometry::Point(points))?;
                 }
             }
         }
-        GeometryType::Curve => {
-            // TODO: implement
-        }
-        GeometryType::Point => {
-            // TODO: implement
-        }
-    });
+        VectorTileGeometryType::LineString => {
+            let mut tiled_lines: HashMap<TileKey, MultiLineString2> = HashMap::new();
+            for entry in geometries {
+                for indexed_line in geom_store
+                    .multilinestring
+                    .iter_range(entry.pos as usize..(entry.pos + entry.len) as usize)
+                {
+                    let line = indexed_line.transform(|index| {
+                        let [longitude, latitude, _height] = geom_store.vertices[*index as usize];
+                        let (x, y) = lnglat_to_web_mercator(longitude, latitude);
+                        [x, y]
+                    });
 
-    for ((z, x, y), mpoly) in tiled_mpolys {
-        if mpoly.is_empty() {
-            continue;
+                    for zoom in min_z..=max_z {
+                        slice_linestring(zoom, extent, buffer, line.raw_coords(), &mut tiled_lines);
+                    }
+                }
+            }
+
+            for ((z, x, y), lines) in tiled_lines {
+                if !lines.is_empty() {
+                    f((z, x, y), SlicedGeometry::LineString(lines))?;
+                }
+            }
         }
-        f((z, x, y), mpoly)?;
+        VectorTileGeometryType::Polygon => {
+            let mut tiled_polygons: HashMap<TileKey, MultiPolygon2> = HashMap::new();
+            for entry in geometries {
+                for indexed_polygon in geom_store
+                    .multipolygon
+                    .iter_range(entry.pos as usize..(entry.pos + entry.len) as usize)
+                {
+                    let polygon = indexed_polygon.transform(|coordinate| {
+                        let [longitude, latitude, _height] =
+                            geom_store.vertices[*coordinate as usize];
+                        let (x, y) = lnglat_to_web_mercator(longitude, latitude);
+                        [x, y]
+                    });
+
+                    // Early rejection of polygons that are not front-facing.
+                    if !polygon.exterior().is_cw() {
+                        continue;
+                    }
+                    debug_assert!(polygon.exterior().ring_area() > 0.0);
+
+                    let area = polygon.area();
+                    for zoom in min_z..=max_z {
+                        // Skip if the polygon is smaller than 4 square subpixels.
+                        // TODO: emulate the 'tiny-polygon-reduction' of tippecanoe.
+                        if area * (4u64.pow(zoom as u32 + max_detail) as f64) < 4.0 {
+                            continue;
+                        }
+
+                        slice_polygon(zoom, extent, buffer, &polygon, &mut tiled_polygons);
+                    }
+                }
+            }
+
+            for ((z, x, y), polygons) in tiled_polygons {
+                if !polygons.is_empty() {
+                    f((z, x, y), SlicedGeometry::Polygon(polygons))?;
+                }
+            }
+        }
     }
 
     Ok(())
+}
 
-    // TODO: linestring, point
+fn slice_point(
+    zoom: u8,
+    extent: u32,
+    buffer: u32,
+    [x, y]: [f64; 2],
+    out: &mut HashMap<TileKey, MultiPoint2>,
+) {
+    if !x.is_finite() || !y.is_finite() {
+        return;
+    }
+
+    let tile_count = 1_i64 << zoom;
+    let scale = tile_count as f64;
+    let buffer_width = buffer as f64 / extent as f64;
+    let tile_x = x * scale;
+    let tile_y = y * scale;
+    let min_x = (tile_x - buffer_width).floor() as i64;
+    let max_x = (tile_x + buffer_width).floor() as i64;
+    let min_y = ((tile_y - buffer_width).floor() as i64).max(0);
+    let max_y = ((tile_y + buffer_width).floor() as i64).min(tile_count - 1);
+
+    if min_y > max_y {
+        return;
+    }
+
+    for yi in min_y..=max_y {
+        let local_y = tile_y - yi as f64;
+        if local_y < -buffer_width || local_y >= 1.0 + buffer_width {
+            continue;
+        }
+
+        for xi in min_x..=max_x {
+            let local_x = tile_x - xi as f64;
+            if local_x < -buffer_width || local_x >= 1.0 + buffer_width {
+                continue;
+            }
+
+            let key = (zoom, xi.rem_euclid(tile_count) as u32, yi as u32);
+            out.entry(key).or_default().push([local_x, local_y]);
+        }
+    }
+}
+
+fn slice_linestring(
+    zoom: u8,
+    extent: u32,
+    buffer: u32,
+    line: &[[f64; 2]],
+    out: &mut HashMap<TileKey, MultiLineString2>,
+) {
+    if line.len() < 2
+        || line
+            .iter()
+            .any(|point| !point[0].is_finite() || !point[1].is_finite())
+    {
+        return;
+    }
+
+    let tile_count = 1_i64 << zoom;
+    let scale = tile_count as f64;
+    let buffer_width = buffer as f64 / extent as f64;
+    let (min_x, max_x, min_y, max_y) = line.iter().fold(
+        (f64::MAX, f64::MIN, f64::MAX, f64::MIN),
+        |(min_x, max_x, min_y, max_y), [x, y]| {
+            (min_x.min(*x), max_x.max(*x), min_y.min(*y), max_y.max(*y))
+        },
+    );
+    let min_tile_x = (min_x * scale - buffer_width).floor() as i64;
+    let max_tile_x = (max_x * scale + buffer_width).floor() as i64;
+    let min_tile_y = ((min_y * scale - buffer_width).floor() as i64).max(0);
+    let max_tile_y = ((max_y * scale + buffer_width).floor() as i64).min(tile_count - 1);
+
+    if min_tile_y > max_tile_y {
+        return;
+    }
+
+    let scaled_line = line
+        .iter()
+        .map(|[x, y]| [x * scale, y * scale])
+        .collect::<Vec<_>>();
+
+    for yi in min_tile_y..=max_tile_y {
+        for xi in min_tile_x..=max_tile_x {
+            let bounds = [
+                xi as f64 - buffer_width,
+                yi as f64 - buffer_width,
+                xi as f64 + 1.0 + buffer_width,
+                yi as f64 + 1.0 + buffer_width,
+            ];
+            let fragments = clip_linestring(&scaled_line, bounds);
+            if fragments.is_empty() {
+                continue;
+            }
+
+            let key = (zoom, xi.rem_euclid(tile_count) as u32, yi as u32);
+            let tile_lines = out.entry(key).or_default();
+            for fragment in fragments {
+                let local = fragment
+                    .into_iter()
+                    .map(|[x, y]| [x - xi as f64, y - yi as f64])
+                    .collect::<Vec<_>>();
+                if local.len() >= 2 {
+                    tile_lines.add_linestring(local);
+                }
+            }
+        }
+    }
+}
+
+fn clip_linestring(line: &[[f64; 2]], bounds: [f64; 4]) -> Vec<Vec<[f64; 2]>> {
+    let mut fragments = Vec::new();
+    let mut current = Vec::new();
+
+    for segment in line.windows(2) {
+        let Some((start, end)) = clip_segment(segment[0], segment[1], bounds) else {
+            push_fragment(&mut fragments, &mut current);
+            continue;
+        };
+
+        if current.last() == Some(&start) {
+            if current.last() != Some(&end) {
+                current.push(end);
+            }
+        } else {
+            push_fragment(&mut fragments, &mut current);
+            current.push(start);
+            if start != end {
+                current.push(end);
+            }
+        }
+    }
+    push_fragment(&mut fragments, &mut current);
+
+    fragments
+}
+
+fn push_fragment(fragments: &mut Vec<Vec<[f64; 2]>>, current: &mut Vec<[f64; 2]>) {
+    if current.len() >= 2 {
+        fragments.push(std::mem::take(current));
+    } else {
+        current.clear();
+    }
+}
+
+fn clip_segment(
+    start: [f64; 2],
+    end: [f64; 2],
+    [min_x, min_y, max_x, max_y]: [f64; 4],
+) -> Option<([f64; 2], [f64; 2])> {
+    let dx = end[0] - start[0];
+    let dy = end[1] - start[1];
+    let mut enter = 0.0_f64;
+    let mut exit = 1.0_f64;
+
+    for (p, q) in [
+        (-dx, start[0] - min_x),
+        (dx, max_x - start[0]),
+        (-dy, start[1] - min_y),
+        (dy, max_y - start[1]),
+    ] {
+        if p == 0.0 {
+            if q < 0.0 {
+                return None;
+            }
+            continue;
+        }
+
+        let ratio = q / p;
+        if p < 0.0 {
+            if ratio > exit {
+                return None;
+            }
+            enter = enter.max(ratio);
+        } else {
+            if ratio < enter {
+                return None;
+            }
+            exit = exit.min(ratio);
+        }
+    }
+
+    Some((
+        [start[0] + enter * dx, start[1] + enter * dy],
+        [start[0] + exit * dx, start[1] + exit * dy],
+    ))
 }
 
 fn slice_polygon(
@@ -101,9 +377,10 @@ fn slice_polygon(
     extent: u32,
     buffer: u32,
     poly: &Polygon2,
-    out: &mut HashMap<(u8, u32, u32), MultiPolygon2>,
+    out: &mut HashMap<TileKey, MultiPolygon2>,
 ) {
-    let z_scale = (1 << zoom) as f64;
+    let tile_count = 1_u32 << zoom;
+    let z_scale = f64::from(tile_count);
     let buf_width = buffer as f64 / extent as f64;
     let mut new_ring_buffer: Vec<[f64; 2]> = Vec::with_capacity(poly.exterior().len() + 1);
 
@@ -115,7 +392,9 @@ fn slice_polygon(
             .fold((f64::MAX, f64::MIN), |(min_y, max_y), c| {
                 (min_y.min(c[1]), max_y.max(c[1]))
             });
-        (min_y * z_scale).floor() as u32..(max_y * z_scale).ceil() as u32
+        let start = ((min_y * z_scale).floor() as i64).clamp(0, i64::from(tile_count));
+        let end = ((max_y * z_scale).ceil() as i64).clamp(0, i64::from(tile_count));
+        start as u32..end as u32
     };
 
     let mut y_sliced_polys = Vec::with_capacity(y_range.len());
@@ -195,7 +474,7 @@ fn slice_polygon(
 
             let key = (
                 zoom,
-                xi.rem_euclid(1 << zoom) as u32, // handling geometry crossing the antimeridian
+                xi.rem_euclid(tile_count as i32) as u32, // handling geometry crossing the antimeridian
                 yi,
             );
             let tile_mpoly = out.entry(key).or_default();


### PR DESCRIPTION
## 概要

MVT・MLT・PMTilesのベクタータイル出力で、従来のPolygonに加えてPointおよびLineStringを変換できるようにします。

## 背景

既存のベクタータイル処理はPolygonを前提としており、PointおよびCurve（LineString）をMVT・MLT・PMTilesへ出力できませんでした。

## 変更内容

- 共通中間型を `SlicedGeometry::{Point, LineString, Polygon}` として定義し、`SlicedFeature` が単一のジオメトリ型を保持する構造へ変更
- Pointのタイル割り当てと、LineStringのタイル境界クリッピング・バッファ処理を共通スライサーへ追加
- Point・LineString・Polygonそれぞれの量子化処理を共通化し、重複点や量子化後に退化した線・リングを除外
- MVTおよびMLTエンコーダーで各ジオメトリ型を対応するFeatureとして出力
- tinymvtを0.2.4から0.3.0へ更新し、2頂点LineStringのエンコードに対応
- PMTilesもMVT・MLTと同じ共通スライス・生成処理を利用

## 影響範囲

- MVT・MLT・PMTiles SinkのPoint・LineString・Polygon出力
- ベクタータイルのスライス、量子化、Feature ID、タイル生成処理
- Polygonの既存出力は同じ共通中間型・共通量子化処理を通る
- MVT・MLT・PMTiles以外のSinkには変更なし

## 検証方法

- `RUSTC_WRAPPER= cargo test -p nusamai`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`