### PR TITLE
fix: PMTiles生成の停止を修正しタイル処理ログをDEBUGに変更

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,6 +1410,8 @@ dependencies = [
  "compression-core",
  "flate2",
  "memchr",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -1526,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "countio"
-version = "0.2.19"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdbee2fbff35a44b492c859b1b2e32e94b631f1d3ea2831dd8393861564180e3"
+checksum = "b9702aee5d1d744c01d82f6915644f950f898e014903385464c773b96fefdecb"
 
 [[package]]
 name = "cpufeatures"
@@ -2182,6 +2195,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "exr"
 version = "1.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2513,21 +2536,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2600,7 +2608,6 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -4373,6 +4380,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5056,14 +5083,16 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.12.5"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
  "bytes",
  "chrono",
- "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "http 1.4.0",
  "humantime",
  "itertools",
@@ -5531,21 +5560,23 @@ dependencies = [
 
 [[package]]
 name = "pmtiles"
-version = "0.17.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f01c60faf873f6bbffc603c84934402fdf51d1b32624a405041524fce89da23"
+checksum = "a6e09ac346b5b6f95a70d264f6c3b148fded16b7eb41f7308c25daa19f08bd95"
 dependencies = [
  "async-compression",
  "async-stream",
  "aws-sdk-s3",
+ "brotli",
  "bytes",
  "countio",
  "fast_hilbert",
  "flate2",
  "fmmap",
  "futures-util",
+ "moka",
  "object_store",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "rust-s3",
  "serde",
  "serde_json",
@@ -5554,6 +5585,7 @@ dependencies = [
  "tokio",
  "twox-hash 2.1.2",
  "varint-rs",
+ "zstd",
 ]
 
 [[package]]
@@ -7780,6 +7812,12 @@ dependencies = [
  "toml 0.8.2",
  "version-compare",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tao"

--- a/nusamai/Cargo.toml
+++ b/nusamai/Cargo.toml
@@ -64,7 +64,7 @@ foldhash = "0.2.0"
 geocentric = "0.1.3"
 uuid = { version = "1.18.1", features = ["v4"] }
 zip = "4.6.1"
-pmtiles = "0.17.0"
+pmtiles = "0.22.0"
 
 [dev-dependencies]
 rand = "0.9.3"

--- a/nusamai/src/sink/cesiumtiles/material.rs
+++ b/nusamai/src/sink/cesiumtiles/material.rs
@@ -143,7 +143,7 @@ fn load_image(feedback: &Feedback, path: &Path) -> std::io::Result<(Vec<u8>, Mim
                 let t = Instant::now();
                 let image = image::open(path)
                     .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
-                feedback.info(format!("Image decoding took {:?}", t.elapsed()));
+                log::debug!("Image decoding took {:?}", t.elapsed());
 
                 let mut writer = std::io::Cursor::new(Vec::new());
                 let encoder = image::codecs::png::PngEncoder::new(&mut writer);

--- a/nusamai/src/sink/cesiumtiles/mod.rs
+++ b/nusamai/src/sink/cesiumtiles/mod.rs
@@ -392,10 +392,10 @@ fn tile_writing_stage(
                 };
 
                 let geom_error = tiling::geometric_error(tile_zoom, tile_y);
-                feedback.info(format!(
+                log::debug!(
                     "tile: z={tile_zoom}, x={tile_x}, y={tile_y} (lng: [{min_lng} => {max_lng}], \
                      lat: [{min_lat} => {max_lat}] geometricError: {geom_error}"
-                ));
+                );
                 let content_path = {
                     let normalized_typename = typename.replace(':', "_");
                     format!("{tile_zoom}/{tile_x}/{tile_y}_{normalized_typename}.glb")

--- a/nusamai/src/sink/pmtiles/mod.rs
+++ b/nusamai/src/sink/pmtiles/mod.rs
@@ -169,7 +169,7 @@ impl DataSink for PmTilesSink {
                             tile_id_method,
                             pipeline_options.max_compressed_tile_size,
                             &encoder,
-                            |tile| send_generated_tile(feedback, &sender_tiles, tile),
+                            |tile| send_generated_tile(&sender_tiles, tile),
                         ) {
                             feedback.fatal_error(error);
                         }
@@ -197,16 +197,15 @@ impl DataSink for PmTilesSink {
 }
 
 fn send_generated_tile(
-    feedback: &Feedback,
     sender_tiles: &mpsc::SyncSender<(u64, Vec<u8>)>,
     tile: EncodedTile,
 ) -> Result<()> {
     let (zoom, x, y) = tile.zxy;
-    feedback.info(format!(
+    log::debug!(
         "Generated tile: {zoom}/{x}/{y} ({} bytes, {} compressed)",
         bytesize::ByteSize(tile.bytes.len() as u64),
         bytesize::ByteSize(tile.zlib_size as u64),
-    ));
+    );
     sender_tiles
         .send((tile.tile_id, tile.bytes))
         .map_err(|_| PipelineError::Canceled)
@@ -300,12 +299,12 @@ fn pmtiles_writing_stage(
         .min_zoom(min_z)
         .max_zoom(max_z)
         .bounds(
-            global_min_lon as f32,
-            global_min_lat as f32,
-            global_max_lon as f32,
-            global_max_lat as f32,
+            global_min_lon,
+            global_min_lat,
+            global_max_lon,
+            global_max_lat,
         )
-        .center(center_lon as f32, center_lat as f32)
+        .center(center_lon, center_lat)
         .center_zoom(center_zoom)
         .metadata(&metadata)
         .create(file)

--- a/nusamai/src/sink/vector_tile/pipeline.rs
+++ b/nusamai/src/sink/vector_tile/pipeline.rs
@@ -182,7 +182,7 @@ where
                     tile_id_method,
                     options.max_compressed_tile_size,
                     encoder,
-                    |tile| write_vector_tile(output_path, extension, feedback, tile),
+                    |tile| write_vector_tile(output_path, extension, tile),
                 ) {
                     feedback.fatal_error(error);
                 }
@@ -199,24 +199,19 @@ fn compressed_size(bytes: &[u8]) -> Result<usize> {
     Ok(encoder.finish()?.len())
 }
 
-fn write_vector_tile(
-    output_path: &Path,
-    extension: &str,
-    feedback: &Feedback,
-    tile: EncodedTile,
-) -> Result<()> {
+fn write_vector_tile(output_path: &Path, extension: &str, tile: EncodedTile) -> Result<()> {
     let (zoom, x, y) = tile.zxy;
     let path = output_path.join(format!("{zoom}/{x}/{y}.{extension}"));
     if let Some(directory) = path.parent() {
         fs::create_dir_all(directory)?;
     }
 
-    feedback.info(format!(
+    log::debug!(
         "Writing a tile: {} ({} bytes, {} compressed)",
         path.to_string_lossy(),
         bytesize::ByteSize(tile.bytes.len() as u64),
         bytesize::ByteSize(tile.zlib_size as u64),
-    ));
+    );
     fs::write(path, tile.bytes)?;
     Ok(())
 }


### PR DESCRIPTION
## 概要

- `pmtiles` crateを0.17系から0.22.0へ更新しました
- PMTilesの`Generated tile`をGUI向け`feedback.info`から`log::debug!`へ変更しました
- MVT・MLT共通処理の`Writing a tile`も同様に`log::debug!`へ変更しました
- 3D Tilesのタイル生成詳細を`log::debug!`へ変更しました
- 3D Tilesのテクスチャ画像デコード時間を`log::debug!`へ変更しました
- `pmtiles` 0.22のAPI変更に合わせ、bounds・centerへ`f64`をそのまま渡すようにしました

## 背景・原因

大規模なGeoJSONをPMTilesへ変換すると、旧`pmtiles` writerのディレクトリ生成処理に起因して終盤で処理が進まなくなるケースがありました。この問題が修正されている0.22.0へ更新します。

また、タイル単位のメッセージを`feedback.info`へ送ると、GUIにも大量のログが転送されます。PMTiles・MVT・MLT・3D Tilesのタイル単位ログを通常のデバッグログへ移し、通常実行時のログ転送負荷を抑えます。3D Tilesでは、テクスチャ画像のデコード処理時間もDEBUGへ移します。

## 影響

- 大規模なPMTiles生成を完了できるようになります
- PMTiles・MVT・MLT・3D Tilesのタイル単位ログはDEBUGレベルでのみ出力されます
- 3D Tilesの画像デコード開始やJPEG/WebP埋め込みログは従来どおりINFOで出力されます
- 完了通知やエラーなど、パイプラインの通常フィードバックは従来どおり維持されます

## 検証

- `cargo fmt --all --check`
- `cargo test -p nusamai --all-features`
- `cargo clippy -p nusamai --all-targets --all-features -- -D warnings`
- `cargo check --workspace --all-features --locked --offline`