### PR TITLE
feat: GUIからMLT変換を利用可能にする

### DIFF
--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -2,15 +2,15 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use log::LevelFilter;
-use nusamai::parameters::Parameters;
+use nusamai::parameters::{ParameterType, Parameters};
 use nusamai::{
     pipeline::{Canceller, feedback},
     sink::{
         DataSinkProvider, cesiumtiles::CesiumTilesSinkProvider, czml::CzmlSinkProvider,
         geojson::GeoJsonSinkProvider, gltf::GltfSinkProvider, gpkg::GpkgSinkProvider,
-        kml::KmlSinkProvider, minecraft::MinecraftSinkProvider, mvt::MvtSinkProvider,
-        obj::ObjSinkProvider, pmtiles::PmTilesSinkProvider, serde::SerdeSinkProvider,
-        shapefile::ShapefileSinkProvider,
+        kml::KmlSinkProvider, minecraft::MinecraftSinkProvider, mlt::MltSinkProvider,
+        mvt::MvtSinkProvider, obj::ObjSinkProvider, pmtiles::PmTilesSinkProvider,
+        serde::SerdeSinkProvider, shapefile::ShapefileSinkProvider,
     },
     source::{
         DataSourceProvider, citygml::CityGmlSourceProvider, collect_input_schema,
@@ -157,6 +157,7 @@ fn select_sink_provider(filetype: &str) -> Option<Box<dyn DataSinkProvider>> {
         "serde" => Some(Box::new(SerdeSinkProvider {})),
         "geojson" => Some(Box::new(GeoJsonSinkProvider {})),
         "gpkg" => Some(Box::new(GpkgSinkProvider {})),
+        "mlt" => Some(Box::new(MltSinkProvider {})),
         "mvt" => Some(Box::new(MvtSinkProvider {})),
         "pmtiles" => Some(Box::new(PmTilesSinkProvider {})),
         "shapefile" => Some(Box::new(ShapefileSinkProvider {})),
@@ -168,6 +169,27 @@ fn select_sink_provider(filetype: &str) -> Option<Box<dyn DataSinkProvider>> {
         "obj" => Some(Box::new(ObjSinkProvider {})),
         _ => None,
     }
+}
+
+fn validate_zoom_range_parameters(params: &Parameters) -> Result<(), Error> {
+    let integer_value = |key| {
+        params.get(key).and_then(|entry| match &entry.parameter {
+            ParameterType::Integer(parameter) => parameter.value,
+            _ => None,
+        })
+    };
+
+    let (Some(min_z), Some(max_z)) = (integer_value("min_z"), integer_value("max_z")) else {
+        return Ok(());
+    };
+
+    if min_z > max_z {
+        return Err(Error::InvalidSetting(format!(
+            "Minimum zoom level (min_z: {min_z}) must be less than or equal to maximum zoom level (max_z: {max_z})"
+        )));
+    }
+
+    Ok(())
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -418,6 +440,7 @@ fn run_conversion(
         log::error!("{msg}");
         return Err(Error::InvalidSetting(msg));
     }
+    validate_zoom_range_parameters(&sink_params)?;
     let mut sink = sink_provider.create(&sink_params);
 
     let mut requirements = sink.make_requirements(transformer_settings);

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -64,6 +64,11 @@ const filetypeOptions: Record<string, { label: string; extensions: string[]; eps
 			extensions: [''],
 			epsg: [{ value: null, label: 'Web Mercator (EPSG:3857)' }]
 		},
+		mlt: {
+			label: 'MapLibre Tiles (MLT)',
+			extensions: [''],
+			epsg: [{ value: null, label: 'Web Mercator (EPSG:3857)' }]
+		},
 		pmtiles: {
 			label: 'PMTiles',
 			extensions: ['pmtiles'],

--- a/nusamai/src/sink/mlt/mod.rs
+++ b/nusamai/src/sink/mlt/mod.rs
@@ -64,20 +64,6 @@ impl DataSinkProvider for MltSinkProvider {
                 label: Some("最大ズームレベル".into()),
             },
         });
-        params.define(ParameterDefinition {
-            key: "max_compressed_tile_size".into(),
-            entry: ParameterEntry {
-                description:
-                    "Maximum zlib-compressed tile size in bytes before lowering tile detail".into(),
-                required: true,
-                parameter: ParameterType::Integer(IntegerParameter {
-                    value: Some(DEFAULT_MAX_COMPRESSED_TILE_SIZE as i64),
-                    min: Some(1),
-                    max: None,
-                }),
-                label: Some("最大圧縮タイルサイズ".into()),
-            },
-        });
         params
     }
 
@@ -99,8 +85,6 @@ impl DataSinkProvider for MltSinkProvider {
         let min_z = get_parameter_value!(params, "min_z", Integer).unwrap() as u8;
         let max_z = get_parameter_value!(params, "max_z", Integer).unwrap() as u8;
         validate_zoom_range(min_z, max_z);
-        let max_compressed_tile_size =
-            get_parameter_value!(params, "max_compressed_tile_size", Integer).unwrap() as usize;
 
         Box::new(MltSink {
             output_path: output_path.as_ref().unwrap().into(),
@@ -108,7 +92,7 @@ impl DataSinkProvider for MltSinkProvider {
             options: MltParams {
                 min_z,
                 max_z,
-                max_compressed_tile_size,
+                max_compressed_tile_size: DEFAULT_MAX_COMPRESSED_TILE_SIZE,
             },
         })
     }


### PR DESCRIPTION
## 概要

既存のMapLibre Tiles（MLT）sinkをTauri GUIから選択し、MLT形式へ変換できるようにします。

## 背景

MLT sink自体は実装済みでしたが、Tauri側のGUI用sink registryとフロントエンドの出力形式一覧に登録されていなかったため、GUIから選択できませんでした。

## 変更内容

- Tauriのsink registryへ`MltSinkProvider`を登録
- フロントエンドの出力形式一覧へ`MapLibre Tiles (MLT)`を追加
- `min_z > max_z`をsink生成前に`InvalidSetting`として拒否

## 利用者への影響

- GUIの出力形式からMLTを選択可能になります
- 不正なズーム範囲はpanicではなく設定エラーとして表示されます

## 動作確認

- `cargo fmt --all -- --check`
- `cargo test -p nusamai --test sink mlt -- --nocapture`
- `cargo test -p app`
- `cargo clippy -p nusamai -p app --all-targets -- -D warnings`
- `npm run check`
- `npm run lint`
- `npm test -- --run`
- `npm run build`