### PR TITLE
feat: Sink入力CRS要件を導入し固定CRSの指定を制御

### DIFF
--- a/app/.prettierignore
+++ b/app/.prettierignore
@@ -3,6 +3,7 @@ node_modules
 /build
 /.svelte-kit
 /package
+/src-tauri/gen
 .env
 .env.*
 !.env.example

--- a/app/.prettierrc
+++ b/app/.prettierrc
@@ -4,7 +4,6 @@
 	"trailingComma": "none",
 	"printWidth": 100,
 	"plugins": ["prettier-plugin-svelte", "prettier-plugin-tailwindcss"],
-	"pluginSearchDirs": ["."],
 	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }],
 	"tailwindStylesheet": "./src/app.css"
 }

--- a/app/package.json
+++ b/app/package.json
@@ -9,8 +9,8 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"test": "vitest",
-		"lint": "prettier --plugin-search-dir . --check . && eslint .",
-		"format": "prettier --plugin-search-dir . --write .",
+		"lint": "prettier --check . && eslint .",
+		"format": "prettier --write .",
 		"tauri": "tauri"
 	},
 	"type": "module",

--- a/app/src-tauri/capabilities/migrated.json
+++ b/app/src-tauri/capabilities/migrated.json
@@ -1,22 +1,20 @@
 {
-  "identifier": "migrated",
-  "description": "permissions that were migrated from v1",
-  "local": true,
-  "windows": [
-    "main"
-  ],
-  "permissions": [
-    "core:default",
-    "fs:allow-read-dir",
-    "shell:allow-open",
-    "dialog:allow-open",
-    "dialog:allow-save",
-    "dialog:allow-message",
-    "dialog:allow-ask",
-    "dialog:allow-confirm",
-    "fs:default",
-    "shell:default",
-    "dialog:default",
-    "log:default"
-  ]
+	"identifier": "migrated",
+	"description": "permissions that were migrated from v1",
+	"local": true,
+	"windows": ["main"],
+	"permissions": [
+		"core:default",
+		"fs:allow-read-dir",
+		"shell:allow-open",
+		"dialog:allow-open",
+		"dialog:allow-save",
+		"dialog:allow-message",
+		"dialog:allow-ask",
+		"dialog:allow-confirm",
+		"fs:default",
+		"shell:default",
+		"dialog:default",
+		"log:default"
+	]
 }

