### PR TITLE
feat: GeoJSON入力時のLOD指定を無効化する

### DIFF
--- a/app/src/lib/components/TransformerOptions.svelte
+++ b/app/src/lib/components/TransformerOptions.svelte
@@ -1,7 +1,18 @@
 <script lang="ts">
-	import { isBooleanConfig, isSelectionConfig } from '$lib/transformer';
+	import {
+		isBooleanConfig,
+		isSelectionConfig,
+		type DisabledTransformerConfigReasons,
+		type TransformerSettings
+	} from '$lib/transformer';
 
-	let { transformerSettings = $bindable() } = $props();
+	let {
+		transformerSettings = $bindable(),
+		disabledConfigReasons = {}
+	}: {
+		transformerSettings: TransformerSettings | undefined;
+		disabledConfigReasons?: DisabledTransformerConfigReasons;
+	} = $props();
 </script>
 
 {#if transformerSettings && transformerSettings.configs.length > 0}
@@ -29,17 +40,36 @@
 				</div>
 			</div>
 		{:else if isSelectionConfig(config.parameter)}
-			<div class="flex w-80 gap-2">
-				<label for={config.key} class="pointer-events-none w-2/4">{config.label}</label>
-				<select
-					id={config.key}
-					class="w-2/4 cursor-pointer rounded-md border-2 border-gray-300 px-2"
-					bind:value={config.parameter.Selection.selected_value}
-				>
-					{#each config.parameter.Selection.options as option, index (index)}
-						<option value={option.value}>{option.label}</option>
-					{/each}
-				</select>
+			{@const disabledReason = disabledConfigReasons[config.key]}
+			<div class="flex flex-col gap-1">
+				<div class="flex w-80 gap-2" class:opacity-50={Boolean(disabledReason)}>
+					<label for={config.key} class="pointer-events-none w-2/4">{config.label}</label>
+					{#if disabledReason}
+						<select
+							id={config.key}
+							disabled
+							aria-describedby={`${config.key}-disabled-reason`}
+							class="w-2/4 cursor-not-allowed rounded-md border-2 border-gray-300 px-2"
+						>
+							<option>対象外</option>
+						</select>
+					{:else}
+						<select
+							id={config.key}
+							class="w-2/4 cursor-pointer rounded-md border-2 border-gray-300 px-2"
+							bind:value={config.parameter.Selection.selected_value}
+						>
+							{#each config.parameter.Selection.options as option, index (index)}
+								<option value={option.value}>{option.label}</option>
+							{/each}
+						</select>
+					{/if}
+				</div>
+				{#if disabledReason}
+					<p id={`${config.key}-disabled-reason`} class="w-80 text-xs text-gray-500">
+						{disabledReason}
+					</p>
+				{/if}
 			</div>
 		{/if}
 	{/each}

--- a/app/src/lib/inputFormat.ts
+++ b/app/src/lib/inputFormat.ts
@@ -1,0 +1,37 @@
+export type InputFormat = 'citygml' | 'geojson' | 'mixed' | 'unknown';
+
+type SupportedInputFormat = Exclude<InputFormat, 'mixed'>;
+
+function detectPathInputFormat(path: string): SupportedInputFormat {
+	const normalizedPath = path.toLowerCase();
+
+	if (normalizedPath.endsWith('.gml')) {
+		return 'citygml';
+	}
+	if (normalizedPath.endsWith('.geojson') || normalizedPath.endsWith('.json')) {
+		return 'geojson';
+	}
+
+	return 'unknown';
+}
+
+export function detectInputFormat(inputPaths: readonly string[]): InputFormat {
+	if (inputPaths.length === 0) {
+		return 'unknown';
+	}
+
+	let detectedFormat: SupportedInputFormat | undefined;
+
+	for (const path of inputPaths) {
+		const pathFormat = detectPathInputFormat(path);
+		if (pathFormat === 'unknown') {
+			return 'unknown';
+		}
+		if (detectedFormat && detectedFormat !== pathFormat) {
+			return 'mixed';
+		}
+		detectedFormat = pathFormat;
+	}
+
+	return detectedFormat ?? 'unknown';
+}

--- a/app/src/lib/transformer.ts
+++ b/app/src/lib/transformer.ts
@@ -1,3 +1,7 @@
+import type { InputFormat } from '$lib/inputFormat';
+
+export const LOD_TRANSFORMER_CONFIG_KEY = 'use_lod' as const;
+
 export interface SelectionOptions<T extends string> {
 	label: string;
 	value: T;
@@ -28,6 +32,8 @@ export type TransformerSettings = {
 	configs: Array<TransformerConfig<TransformerParameterType>>;
 };
 
+export type DisabledTransformerConfigReasons = Readonly<Partial<Record<string, string>>>;
+
 export type TransformerOptions = {
 	label: string;
 	parameter_type: 'Boolean' | 'Selection';
@@ -55,4 +61,19 @@ export function isSelectionConfig<T extends string>(param: any): param is Select
 		'selected_value' in param.Selection &&
 		typeof param.Selection.selected_value === 'string'
 	);
+}
+
+// When GeoJSON is selected, the LOD setting is unnecessary and should be removed.
+export function prepareTransformerSettingsForInput(
+	settings: TransformerSettings | undefined,
+	inputFormat: InputFormat
+): TransformerSettings | undefined {
+	if (!settings || inputFormat !== 'geojson') {
+		return settings;
+	}
+
+	return {
+		...settings,
+		configs: settings.configs.filter(({ key }) => key !== LOD_TRANSFORMER_CONFIG_KEY)
+	};
 }

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -3,7 +3,8 @@
 	import { invoke } from '@tauri-apps/api/core';
 	import { attachConsole } from '@tauri-apps/plugin-log';
 	import type { SinkParameters } from '$lib/sinkparams';
-	import type { TransformerSettings } from '$lib/transformer';
+	import { detectInputFormat } from '$lib/inputFormat';
+	import { prepareTransformerSettingsForInput, type TransformerSettings } from '$lib/transformer';
 
 	import Icon from '@iconify/svelte';
 	import InputSelector from './InputSelector.svelte';
@@ -22,6 +23,7 @@
 	let sinkParameters = $state({} as SinkParameters);
 	let isRunning = $state(false);
 	let isConvertButtonDisabled = $derived(!inputPaths.length || !outputPath || isRunning);
+	let inputFormat = $derived(detectInputFormat(inputPaths));
 
 	let transformerSettings: TransformerSettings | undefined = $state(undefined);
 
@@ -29,13 +31,17 @@
 		isRunning = true;
 
 		try {
+			const effectiveTransformerSettings = prepareTransformerSettingsForInput(
+				transformerSettings,
+				inputFormat
+			);
 			await invoke('run_conversion', {
 				inputPaths,
 				outputPath,
 				filetype,
 				epsg,
 				rulesPath,
-				transformerSettings,
+				transformerSettings: effectiveTransformerSettings,
 				sinkParameters
 			});
 
@@ -79,6 +85,7 @@
 			bind:rulesPath
 			bind:sinkParameters
 			bind:transformerSettings
+			{inputFormat}
 		/>
 
 		<OutputSelector {filetype} bind:outputPath />

--- a/app/src/routes/SettingSelector.svelte
+++ b/app/src/routes/SettingSelector.svelte
@@ -2,7 +2,12 @@
 	import { filetypeOptions } from '$lib/settings';
 	import { invoke } from '@tauri-apps/api/core';
 	import type { SinkParameters } from '$lib/sinkparams';
-	import type { TransformerSettings } from '$lib/transformer';
+	import type { InputFormat } from '$lib/inputFormat';
+	import {
+		LOD_TRANSFORMER_CONFIG_KEY,
+		type DisabledTransformerConfigReasons,
+		type TransformerSettings
+	} from '$lib/transformer';
 	import Icon from '@iconify/svelte';
 	import {} from '@tauri-apps/api';
 	import SinkOptions from '$lib/components/SinkOptions.svelte';
@@ -15,18 +20,25 @@
 		rulesPath: string;
 		sinkParameters: SinkParameters;
 		transformerSettings: TransformerSettings | undefined;
+		inputFormat?: InputFormat;
 	};
+
+	const GEOJSON_LOD_DISABLED_REASON = 'GeoJSONにはLODがないため指定できません';
 
 	let {
 		filetype = $bindable(),
 		epsg = $bindable(4979),
 		rulesPath = $bindable(),
 		sinkParameters = $bindable(),
-		transformerSettings = $bindable()
+		transformerSettings = $bindable(),
+		inputFormat = 'citygml'
 	}: SettingSelectorProps = $props();
 
 	let epsgOptions = $derived(filetypeOptions[filetype]?.epsg || []);
 	let disableEpsgOptions = $derived(epsgOptions.length < 2);
+	let disabledConfigReasons: DisabledTransformerConfigReasons = $derived(
+		inputFormat === 'geojson' ? { [LOD_TRANSFORMER_CONFIG_KEY]: GEOJSON_LOD_DISABLED_REASON } : {}
+	);
 
 	$effect(() => {
 		// Reset the target CRS if the selected filetype does not support the current CRS
@@ -134,7 +146,7 @@
 			<div class="flex flex-col">
 				<label for="transform-select" class="mb-1.5 font-bold">出力の詳細設定</label>
 				<div class="flex flex-col gap-2">
-					<TransformerOptions bind:transformerSettings />
+					<TransformerOptions bind:transformerSettings {disabledConfigReasons} />
 					<SinkOptions bind:sinkOptionKeys bind:sinkParameters />
 				</div>
 			</div>


### PR DESCRIPTION
## 概要

GeoJSON入力ではLODを指定できないため、入力形式に応じてGUIからLOD選択を無効化します。

## 変更内容

- 入力ファイルからGeoJSON単独入力を判定
- GeoJSON入力時にLOD選択欄をグレーアウトし、対象外である理由を表示
- GeoJSON入力時は変換設定からuse_lodを除外
- CityGMLへ切り替えた際は以前のLOD選択値を維持

## 動作確認

- npm run test -- --run
- npm run check
- npm run lint
- npm run build