### PR TITLE
fix: Display the actual version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Check that the release tag matches the workspace version
         run: |
+          set -euo pipefail
           TAG="${{ github.event.release.tag_name }}"
           VERSION="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "nusamai") | .version')"
           if [ "${TAG}" != "v${VERSION}" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           TAG="${{ github.event.release.tag_name }}"
           VERSION="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "nusamai") | .version')"
           if [ "${TAG}" != "v${VERSION}" ]; then
-            echo "Release tag ${TAG} does not match the workspace version in Cargo.toml (expected v${VERSION})." >&2
+            echo "Release tag ${TAG} does not match the nusamai package version (expected v${VERSION})." >&2
             echo "Bump [workspace.package] version in Cargo.toml before tagging a release." >&2
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,9 @@ jobs:
   check-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
+      - name: Rust setup
+        uses: dtolnay/rust-toolchain@stable
       - name: Check that the release tag matches the workspace version
         run: |
           TAG="${{ github.event.release.tag_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,22 @@ on:
     types: [published]
 
 jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check that the release tag matches the workspace version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "nusamai") | .version')"
+          if [ "${TAG}" != "v${VERSION}" ]; then
+            echo "Release tag ${TAG} does not match the workspace version in Cargo.toml (expected v${VERSION})." >&2
+            echo "Bump [workspace.package] version in Cargo.toml before tagging a release." >&2
+            exit 1
+          fi
+
   build-cli:
+    needs: [check-version]
     strategy:
       fail-fast: false
       matrix:
@@ -57,6 +72,7 @@ jobs:
           path: nusamai-*.tar.gz
 
   build-gui:
+    needs: [check-version]
     permissions:
       contents: write
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4221,7 +4221,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "macros"
-version = "0.1.0"
+version = "0.1.17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4761,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "nusamai-czml"
-version = "0.1.0"
+version = "0.1.17"
 dependencies = [
  "chrono",
  "flatgeom",
@@ -4772,7 +4772,7 @@ dependencies = [
 
 [[package]]
 name = "nusamai-geojson"
-version = "0.1.0"
+version = "0.1.17"
 dependencies = [
  "flatgeom",
  "geojson",
@@ -4781,7 +4781,7 @@ dependencies = [
 
 [[package]]
 name = "nusamai-gltf"
-version = "0.1.0"
+version = "0.1.17"
 dependencies = [
  "byteorder",
  "glob",
@@ -4791,7 +4791,7 @@ dependencies = [
 
 [[package]]
 name = "nusamai-gltf-json"
-version = "0.1.0"
+version = "0.1.17"
 dependencies = [
  "cesiumtiles",
  "glob",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "nusamai-gpkg"
-version = "0.1.0"
+version = "0.1.17"
 dependencies = [
  "flatgeom",
  "indexmap 2.13.0",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "nusamai-kml"
-version = "0.1.0"
+version = "0.1.17"
 dependencies = [
  "flatgeom",
  "kml",
@@ -4844,7 +4844,7 @@ dependencies = [
 
 [[package]]
 name = "nusamai-projection"
-version = "0.1.0"
+version = "0.1.17"
 dependencies = [
  "japan-geoid",
  "jprect",
@@ -4853,7 +4853,7 @@ dependencies = [
 
 [[package]]
 name = "nusamai-shapefile"
-version = "0.1.0"
+version = "0.1.17"
 dependencies = [
  "flatgeom",
  "shapefile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "app"
-version = "0.1.0"
+version = "0.1.17"
 dependencies = [
  "flatgeom",
  "log",
@@ -4680,7 +4680,7 @@ dependencies = [
 
 [[package]]
 name = "nusamai"
-version = "0.1.0"
+version = "0.1.17"
 dependencies = [
  "assert_cmd",
  "atlas-packer",
@@ -4743,7 +4743,7 @@ dependencies = [
 
 [[package]]
 name = "nusamai-citygml"
-version = "0.1.0"
+version = "0.1.17"
 dependencies = [
  "chrono",
  "flatgeom",
@@ -4822,7 +4822,7 @@ dependencies = [
 
 [[package]]
 name = "nusamai-plateau"
-version = "0.1.0"
+version = "0.1.17"
 dependencies = [
  "bincode 2.0.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.17"
 authors = ["MIERUNE Inc. <info@mierune.co.jp>"]
 
 [profile.dev.package."*"]

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -42,7 +42,6 @@
 	},
 	"productName": "PLATEAU GIS Converter",
 	"mainBinaryName": "PLATEAU GIS Converter",
-	"version": "0.1.0",
 	"identifier": "jp.co.mierune.nusamai",
 	"plugins": {},
 	"app": {

--- a/nusamai-citygml/macros/Cargo.toml
+++ b/nusamai-citygml/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macros"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [lib]

--- a/nusamai-czml/Cargo.toml
+++ b/nusamai-czml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nusamai-czml"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/nusamai-geojson/Cargo.toml
+++ b/nusamai-geojson/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nusamai-geojson"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/nusamai-gltf/Cargo.toml
+++ b/nusamai-gltf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nusamai-gltf"
 edition = "2021"
-version = "0.1.0"
+version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/nusamai-gltf/nusamai-gltf-json/Cargo.toml
+++ b/nusamai-gltf/nusamai-gltf-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nusamai-gltf-json"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/nusamai-gpkg/Cargo.toml
+++ b/nusamai-gpkg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nusamai-gpkg"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/nusamai-kml/Cargo.toml
+++ b/nusamai-kml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nusamai-kml"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/nusamai-projection/Cargo.toml
+++ b/nusamai-projection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nusamai-projection"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/nusamai-shapefile/Cargo.toml
+++ b/nusamai-shapefile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nusamai-shapefile"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #793

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

- `Cargo.toml` のバージョンを正しいバージョンに
- メンバー crate でも `woerkspace.version` を使う
- `tauri.conf.json` にバージョンが書かれているとこっちが優先されてしまうので、削除して `Cargo.toml` のバージョンを引き継ぐようにする
- CI でタグと実際のバージョンが一致しているかチェックする

### Notes
<!-- If manual testing is required, please describe the procedure. -->

バージョンのチェックとかは cargo-dist を使えば自動でやってくれますが、とりあえず今はこれくらいで。