--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -353,7 +353,7 @@ fn run_conversion(
     input_paths: Vec<String>,
     output_path: String,
     filetype: String,
-    epsg: u16,
+    epsg: Option<u16>,
     rules_path: String,
     transformer_settings: TransformerSettings,
     sink_parameters: Parameters,
@@ -401,29 +401,35 @@ fn run_conversion(
 
     log::info!("Running pipeline with input: {input_paths:?}");
 
-    let mut sink = {
-        let sink_provider = select_sink_provider(&filetype).ok_or_else(|| {
-            let msg = format!("Invalid sink type: {filetype}");
+    let sink_provider = select_sink_provider(&filetype).ok_or_else(|| {
+        let msg = format!("Invalid sink type: {filetype}");
+        log::error!("{msg}");
+        Error::InvalidSetting(msg)
+    })?;
+
+    let mut sink_params = sink_parameters;
+    if let Err(err) = sink_params.update_values_with_str(&sinkopt) {
+        let msg = format!("Error parsing sink options: {err:?}");
+        log::error!("{msg}");
+        return Err(Error::InvalidSetting(msg));
+    };
+    if let Err(err) = sink_params.validate() {
+        let msg = format!("Error validating sink parameters: {err:?}");
+        log::error!("{msg}");
+        return Err(Error::InvalidSetting(msg));
+    }
+    let mut sink = sink_provider.create(&sink_params);
+
+    let mut requirements = sink.make_requirements(transformer_settings);
+    let output_epsg = sink_provider
+        .sink_input_crs_requirement()
+        .resolve(requirements.output_epsg, epsg)
+        .map_err(|error| {
+            let msg = format!("Invalid CRS setting for {filetype}: {error}");
             log::error!("{msg}");
             Error::InvalidSetting(msg)
         })?;
-
-        let mut sink_params = sink_parameters;
-        if let Err(err) = sink_params.update_values_with_str(&sinkopt) {
-            let msg = format!("Error parsing sink options: {err:?}");
-            log::error!("{msg}");
-            return Err(Error::InvalidSetting(msg));
-        };
-        if let Err(err) = sink_params.validate() {
-            let msg = format!("Error validating sink parameters: {err:?}");
-            log::error!("{msg}");
-            return Err(Error::InvalidSetting(msg));
-        }
-        sink_provider.create(&sink_params)
-    };
-
-    let mut requirements = sink.make_requirements(transformer_settings);
-    requirements.set_output_epsg(epsg);
+    requirements.set_output_epsg(output_epsg);
 
     let (source, input_schema) = {
         // ファイルを拡張子で分類
@@ -1067,7 +1073,7 @@ async fn pack_and_run_conversion(
     zip_output_path: Option<String>,
     output_path: String,
     filetype: String,
-    epsg: u16,
+    epsg: Option<u16>,
     rules_path: String,
     transformer_settings: TransformerSettings,
     sink_parameters: Parameters,

--- a/app/src/app.css
+++ b/app/src/app.css
@@ -1,9 +1,9 @@
-@import "tailwindcss" source("../src");
+@import 'tailwindcss' source('../src');
 
 @theme {
 	--color-base: #334155;
-	--color-accent1: #00BEBE;
-	--color-accent2: #463C64;
+	--color-accent1: #00bebe;
+	--color-accent2: #463c64;
 }
 
 @utility animate-loading-pulse-* {
@@ -12,9 +12,8 @@
 	animation-name: scale;
 	animation-timing-function: cubic-bezier(0.2, 0.68, 0.18, 1.08);
 	animation-fill-mode: both;
-	animation-delay: --value([*]);
+	animation-delay: --value([ *]);
 }
-
 
 @keyframes scale {
 	0% {

--- a/app/src/app.html
+++ b/app/src/app.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
 	<head>
 		<meta charset="utf-8" />

--- a/app/src/lib/fetchCityGMLMetadata.ts
+++ b/app/src/lib/fetchCityGMLMetadata.ts
@@ -38,10 +38,11 @@ export async function fetchCityGMLMetadataByMeshcodes(
 		return { success: true, ...response };
 	} catch (e) {
 		console.error('Error fetching CityGML metadata by meshcodes:', e);
+		const error = e as { type: string; message: string };
 		return {
 			success: false,
-			type: e.type,
-			message: e.message
+			type: error.type,
+			message: error.message
 		};
 	}
 }

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -1,4 +1,4 @@
-type epsgOption = { value: number; label: string };
+type epsgOption = { value: number | null; label: string };
 
 const filetypeOptions: Record<string, { label: string; extensions: string[]; epsg: epsgOption[] }> =
 	{
@@ -62,12 +62,12 @@ const filetypeOptions: Record<string, { label: string; extensions: string[]; eps
 		mvt: {
 			label: 'Vector Tiles (MVT)',
 			extensions: [''],
-			epsg: [{ value: 3857, label: 'Web Mercator (EPSG:3857)' }]
+			epsg: [{ value: null, label: 'Web Mercator (EPSG:3857)' }]
 		},
 		pmtiles: {
 			label: 'PMTiles',
 			extensions: ['pmtiles'],
-			epsg: [{ value: 3857, label: 'Web Mercator (EPSG:3857)' }]
+			epsg: [{ value: null, label: 'Web Mercator (EPSG:3857)' }]
 		},
 		czml: {
 			label: 'CZML',

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -16,7 +16,7 @@
 
 	let inputPaths: string[] = $state([]);
 	let filetype: string = $state('gpkg');
-	let epsg: number = $state(4979);
+	let epsg: number | null = $state(4979);
 	let rulesPath = $state('');
 	let outputPath = $state('');
 	let sinkParameters = $state({} as SinkParameters);

--- a/app/src/routes/SettingSelector.svelte
+++ b/app/src/routes/SettingSelector.svelte
@@ -11,7 +11,7 @@
 
 	export type SettingSelectorProps = {
 		filetype: string;
-		epsg?: number;
+		epsg?: number | null;
 		rulesPath: string;
 		sinkParameters: SinkParameters;
 		transformerSettings: TransformerSettings | undefined;
@@ -30,8 +30,9 @@
 
 	$effect(() => {
 		// Reset the target CRS if the selected filetype does not support the current CRS
-		if (!filetypeOptions[filetype]?.epsg.some((item) => item.value === epsg)) {
-			epsg = filetypeOptions[filetype]?.epsg[0].value || 4979;
+		const options = filetypeOptions[filetype]?.epsg || [];
+		if (options.length > 0 && !options.some((item) => item.value === epsg)) {
+			epsg = options[0].value;
 		}
 	});
 

--- a/app/src/routes/map/+page.svelte
+++ b/app/src/routes/map/+page.svelte
@@ -19,7 +19,7 @@
 
 	// Conversion settings
 	let filetype: string = $state('gpkg');
-	let epsg: number = $state(4979);
+	let epsg: number | null = $state(4979);
 	let rulesPath = $state('');
 	let outputPath = $state('');
 	let zipOutputPath: string = $state('');

--- a/app/src/routes/zip/+page.svelte
+++ b/app/src/routes/zip/+page.svelte
@@ -19,7 +19,7 @@
 
 	// Conversion settings
 	let filetype: string = $state('gpkg');
-	let epsg: number = $state(4979);
+	let epsg: number | null = $state(4979);
 	let rulesPath = $state('');
 	let outputPath = $state('');
 	let sinkParameters = $state({} as SinkParameters);

--- a/nusamai/src/main.rs
+++ b/nusamai/src/main.rs
@@ -36,9 +36,9 @@ struct Args {
     #[arg(long, value_parser = parse_non_empty)]
     output: String,
 
-    /// Specify the output EPSG code (default: WGS84 3D)
-    #[arg(long, default_value_t = 4979)]
-    epsg: u16,
+    /// Specify the output EPSG code
+    #[arg(long)]
+    epsg: Option<u16>,
 
     /// Specify the mapping rules JSON file
     #[arg(long)]
@@ -236,10 +236,21 @@ fn main() -> ExitCode {
     };
 
     let mut requirements = sink.make_requirements(updated_transformer_registry);
-    requirements.set_output_epsg(match args.sink.0.as_ref() {
-        "kml" => 6697, // temporary hack for KML output
+    let requested_epsg = match args.sink.0.as_ref() {
+        "kml" => Some(6697), // temporary hack for KML output
         _ => args.epsg,
-    });
+    };
+    let output_epsg = match sink_provider
+        .sink_input_crs_requirement()
+        .resolve(requirements.output_epsg, requested_epsg)
+    {
+        Ok(epsg) => epsg,
+        Err(error) => {
+            log::error!("Invalid --epsg for {}: {error}", args.sink.0);
+            return ExitCode::FAILURE;
+        }
+    };
+    requirements.set_output_epsg(output_epsg);
 
     let mapping_rules = match &args.rules {
         Some(rules_path) => {

--- a/nusamai/src/sink/mlt/mod.rs
+++ b/nusamai/src/sink/mlt/mod.rs
@@ -5,6 +5,7 @@ mod encode;
 use std::path::PathBuf;
 
 use nusamai_citygml::schema::Schema;
+use nusamai_projection::crs::EPSG_WGS84_GEOGRAPHIC_3D;
 
 use crate::{
     get_parameter_value,
@@ -15,7 +16,7 @@ use crate::{
             run_vector_tile_pipeline, slice::validate_zoom_range, TilePipelineOptions,
             DEFAULT_MAX_COMPRESSED_TILE_SIZE,
         },
-        DataRequirements, DataSink, DataSinkProvider, SinkInfo,
+        DataRequirements, DataSink, DataSinkProvider, SinkInfo, SinkInputCrsRequirement,
     },
     transformer,
     transformer::{use_lod_config, TransformerSettings},
@@ -84,6 +85,13 @@ impl DataSinkProvider for MltSinkProvider {
         let mut settings = TransformerSettings::new();
         settings.insert(use_lod_config("min_lod", None));
         settings
+    }
+
+    fn sink_input_crs_requirement(&self) -> SinkInputCrsRequirement {
+        // TODO: Switch to Fixed(EPSG:3857). ProjectionTransform should produce Web Mercator
+        // coordinates, and the shared vector-tile sink should consume them directly instead of
+        // calling lnglat_to_web_mercator, performing only the tile-space conversion itself.
+        SinkInputCrsRequirement::Fixed(EPSG_WGS84_GEOGRAPHIC_3D)
     }
 
     fn create(&self, params: &Parameters) -> Box<dyn DataSink> {

--- a/nusamai/src/sink/mod.rs
+++ b/nusamai/src/sink/mod.rs
@@ -22,6 +22,7 @@ pub(crate) mod vector_tile;
 
 use nusamai_citygml::schema::Schema;
 use nusamai_projection::crs;
+use thiserror::Error;
 
 use crate::{
     parameters::Parameters,
@@ -34,6 +35,38 @@ pub struct SinkInfo {
     pub name: String,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SinkInputCrsRequirement {
+    Selectable,
+    Fixed(crs::EpsgCode),
+}
+
+#[derive(Debug, Error, Eq, PartialEq)]
+#[error("sink requires fixed input CRS EPSG:{required}, but EPSG:{requested} was requested")]
+pub struct SinkInputCrsError {
+    required: crs::EpsgCode,
+    requested: crs::EpsgCode,
+}
+
+impl SinkInputCrsRequirement {
+    pub fn resolve(
+        self,
+        default: crs::EpsgCode,
+        requested: Option<crs::EpsgCode>,
+    ) -> Result<crs::EpsgCode, SinkInputCrsError> {
+        match (self, requested) {
+            (Self::Selectable, requested) => Ok(requested.unwrap_or(default)),
+            (Self::Fixed(required), Some(requested)) if requested != required => {
+                Err(SinkInputCrsError {
+                    required,
+                    requested,
+                })
+            }
+            (Self::Fixed(required), _) => Ok(required),
+        }
+    }
+}
+
 pub trait DataSinkProvider: Sync {
     /// Gets basic information about the sink.
     fn info(&self) -> SinkInfo;
@@ -43,6 +76,11 @@ pub trait DataSinkProvider: Sync {
 
     /// Gets the transform options of the sink.
     fn transformer_options(&self) -> TransformerSettings;
+
+    /// Gets the CRS requirement for data passed from Transform to this sink.
+    fn sink_input_crs_requirement(&self) -> SinkInputCrsRequirement {
+        SinkInputCrsRequirement::Selectable
+    }
 
     /// Creates a sink instance.
     fn create(&self, config: &Parameters) -> Box<dyn DataSink>;

--- a/nusamai/src/sink/mvt/mod.rs
+++ b/nusamai/src/sink/mvt/mod.rs
@@ -6,6 +6,7 @@ mod tags;
 use std::path::PathBuf;
 
 use nusamai_citygml::schema::Schema;
+use nusamai_projection::crs::EPSG_WGS84_GEOGRAPHIC_3D;
 
 use crate::{
     get_parameter_value,
@@ -16,7 +17,7 @@ use crate::{
             run_vector_tile_pipeline, slice::validate_zoom_range, TilePipelineOptions,
             DEFAULT_MAX_COMPRESSED_TILE_SIZE,
         },
-        DataRequirements, DataSink, DataSinkProvider, SinkInfo,
+        DataRequirements, DataSink, DataSinkProvider, SinkInfo, SinkInputCrsRequirement,
     },
     transformer,
     transformer::{use_lod_config, TransformerSettings},
@@ -71,6 +72,13 @@ impl DataSinkProvider for MvtSinkProvider {
         let mut settings = TransformerSettings::new();
         settings.insert(use_lod_config("min_lod", None));
         settings
+    }
+
+    fn sink_input_crs_requirement(&self) -> SinkInputCrsRequirement {
+        // TODO: Switch to Fixed(EPSG:3857). ProjectionTransform should produce Web Mercator
+        // coordinates, and the shared vector-tile sink should consume them directly instead of
+        // calling lnglat_to_web_mercator, performing only the tile-space conversion itself.
+        SinkInputCrsRequirement::Fixed(EPSG_WGS84_GEOGRAPHIC_3D)
     }
 
     fn create(&self, params: &Parameters) -> Box<dyn DataSink> {

--- a/nusamai/src/sink/pmtiles/mod.rs
+++ b/nusamai/src/sink/pmtiles/mod.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use nusamai_citygml::schema::Schema;
+use nusamai_projection::crs::EPSG_WGS84_GEOGRAPHIC_3D;
 use pmtiles::{PmTilesWriter, TileCoord, TileType};
 
 use crate::{
@@ -19,7 +20,7 @@ use crate::{
             feature_sorting_stage, generate_stage, slice_stage, tile_id::TileIdMethod, EncodedTile,
             TilePipelineOptions, DEFAULT_MAX_COMPRESSED_TILE_SIZE, FEATURE_CHANNEL_CAPACITY,
         },
-        DataRequirements, DataSink, DataSinkProvider, SinkInfo,
+        DataRequirements, DataSink, DataSinkProvider, SinkInfo, SinkInputCrsRequirement,
     },
     transformer,
     transformer::{use_lod_config, TransformerSettings},
@@ -75,6 +76,13 @@ impl DataSinkProvider for PmTilesSinkProvider {
         let mut settings = TransformerSettings::new();
         settings.insert(use_lod_config("min_lod", None));
         settings
+    }
+
+    fn sink_input_crs_requirement(&self) -> SinkInputCrsRequirement {
+        // TODO: Switch to Fixed(EPSG:3857). ProjectionTransform should produce Web Mercator
+        // coordinates, and the shared vector-tile sink should consume them directly instead of
+        // calling lnglat_to_web_mercator, performing only the tile-space conversion itself.
+        SinkInputCrsRequirement::Fixed(EPSG_WGS84_GEOGRAPHIC_3D)
     }
 
     fn create(&self, params: &Parameters) -> Box<dyn DataSink> {


### PR DESCRIPTION
## 概要

Sink Providerに入力CRS要件を持たせ、Sinkに対してGUI・CLI・Tauri側から矛盾するEPSGが渡らないようにします。

## 背景

MVT・MLT・PMTilesは現在、Sink内で経緯度をWeb Mercatorへ変換しています。そのため、Transform側で先にEPSG:3857へ変換すると、Sinkがメートル単位の座標を経緯度と誤認して再変換し、極端に大きな座標と処理負荷を発生させる可能性がありました。

CRSの契約が各入口に分散していたことが根本原因です。

## 変更内容

- `SinkInputCrsRequirement` を追加し、Sink Providerを入力CRS契約の正とする
- MVT・MLT・PMTilesを当面 `Fixed(EPSG:4979)` として宣言する
  - 将来 `ProjectionTransform` でEPSG:3857へ変換し、Sink内の `lnglat_to_web_mercator` を廃止する方針をコメントに記載する
- CLIの `--epsg` を任意指定に変更し、固定CRSと異なる指定を拒否する
- Tauri側でも同じSink入力CRS契約を適用する
- GUIではMVT・PMTilesのCRSラベルを維持しつつ、明示的なEPSG値を渡さずセレクターを無効化する

## 影響

- 固定CRSのSinkでは、利用者が変換経路と矛盾するCRSを選択できなくなります
- 選択可能なSinkでは、従来どおり `--epsg` で出力CRSを指定できます
- 現段階ではベクタータイルSinkへの入力はEPSG:4979のままで、EPSG:3857への後続対応が必要です。

## 検証

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `npm run check`
- `npm run lint`
- `npm run test -- --run`
- `npm run build`
